### PR TITLE
Allow ignoring go list errors

### DIFF
--- a/build/build_test.go
+++ b/build/build_test.go
@@ -49,7 +49,9 @@ func TestCollectEnv(t *testing.T) {
 	// Set environment variables
 	for key, value := range env {
 		assert.NoError(t, os.Setenv(key, value))
-		defer os.Unsetenv(key)
+		defer func() {
+			assert.NoError(t, os.Unsetenv(key))
+		}()
 	}
 
 	service := NewBuildInfoService()

--- a/utils/goutils.go
+++ b/utils/goutils.go
@@ -18,7 +18,7 @@ import (
 
 const credentialsInUrlRegexp = `(http|https|git)://.+@`
 
-// Minimum go version, which its output does not require to mask passwords in URLs.
+// Minimum go version, which its output does not require masking passwords in URLs.
 const minGoVersionForMasking = "go1.13"
 
 // Max go version, which automatically modify go.mod and go.sum when executing build commands.
@@ -267,7 +267,7 @@ func GetProjectRoot() (string, error) {
 		wd = filepath.Dir(wd)
 		os.Chdir(wd)
 
-		// If we already visited this directory, it means that there's a loop and we can stop.
+		// If we already visited this directory, it means that there's a loop, and we can stop.
 		if visitedPaths[wd] {
 			return "", errors.New("Could not find go.mod for project.")
 		}
@@ -354,7 +354,7 @@ func removeCredentials(pattern *gofrogcmd.CmdOutputPattern) (string, error) {
 	return strings.Replace(pattern.Line, pattern.MatchedResults[0], splitResult[0]+"//", 1), nil
 }
 
-// GetCachePath returns the location of downloads dir insied the GOMODCACHE
+// GetCachePath returns the location of downloads dir inside the GOMODCACHE
 func GetCachePath() (string, error) {
 	goModCachePath, err := GetGoModCachePath()
 	if err != nil {

--- a/utils/goutils.go
+++ b/utils/goutils.go
@@ -140,8 +140,8 @@ func GetDependenciesList(projectDir string, log Log) (map[string]bool, error) {
 	}
 	output, err := runDependenciesCmd(projectDir, append(cmdArgs, "-f", "{{with .Module}}{{.Path}}@{{.Version}}{{end}}", "all"), log)
 	if err != nil {
-		// Errors occurred during running "go list". Run again and this time ignore errors (with '-e')
-		log.Warn("Errors occurred during building the Go dependency tree. The dependency tree may be incomplete:" + err.Error())
+		// Errors occurred while running "go list". Run again and this time ignore errors (with '-e')
+		log.Warn("Errors occurred while building the Go dependency tree. The dependency tree may be incomplete:" + err.Error())
 		output, err = runDependenciesCmd(projectDir, append(cmdArgs, "-e", "-f", "{{with .Module}}{{.Path}}@{{.Version}}{{end}}", "all"), log)
 		if err != nil {
 			return nil, err
@@ -247,7 +247,7 @@ func GetProjectRoot() (string, error) {
 		osRoot = "/"
 	}
 
-	// Check if the current directory includes the go.mod file. If not, check the parent directpry
+	// Check if the current directory includes the go.mod file. If not, check the parent directory
 	// and so on.
 	for {
 		// If the go.mod is found the current directory, return the path.

--- a/utils/goutils_test.go
+++ b/utils/goutils_test.go
@@ -109,8 +109,18 @@ func TestGetProjectRoot(t *testing.T) {
 }
 
 func TestGetDependenciesList(t *testing.T) {
+	testGetDependenciesList(t, "testGoList")
+}
+
+func TestGetDependenciesListWithIgnoreErrors(t *testing.T) {
+	// In some cases, we see that running go list on some Go packages may fail.
+	// We should allow ignoring the errors in such cases and build the Go dependency tree, even if partial.
+	testGetDependenciesList(t, "testBadGoList")
+}
+
+func testGetDependenciesList(t *testing.T, testDir string) {
 	log := NewDefaultLogger(ERROR)
-	gomodPath := filepath.Join("testdata", "mods", "testGoList")
+	gomodPath := filepath.Join("testdata", "mods", testDir)
 	err := os.Rename(filepath.Join(gomodPath, "go.mod.txt"), filepath.Join(gomodPath, "go.mod"))
 	assert.NoError(t, err)
 	defer func() {

--- a/utils/testdata/mods/testBadGoList/go.mod.txt
+++ b/utils/testdata/mods/testBadGoList/go.mod.txt
@@ -1,0 +1,7 @@
+module testGoList
+
+go 1.16
+
+require rsc.io/quote v1.5.2
+
+require golang.org/x/text v0.3.3 // indirect

--- a/utils/testdata/mods/testBadGoList/go.mod.txt
+++ b/utils/testdata/mods/testBadGoList/go.mod.txt
@@ -1,4 +1,4 @@
-module testGoList
+module testGoBadList
 
 go 1.16
 

--- a/utils/testdata/mods/testBadGoList/go.sum.txt
+++ b/utils/testdata/mods/testBadGoList/go.sum.txt
@@ -1,0 +1,8 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/utils/testdata/mods/testBadGoList/test.go.txt
+++ b/utils/testdata/mods/testBadGoList/test.go.txt
@@ -1,4 +1,4 @@
-package testGoList
+package testGoBadList
 
 import (
 	"fmt"

--- a/utils/testdata/mods/testBadGoList/test.go.txt
+++ b/utils/testdata/mods/testBadGoList/test.go.txt
@@ -1,0 +1,11 @@
+package testGoList
+
+import (
+	"fmt"
+	"rsc.io/quote"
+	"rscxxxx.ioxxxx/quotexxxx"
+)
+
+func PrintHello() {
+	fmt.Println(quote.Hello())
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

In some cases, we see that running `go list` on some Go packages may fail.
We should allow ignoring the errors in such cases and build the Go dependency tree, even if partial.