### PR TITLE
Skip empty generated build info

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -153,6 +153,9 @@ func (b *Build) getGeneratedBuildsInfo() ([]*entities.BuildInfo, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(content) == 0 {
+			continue
+		}
 		buildInfo := new(entities.BuildInfo)
 		err = json.Unmarshal(content, &buildInfo)
 		if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Resolves jfrog/jfrog-cli#1276

The following scenarios generate empty generatedBuildInfo files:
* Maven or Gradle command failures.
* Running Maven command without `install` goal.
* Running Gradle command without `aP` goal.
* Probably more scenarios...

Running the `jfrog rt bp` command on empty generatedBuildInfo file causes an `unexpected end of JSON input` error.
To overcome this issue, let's skip empty generatedBuildInfo files.