### PR TITLE
Set version dynamically on build

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"os"
+
 	"github.com/jfrog/build-info-go/cli"
 	"github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/build-info-go/utils/cliutils"
 	clitool "github.com/urfave/cli/v2"
-	"os"
 )
 
 var log utils.Log
+var cliVersion = "dev"
 
 func main() {
 	log = utils.NewDefaultLogger(getCliLogLevel())
@@ -16,7 +17,7 @@ func main() {
 		Name:     "Build-Info CLI",
 		Usage:    "Generate build-info for your source code",
 		Commands: cli.GetCommands(log),
-		Version:  cliutils.CliVersion,
+		Version:  cliVersion,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/release/build.sh
+++ b/release/build.sh
@@ -9,7 +9,7 @@ build () {
   exeName="$4"
   echo "Building $exeName for $GOOS-$GOARCH ..."
 
-  CGO_ENABLED=0 jf go build -o "$exeName" -ldflags '-w -extldflags "-static"' main.go
+  CGO_ENABLED=0 jf go build -o "$exeName" -ldflags '-w -extldflags "-static" -X main.cliVersion='$version main.go
   chmod +x bi
 
   # Run verification after building plugin for the correct platform of this image.

--- a/release/build.sh
+++ b/release/build.sh
@@ -10,7 +10,7 @@ build () {
   echo "Building $exeName for $GOOS-$GOARCH ..."
 
   CGO_ENABLED=0 jf go build -o "$exeName" -ldflags '-w -extldflags "-static" -X main.cliVersion='$version main.go
-  chmod +x bi
+  chmod +x $exeName
 
   # Run verification after building plugin for the correct platform of this image.
   if [[ "$pkg" = "linux-386" ]]; then

--- a/release/pipelines.yml
+++ b/release/pipelines.yml
@@ -47,7 +47,7 @@ pipelines:
 
             # Configure Git and merge from the dev
             - git checkout master
-            - git remote set-url origin https://$int_il_automation_token@github.com/jfrog/builf-info-go.git
+            - git remote set-url origin https://$int_il_automation_token@github.com/jfrog/build-info-go.git
             - git merge origin/dev
             - git tag ${NEXT_VERSION}
 
@@ -67,6 +67,8 @@ pipelines:
               JFROG_CLI_BUILD_NUMBER=$JFROG_CLI_BUILD_NUMBER 
               JFROG_CLI_BUILD_PROJECT=$JFROG_CLI_BUILD_PROJECT 
               release/build.sh "$NEXT_VERSION"
+            - jf rt bag && jf rt bce
+            - jf rt bp
 
             # Distribute release bundle
             - jf ds rbc "build-info-go" $NEXT_VERSION --spec="specs/bi-rbc-spec.json" --spec-vars="VERSION=$NEXT_VERSION" --sign

--- a/utils/cliutils/consts.go
+++ b/utils/cliutils/consts.go
@@ -2,6 +2,5 @@ package cliutils
 
 const (
 	// General CLI constants
-	CliVersion  = "0.1.5"
 	ClientAgent = "build-info-go"
 )


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Move cliVersion var to main.go
* Set the version dynamically on the build:
```bash
go build -X main.cliVersion=$version 
```
* The default version is `dev`