### PR TITLE
Missing npm dependencies may return an error

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CalculateNpmDependenciesList gets an npm project's dependencies.
-func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmArgs []string, calculateChecksums bool, log utils.Log) (dependenciesList []entities.Dependency, err error) {
+func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmArgs []string, calculateChecksums bool, log utils.Log) ([]entities.Dependency, error) {
 	if log == nil {
 		log = &utils.NullLog{}
 	}
@@ -35,6 +35,7 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmA
 		}
 		cacache = NewNpmCacache(cacheLocation)
 	}
+	var dependenciesList []entities.Dependency
 	var missingPeerDeps, missingBundledDeps, missingOptionalDeps, otherMissingDeps []string
 	for _, dep := range dependenciesMap {
 		if dep.npmLsDependency.Integrity == "" && dep.npmLsDependency.InBundle {
@@ -76,7 +77,7 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmA
 	if len(otherMissingDeps) > 0 {
 		log.Warn("The following dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(otherMissingDeps, ",") + "'.\nHint: Try to delete 'node_models' and/or 'package-lock.json'.")
 	}
-	return
+	return dependenciesList, nil
 }
 
 type dependencyInfo struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fixes https://github.com/jfrog/jfrog-cli/issues/1526
Followup https://github.com/jfrog/build-info-go/pull/78

In case there are missing dependencies in npm cache, we should warn about them and not fail the build.
https://github.com/jfrog/build-info-go/pull/78 fix this issue partially - if the last dependency does not exist in the npm cache, an error may still be returned by CalculateNpmDependenciesList.