### PR TITLE
Convert pip module type to python

### DIFF
--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -23,7 +23,7 @@ const (
 	Npm     ModuleType = "npm"
 	Nuget   ModuleType = "nuget"
 	Go      ModuleType = "go"
-	Pip     ModuleType = "pip"
+	Python  ModuleType = "python"
 )
 
 type BuildInfo struct {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Convert pip module type to python to support both pip and pipenv