### PR TITLE
Fix implicit memory aliasing in for loop

### DIFF
--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -74,13 +74,11 @@ func (targetBuildInfo *BuildInfo) SetPluginVersion(pluginVersion string) {
 // If the two build info instances contain modules with identical names, these modules are merged.
 // When merging the modules, the artifacts and dependencies remain unique according to their checksum.
 func (targetBuildInfo *BuildInfo) Append(buildInfo *BuildInfo) {
-	for i := range buildInfo.Modules {
-		newModule := buildInfo.Modules[i]
+	for i, newModule := range buildInfo.Modules {
 		exists := false
 		for j := range targetBuildInfo.Modules {
-			targetModule := targetBuildInfo.Modules[j]
-			if newModule.Id == targetModule.Id {
-				mergeModules(&newModule, &targetModule)
+			if newModule.Id == targetBuildInfo.Modules[j].Id {
+				mergeModules(&buildInfo.Modules[i], &targetBuildInfo.Modules[j])
 				exists = true
 				break
 			}

--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -73,11 +73,13 @@ func (targetBuildInfo *BuildInfo) SetPluginVersion(pluginVersion string) {
 // If the two build info instances contain modules with identical names, these modules are merged.
 // When merging the modules, the artifacts and dependencies remain unique according to their checksum.
 func (targetBuildInfo *BuildInfo) Append(buildInfo *BuildInfo) {
-	for _, newModule := range buildInfo.Modules {
+	for i := range buildInfo.Modules {
+		newModule := buildInfo.Modules[i]
 		exists := false
-		for i := range targetBuildInfo.Modules {
-			if newModule.Id == targetBuildInfo.Modules[i].Id {
-				mergeModules(&newModule, &targetBuildInfo.Modules[i])
+		for j := range targetBuildInfo.Modules {
+			targetModule := targetBuildInfo.Modules[j]
+			if newModule.Id == targetModule.Id {
+				mergeModules(&newModule, &targetModule)
 				exists = true
 				break
 			}

--- a/entities/buildinfo_test.go
+++ b/entities/buildinfo_test.go
@@ -109,3 +109,40 @@ func TestMergeDependenciesLists(t *testing.T) {
 	mergeDependenciesLists(&dependenciesToAdd, &intoDependencies)
 	reflect.DeepEqual(expectedMergedDependencies, intoDependencies)
 }
+
+func TestAppend(t *testing.T) {
+	artifactA := Artifact{Name: "artifact-a", Checksum: Checksum{Sha1: "artifact-a-sha"}}
+	artifactB := Artifact{Name: "artifact-b", Checksum: Checksum{Sha1: "artifact-b-sha"}}
+	artifactC := Artifact{Name: "artifact-c", Checksum: Checksum{Sha1: "artifact-c-sha"}}
+
+	dependencyA := Dependency{Id: "dependency-a", Checksum: Checksum{Sha1: "dependency-a-sha"}}
+	dependencyB := Dependency{Id: "dependency-b", Checksum: Checksum{Sha1: "dependency-b-sha"}}
+	dependencyC := Dependency{Id: "dependency-c", Checksum: Checksum{Sha1: "dependency-c-sha"}}
+
+	buildInfo1 := BuildInfo{
+		Modules: []Module{{
+			Id:           "module-id",
+			Artifacts:    []Artifact{artifactA, artifactB},
+			Dependencies: []Dependency{dependencyA, dependencyB},
+		}},
+	}
+
+	buildInfo2 := BuildInfo{
+		Modules: []Module{{
+			Id:           "module-id",
+			Artifacts:    []Artifact{artifactA, artifactC},
+			Dependencies: []Dependency{dependencyA, dependencyC},
+		}},
+	}
+
+	expected := BuildInfo{
+		Modules: []Module{{
+			Id:           "module-id",
+			Artifacts:    []Artifact{artifactA, artifactB, artifactC},
+			Dependencies: []Dependency{dependencyA, dependencyB, dependencyC},
+		}},
+	}
+
+	buildInfo1.Append(&buildInfo2)
+	assert.True(t, IsEqualModuleSlices(expected.Modules, buildInfo1.Modules))
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fixes implicit memory aliasing in for loop whereby the targetBuildInfo modules may be reused accidentally:

```go
for i := range targetBuildInfo.Modules {
	if newModule.Id == targetBuildInfo.Modules[i].Id {
		mergeModules(&newModule, &targetBuildInfo.Modules[i]) // This line is troublesome
	}
}
```

For more info see: https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop/68247837