### PR TITLE
Duplicate artifacts are counted by their paths instead of their names

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jfrog/build-info-go/utils/pythonutils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jfrog/build-info-go/utils/pythonutils"
 
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
@@ -442,7 +443,7 @@ func addArtifactToPartialModule(artifact entities.Artifact, moduleId string, par
 	if partialModules[moduleId].artifacts == nil {
 		partialModules[moduleId].artifacts = make(map[string]entities.Artifact)
 	}
-	key := fmt.Sprintf("%s-%s-%s", artifact.Name, artifact.Sha1, artifact.Md5)
+	key := fmt.Sprintf("%s-%s-%s", artifact.Path, artifact.Sha1, artifact.Md5)
 	partialModules[moduleId].artifacts[key] = artifact
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix: https://github.com/jfrog/jfrog-cli/issues/1418
Depends on: 
* https://github.com/jfrog/jfrog-client-go/pull/594
* https://github.com/jfrog/jfrog-cli-core/pull/406
* https://github.com/jfrog/jfrog-cli/pull/1552