### PR TITLE
Remove pointer from  embedded checksum struct

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -340,7 +340,7 @@ type partialModule struct {
 	moduleType   entities.ModuleType
 	artifacts    map[string]entities.Artifact
 	dependencies map[string]entities.Dependency
-	checksum     *entities.Checksum
+	checksum     entities.Checksum
 }
 
 func extractBuildInfoData(partials entities.Partials) ([]entities.Module, entities.Env, []entities.Vcs, entities.Issues, error) {
@@ -442,7 +442,7 @@ func dependenciesMapToList(dependenciesMap map[string]entities.Dependency) []ent
 	return dependencies
 }
 
-func createModule(moduleId string, moduleType entities.ModuleType, checksum *entities.Checksum, artifacts []entities.Artifact, dependencies []entities.Dependency) *entities.Module {
+func createModule(moduleId string, moduleType entities.ModuleType, checksum entities.Checksum, artifacts []entities.Artifact, dependencies []entities.Dependency) *entities.Module {
 	module := createDefaultModule(moduleId)
 	module.Type = moduleType
 	module.Checksum = checksum

--- a/build/golang.go
+++ b/build/golang.go
@@ -157,7 +157,7 @@ func populateZip(packageId, zipPath string) (zipDependency entities.Dependency, 
 		return
 	}
 	zipDependency.Type = "zip"
-	zipDependency.Checksum = &entities.Checksum{Sha1: checksums.Sha1, Md5: checksums.Md5, Sha256: checksums.Sha256}
+	zipDependency.Checksum = entities.Checksum{Sha1: checksums.Sha1, Md5: checksums.Md5, Sha256: checksums.Sha256}
 	return
 }
 

--- a/build/golang_test.go
+++ b/build/golang_test.go
@@ -20,7 +20,7 @@ func TestGenerateBuildInfoForGoProject(t *testing.T) {
 	assert.NoError(t, err)
 	err = goModule.CalcDependencies()
 	assert.NoError(t, err)
-	err = goModule.AddArtifacts(entities.Artifact{Name: "artifactName", Type: "artifactType", Path: "artifactPath", Checksum: &entities.Checksum{Sha1: "123", Md5: "456", Sha256: "789"}})
+	err = goModule.AddArtifacts(entities.Artifact{Name: "artifactName", Type: "artifactType", Path: "artifactPath", Checksum: entities.Checksum{Sha1: "123", Md5: "456", Sha256: "789"}})
 	assert.NoError(t, err)
 	buildInfo, err := goBuild.ToBuildInfo()
 	assert.NoError(t, err)
@@ -42,7 +42,7 @@ func validateModule(t *testing.T, module buildinfo.Module, expectedDependencies,
 		assert.Equal(t, "789", module.Artifacts[0].Checksum.Sha256, "Unexpected SHA256 field.")
 	}
 	assert.Equal(t, moduleType, module.Type)
-	assert.Equal(t, depsContainChecksums, module.Dependencies[0].Checksum != nil)
+	assert.Equal(t, depsContainChecksums, !module.Dependencies[0].Checksum.IsEmpty())
 	if depsContainChecksums {
 		assert.NotEmpty(t, module.Dependencies[0].Checksum.Sha1, "Empty Sha1 field.")
 		assert.NotEmpty(t, module.Dependencies[0].Checksum.Md5, "Empty MD5 field.")

--- a/build/npm_test.go
+++ b/build/npm_test.go
@@ -20,7 +20,7 @@ func TestGenerateBuildInfoForNpmProject(t *testing.T) {
 	assert.NoError(t, err)
 	err = npmModule.CalcDependencies()
 	assert.NoError(t, err)
-	err = npmModule.AddArtifacts(entities.Artifact{Name: "artifactName", Type: "artifactType", Path: "artifactPath", Checksum: &entities.Checksum{Sha1: "123", Md5: "456", Sha256: "789"}})
+	err = npmModule.AddArtifacts(entities.Artifact{Name: "artifactName", Type: "artifactType", Path: "artifactPath", Checksum: entities.Checksum{Sha1: "123", Md5: "456", Sha256: "789"}})
 	assert.NoError(t, err)
 	buildInfo, err := goBuild.ToBuildInfo()
 	assert.NoError(t, err)
@@ -41,7 +41,7 @@ func TestCollectDepsForNpmProjectWithTraverse(t *testing.T) {
 		if dependency.Id == "xml:1.0.1" {
 			return false, nil
 		}
-		dependency.Checksum = &entities.Checksum{Sha1: "test123", Md5: "test456", Sha256: "test789"}
+		dependency.Checksum = entities.Checksum{Sha1: "test123", Md5: "test456", Sha256: "test789"}
 		return true, nil
 	})
 	err = npmModule.CalcDependencies()

--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -1,9 +1,10 @@
 package entities
 
 import (
-	"github.com/pkg/errors"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/jfrog/gofrog/stringutils"
@@ -167,7 +168,7 @@ func (targetBuildInfo *BuildInfo) ToCycloneDxBom() (*cdx.BOM, error) {
 			newComp.Type = cdx.ComponentTypeLibrary
 		}
 
-		if biDep.Checksum != nil {
+		if !biDep.Checksum.IsEmpty() {
 			hashes := []cdx.Hash{
 				{
 					Algorithm: cdx.HashAlgoSHA256,
@@ -255,7 +256,7 @@ func mergeDependenciesLists(dependenciesToAdd, intoDependencies *[]Dependency) {
 	for i, dependencyToAdd := range *dependenciesToAdd {
 		exists := false
 		for _, dependency := range *intoDependencies {
-			if (dependencyToAdd.Checksum != nil && dependency.Checksum != nil && dependencyToAdd.Sha1 == dependency.Sha1) || (dependencyToAdd.Checksum == nil && dependency.Checksum == nil && dependencyToAdd.Id == dependency.Id) {
+			if dependencyToAdd.Sha1 == dependency.Sha1 && dependencyToAdd.Id == dependency.Id {
 				exists = true
 				(*dependenciesToAdd)[i] = mergeDependencies(dependency, dependencyToAdd)
 				break
@@ -341,7 +342,7 @@ type Module struct {
 	ExcludedArtifacts []Artifact   `json:"excludedArtifacts,omitempty"`
 	Dependencies      []Dependency `json:"dependencies,omitempty"`
 	// Used in aggregated builds - this field stores the checksums of the referenced build-info JSON.
-	*Checksum
+	Checksum
 }
 
 func (m *Module) isEqual(other Module) bool {
@@ -374,19 +375,10 @@ type Artifact struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
 	Path string `json:"path,omitempty"`
-	*Checksum
+	Checksum
 }
 
 func (a *Artifact) isEqual(other Artifact) bool {
-	if other.Checksum == nil && a.Checksum == nil {
-		return a.Name == other.Name && a.Path == other.Path && a.Type == other.Type
-	}
-	if other.Checksum == nil && a.Checksum != nil {
-		return false
-	}
-	if other.Checksum != nil && a.Checksum == nil {
-		return false
-	}
 	return a.Name == other.Name && a.Path == other.Path && a.Type == other.Type && a.Sha1 == other.Sha1 && a.Md5 == other.Md5 && a.Sha256 == other.Sha256
 }
 
@@ -413,19 +405,10 @@ type Dependency struct {
 	Type        string     `json:"type,omitempty"`
 	Scopes      []string   `json:"scopes,omitempty"`
 	RequestedBy [][]string `json:"requestedBy,omitempty"`
-	*Checksum
+	Checksum
 }
 
 func (d *Dependency) IsEqual(other Dependency) bool {
-	if d.Checksum == nil && other.Checksum == nil {
-		return d.Id == other.Id && d.Type == other.Type
-	}
-	if d.Checksum != nil && other.Checksum == nil {
-		return false
-	}
-	if d.Checksum == nil && other.Checksum != nil {
-		return false
-	}
 	return d.Id == other.Id && d.Type == other.Type && d.Sha1 == other.Sha1 && d.Md5 == other.Md5 && d.Sha256 == other.Sha256
 }
 
@@ -483,6 +466,10 @@ type Checksum struct {
 	Sha256 string `json:"sha256,omitempty"`
 }
 
+func (c *Checksum) IsEmpty() bool {
+	return c.Md5 == "" && c.Sha1 == "" && c.Sha256 == ""
+}
+
 type Env map[string]string
 
 type Vcs struct {
@@ -503,7 +490,7 @@ type Partial struct {
 	ModuleId     string       `json:"ModuleId,omitempty"`
 	Issues       *Issues      `json:"Issues,omitempty"`
 	VcsList      []Vcs        `json:"vcs,omitempty"`
-	*Checksum
+	Checksum
 }
 
 func (partials Partials) Len() int {

--- a/entities/buildinfo_test.go
+++ b/entities/buildinfo_test.go
@@ -15,7 +15,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 			Name: "layer",
 			Type: "",
 			Path: "path/to/somewhere",
-			Checksum: &Checksum{
+			Checksum: Checksum{
 				Sha1: "1",
 				Md5:  "2",
 			},
@@ -23,7 +23,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 		Dependencies: []Dependency{{
 			Id:   "alpine",
 			Type: "docker",
-			Checksum: &Checksum{
+			Checksum: Checksum{
 				Sha1: "3",
 				Md5:  "4",
 			},
@@ -36,7 +36,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 			Name: "layer",
 			Type: "",
 			Path: "path/to/somewhere",
-			Checksum: &Checksum{
+			Checksum: Checksum{
 				Sha1: "1",
 				Md5:  "2",
 			},
@@ -44,7 +44,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 		Dependencies: []Dependency{{
 			Id:   "alpine",
 			Type: "docker",
-			Checksum: &Checksum{
+			Checksum: Checksum{
 				Sha1: "3",
 				Md5:  "4",
 			},
@@ -67,7 +67,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 	newDependency := Dependency{
 		Id:   "alpine",
 		Type: "docker",
-		Checksum: &Checksum{
+		Checksum: Checksum{
 			Sha1: "3",
 			Md5:  "4",
 		},
@@ -81,7 +81,7 @@ func TestIsEqualModuleSlices(t *testing.T) {
 		Name:     "a",
 		Type:     "s",
 		Path:     "s",
-		Checksum: &Checksum{},
+		Checksum: Checksum{},
 	}
 	a[0].Artifacts = append(a[0].Artifacts, newArtifact)
 	assert.False(t, IsEqualModuleSlices(a, b))
@@ -91,18 +91,18 @@ func TestIsEqualModuleSlices(t *testing.T) {
 func TestMergeDependenciesLists(t *testing.T) {
 	dependenciesToAdd := []Dependency{
 		{Id: "test-dep1", Type: "tst", Scopes: []string{"a", "b"}, RequestedBy: [][]string{{"a", "b"}, {"b", "a"}}},
-		{Id: "test-dep2", Type: "tst", Scopes: []string{"a"}, RequestedBy: [][]string{{"a", "b"}}, Checksum: &Checksum{Sha1: "123"}},
+		{Id: "test-dep2", Type: "tst", Scopes: []string{"a"}, RequestedBy: [][]string{{"a", "b"}}, Checksum: Checksum{Sha1: "123"}},
 		{Id: "test-dep3", Type: "tst"},
 		{Id: "test-dep4", Type: "tst"},
 	}
 	intoDependencies := []Dependency{
 		{Id: "test-dep1", Type: "tst", Scopes: []string{"a"}, RequestedBy: [][]string{{"b", "a"}}},
-		{Id: "test-dep2", Type: "tst", Scopes: []string{"b"}, RequestedBy: [][]string{{"a", "c"}}, Checksum: &Checksum{Sha1: "123"}},
+		{Id: "test-dep2", Type: "tst", Scopes: []string{"b"}, RequestedBy: [][]string{{"a", "c"}}, Checksum: Checksum{Sha1: "123"}},
 		{Id: "test-dep3", Type: "tst", Scopes: []string{"a"}, RequestedBy: [][]string{{"a", "b"}}},
 	}
 	expectedMergedDependencies := []Dependency{
 		{Id: "test-dep1", Type: "tst", Scopes: []string{"a", "b"}, RequestedBy: [][]string{{"b", "a"}, {"a", "b"}}},
-		{Id: "test-dep2", Type: "tst", Scopes: []string{"b"}, RequestedBy: [][]string{{"a", "c"}}, Checksum: &Checksum{Sha1: "123"}},
+		{Id: "test-dep2", Type: "tst", Scopes: []string{"b"}, RequestedBy: [][]string{{"a", "c"}}, Checksum: Checksum{Sha1: "123"}},
 		{Id: "test-dep3", Type: "tst", Scopes: []string{"a"}, RequestedBy: [][]string{{"a", "b"}}},
 		{Id: "test-dep4", Type: "tst"},
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The struct `entities.Checksum` located in a few places as an embedded field.
It's bad practice to use it as a pointer and not a struct for a couple of reasons:

First, most of the time, the wrapper struct, which  `entities.Checksum` is embedded inside, is a pointer itself, so there is no real benefit for using nested pointers.
Seconds, `entities.Checksum` fields are string, when referencing one of the fields, it looks like no nil check is required but `entities.Checksum` itself could be nil.
This may open the door for runtime exceptions such as here https://github.com/jfrog/jfrog-cli/issues/1297.

The solution to this problem is simple, use struct instead of pointer as embedded field.
Related PRs:
* https://github.com/jfrog/jfrog-cli-core/pull/306
* https://github.com/jfrog/jfrog-client-go/pull/504