### PR TITLE
The latest npm tests have been updated to work with npm versions 8.11.0 and above

### DIFF
--- a/build/testdata/npm/project1/npmv8/excpected_dependencies_list.json
+++ b/build/testdata/npm/project1/npmv8/excpected_dependencies_list.json
@@ -1,42 +1,53 @@
 [
     {
-        "id": "node-releases:2.0.2",
+        "id": "p-limit:2.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "p-locate:4.1.0",
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "7139fe71e2f4f11b47d4d2986aaf8c48699e0c01",
-        "md5": "206a057876754acbeb1d795a17f2017b",
-        "sha256": "cf2ed799dedf5a349363551f1a94508188260aa0e207ab82f09846453c58adbb"
+        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
+        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
+        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
     },
     {
-        "id": "istanbul-lib-report:3.0.0",
+        "id": "supports-color:7.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-reports:3.1.4",
+                "istanbul-lib-report:3.0.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
-        "md5": "87a16f7a36e489fdd042510550872167",
-        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
+        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
+        "md5": "da58ae58b985905e1445bc447625dc1b",
+        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
+    },
+    {
+        "id": "append-transform:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-hook:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
+        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
+        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
     },
     {
         "id": "fromentries:1.3.2",
@@ -55,28 +66,571 @@
         "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
     },
     {
-        "id": "is-typedarray:1.0.0",
+        "id": "symbol:0.2.3",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "3b9873b8a901e47c6efe21526a3ac372ef28bbc7",
+        "md5": "f21f7b178297af9a67a8aef376c7253a",
+        "sha256": "8b6166f4dfd4d930eca2775d3bb8e6e3d97e6e02f2594020cc3ff465c09d63d1"
+    },
+    {
+        "id": "normalize-package-data:2.5.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
+        "md5": "b46c083aa373a30b8d2421e9f269d543",
+        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
+    },
+    {
+        "id": "lodash.assign:4.2.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs-parser:2.4.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
+        "md5": "5a92447d4e8669abba120d5164892902",
+        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
+    },
+    {
+        "id": "type-fest:0.8.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "typedarray-to-buffer:3.1.5",
-                "write-file-atomic:3.0.3",
+                "hasha:5.2.2",
                 "caching-transform:4.0.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
-        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
-        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
+        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
+        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
+        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
+    },
+    {
+        "id": "p-locate:4.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
+        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
+        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
+    },
+    {
+        "id": "istanbul-lib-coverage:3.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-source-maps:4.0.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
+        "md5": "799503e96989c6a2906f2c58bc51f0d6",
+        "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
+    },
+    {
+        "id": "@jridgewell/gen-mapping:0.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9",
+        "md5": "de5b5402b140d1634f9bbf189b298ee3",
+        "sha256": "8176fad9663205ddefe81637fcc24097dded9716ad300a3d8ede3062e4cfc6fd"
+    },
+    {
+        "id": "@babel/helper-compilation-targets:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf",
+        "md5": "e4bb285eb8cfaafeb0964e277713e836",
+        "sha256": "b1045536c086bdc82da52399401e7fabeacf8c52f38c653f04e921d3def4b74f"
+    },
+    {
+        "id": "html-escaper:2.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-reports:3.1.5",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
+        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
+        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
+    },
+    {
+        "id": "test-exclude:6.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
+        "md5": "c9d2be086d4d740f9999b77971777008",
+        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
+    },
+    {
+        "id": "string-width:4.2.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
+        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
+        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
+    },
+    {
+        "id": "make-dir:3.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
+        "md5": "e47d13370c2b27671a13f28ebc27585f",
+        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
+    },
+    {
+        "id": "pkg-dir:4.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
+        "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
+        "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
+    },
+    {
+        "id": "has:1.0.3",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "is-core-module:2.9.0",
+                "resolve:1.22.1",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+        "md5": "b765203b0d733534ee6a58d84767223a",
+        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
+    },
+    {
+        "id": "require-main-filename:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
+        "md5": "8b45166659a670e83387649f79c641ad",
+        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
+    },
+    {
+        "id": "pify:2.3.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "md5": "475310192b9d153240ac82eb66b827e8",
+        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
+    },
+    {
+        "id": "hasha:5.2.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
+        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
+        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
+    },
+    {
+        "id": "lodash.flattendeep:4.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
+        "md5": "17ca06c4643969cb10e948854434eba0",
+        "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
+    },
+    {
+        "id": "safe-buffer:5.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "convert-source-map:1.8.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "md5": "dc7142b470e0957c5c34098b6fced0ab",
+        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+        "id": "ms:2.1.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "debug:4.3.3",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
+        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
+        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
+    },
+    {
+        "id": "camelcase:5.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "yargs-parser:18.1.3",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
+        "md5": "efcf73180d9b7001c92f574d4ae7f908",
+        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
+    },
+    {
+        "id": "yargs:4.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "035e5ea466ac7fea584b00353e33eae4082b9894",
+        "md5": "5e59a96f40502e3922d5101b3b1641dd",
+        "sha256": "5dda9828b768e0c8dd5bfb57abf6ca99b5b8ae0f44610cb56e1690a5517b8e65"
+    },
+    {
+        "id": "validate-npm-package-license:3.0.4",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
+        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
+    },
+    {
+        "id": "@babel/helper-module-imports:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "1e3ebdbbd08aad1437b428c50204db13c5a3ca6e",
+        "md5": "3549438c2b0b59c539a58c4cb733f4a0",
+        "sha256": "9b450e94445d86395e12d74981be606bb90d4e92e99ae358093d1318d78c6568"
+    },
+    {
+        "id": "p-map:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
+        "md5": "3b38970091b03645f6f4d6680ada671d",
+        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
+    },
+    {
+        "id": "istanbul-lib-hook:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
+        "md5": "5602d9c25a554fbcca017c4df471866e",
+        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
+    },
+    {
+        "id": "istanbul-lib-instrument:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
+        "md5": "ee314a8a3153abd9396916f9e141d374",
+        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
+    },
+    {
+        "id": "source-map:0.6.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-source-maps:4.0.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
+        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
+    },
+    {
+        "id": "strip-bom:2.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
+        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
+    },
+    {
+        "id": "semver:5.7.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
+        "md5": "99453010ab0aad4c49dba769e6193c35",
+        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
     },
     {
         "id": "shebang-regex:3.0.0",
@@ -97,361 +651,42 @@
         "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
     },
     {
-        "id": "istanbul-lib-hook:3.0.0",
+        "id": "wrappy:1.0.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
-        "md5": "5602d9c25a554fbcca017c4df471866e",
-        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
-    },
-    {
-        "id": "@babel/helper-validator-identifier:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "inflight:1.0.6",
+                "glob:7.2.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
             [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/types:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "once:1.4.0",
+                "glob:7.2.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "e8c602438c4a8195751243da9031d1607d247cad",
-        "md5": "01d9e7c98c18ad2aa95344c17478b185",
-        "sha256": "f647395ab3d4535d85e87df8b3c9979e0bf91f8065145227fbf92c89b3070214"
+        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "md5": "567b1699cfae49cb20f598571a6c90c7",
+        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
     },
     {
-        "id": "@babel/helper-hoist-variables:7.16.7",
+        "id": "node-preload:0.2.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "86bcb19a77a509c7b77d0e22323ef588fa58c246",
-        "md5": "757d50721db19a62b2b9411b070d6e58",
-        "sha256": "72b2c9684e5628ed942f7e608ff79ddc74e4a66a088c5ef10597b4050a4b88bb"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "convert-source-map:1.8.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "@babel/parser:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f0ac33eddbe214e4105363bb17c3341c5ffcc43c",
-        "md5": "5d7976d85b1ab0763660e53d67b768be",
-        "sha256": "b835d7e17844d74a455bed9de58b5787a9b9ead1d82a2985a6b9b73895b29896"
-    },
-    {
-        "id": "ansi-regex:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:6.0.1",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
-        "md5": "7a0bb891f3a7cd9b174af62beb4de186",
-        "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
-    },
-    {
-        "id": "which-module:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "md5": "ce028f30082fbbea9861a40437d17bd3",
-        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
-    },
-    {
-        "id": "path-type:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "md5": "e14c138690b623db36532ff609b81b08",
-        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
-    },
-    {
-        "id": "yargs-parser:2.4.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
-        "md5": "3ed28206e170b6c0cf902511c2d0534b",
-        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
-    },
-    {
-        "id": "commondir:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
-        "md5": "329b8682e83ec34dfe1c58ae90b84988",
-        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
-    },
-    {
-        "id": "balanced-match:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
-        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
-        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
-    },
-    {
-        "id": "globals:11.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
-        "md5": "712d15395573404a3ddb37ce395d948b",
-        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
-    },
-    {
-        "id": "yargs:4.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "035e5ea466ac7fea584b00353e33eae4082b9894",
-        "md5": "5e59a96f40502e3922d5101b3b1641dd",
-        "sha256": "5dda9828b768e0c8dd5bfb57abf6ca99b5b8ae0f44610cb56e1690a5517b8e65"
-    },
-    {
-        "id": "error-ex:1.3.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
-        "md5": "5d2c673565060037f9e04d7975d04feb",
-        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:2.2.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "pkg-dir:4.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
-        "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
-        "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "electron-to-chromium:1.4.71",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "17056914465da0890ce00351a3b946fd4cd51ff6",
-        "md5": "2c5f79188dd916f93d015bd43e40eb43",
-        "sha256": "c3c060dd6e61b6949eb800e540a83830a144210402b1b5e09a577d8efe162c3f"
+        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
+        "md5": "120f936cf9cfb9aaf63819850ee25dab",
+        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
     },
     {
         "id": "aggregate-error:3.1.0",
@@ -470,40 +705,67 @@
         "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
     },
     {
-        "id": "is-fullwidth-code-point:3.0.0",
+        "id": "indent-string:4.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "string-width:4.2.3",
-                "yargs:15.4.1",
+                "aggregate-error:3.1.0",
+                "p-map:3.0.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
-        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
-        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
+        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
+        "md5": "ad188c269f2d9181da4321f8803a4cde",
+        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
     },
     {
-        "id": "spdx-correct:3.1.1",
+        "id": "strip-ansi:3.0.1",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
+                "cliui:3.2.0",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "wrap-ansi:2.1.0",
+                "cliui:3.2.0",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "string-width:1.0.2",
                 "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
-        "md5": "bd668e9b71960e76e867c11ec3ec2982",
-        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
+        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
+        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
+    },
+    {
+        "id": "is-arrayish:0.2.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "error-ex:1.3.2",
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "md5": "4bbbacda455ab73d86f5eda908989f24",
+        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
     },
     {
         "id": "spdx-license-ids:3.0.11",
@@ -535,339 +797,6 @@
         "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
     },
     {
-        "id": "strip-ansi:6.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "string-width:4.2.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
-        "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
-        "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
-    },
-    {
-        "id": "find-cache-dir:3.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
-        "md5": "52bbc85bfe0ddab6259eb6618900ab61",
-        "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "@jridgewell/resolve-uri:3.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@jridgewell/trace-mapping:0.3.4",
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "68eb521368db76d040a6315cdb24bf2483037b9c",
-        "md5": "07cb06db0492aeeb70f4b82acd092497",
-        "sha256": "e619c16d899ea3357c44f5b5f7d7e1e756d56907cc5c61dc962920ed597df449"
-    },
-    {
-        "id": "js-tokens:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
-        "md5": "325b11b965688c69ae45a3cf771fbc5c",
-        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
-    },
-    {
-        "id": "gensync:1.0.0-beta.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
-        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
-        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
-    },
-    {
-        "id": "process-on-spawn:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-preload:0.2.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
-        "md5": "acaca9f6065528d5b79d3d3501b5a745",
-        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
-    },
-    {
-        "id": "color-name:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:2.0.1",
-                "ansi-styles:4.3.0",
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
-        "md5": "a8d4412852471526b8027af2532d0d2b",
-        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
-    },
-    {
-        "id": "string-width:1.0.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "cliui:3.2.0",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
-        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
-        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
-    },
-    {
-        "id": "get-package-type:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
-        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
-        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
-    },
-    {
-        "id": "is-stream:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
-        "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
-        "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
-    },
-    {
-        "id": "@babel/helper-environment-visitor:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ff484094a839bde9d89cd63cba017d7aae80ecd7",
-        "md5": "c5728d1ab5fea8959f6be3e4afb2e0cb",
-        "sha256": "ba9a21976a417bceb8aa7023b06cfdac5e5d1c27b194aeb00d401a932cc75787"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "wrap-ansi:6.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
-        "md5": "f8917d0c5de3cfd4ab98a235260b3951",
-        "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
-    },
-    {
-        "id": "type-fest:0.8.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
-        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
-        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
-    },
-    {
         "id": "path-exists:4.0.0",
         "scopes": [
             "dev"
@@ -884,1182 +813,6 @@
         "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
     },
     {
-        "id": "foreground-child:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
-        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
-        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
-    },
-    {
-        "id": "append-transform:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
-        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
-        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
-    },
-    {
-        "id": "@babel/helper-split-export-declaration:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "0b648c0c42da9d3920d85ad585f2778620b8726b",
-        "md5": "cce660616c0b0f8c1c699b95ad639d03",
-        "sha256": "0bf2cab0c3fb41fb2d3ef0b24a31dad8d781ca53ce6765c09e3243e04b52750f"
-    },
-    {
-        "id": "@babel/traverse:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3143e5066796408ccc880a33ecd3184f3e75cd30",
-        "md5": "3a4cd8b0047b7c1f442688a933b98885",
-        "sha256": "9711bf0f5c6ef0b1c4e256ab3da16c4b2e514606f443b5504910ba45859b79ae"
-    },
-    {
-        "id": "@babel/helper-function-name:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f1ec51551fb1c8956bc8dd95f38523b6cf375f8f",
-        "md5": "fe6ef594ab8e9c55fa7acc2f44e800d3",
-        "sha256": "da1772107abcf286f381db20854100ae0f7736d26780781ac47ba56ac54c045f"
-    },
-    {
-        "id": "convert-source-map:1.8.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
-        "md5": "d1c553aaaffba79be7073471b2619511",
-        "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
-    },
-    {
-        "id": "archy:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
-        "md5": "b2a24c65e2212f53168f984b5a693dbd",
-        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
-    },
-    {
-        "id": "wrap-ansi:2.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "cliui:3.2.0",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
-        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
-    },
-    {
-        "id": "find-up:1.1.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
-        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
-    },
-    {
-        "id": "spdx-expression-parse:3.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
-        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
-        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
-    },
-    {
-        "id": "spdx-exceptions:2.3.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
-        "md5": "acbb50a4dc418357a51310b852eb2e38",
-        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
-    },
-    {
-        "id": "lodash.assign:4.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
-        "md5": "5a92447d4e8669abba120d5164892902",
-        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.1.1",
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "json5:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "2dfefe720c6ba525d9ebd909950f0515316c89a3",
-        "md5": "e4711e39d31c4887d0c727ee258c7b40",
-        "sha256": "37875a2bd12417df58f547acc8b909db3a2cb437511f44516a6871e344c0b1fe"
-    },
-    {
-        "id": "node-preload:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
-        "md5": "120f936cf9cfb9aaf63819850ee25dab",
-        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
-    },
-    {
-        "id": "ansi-styles:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
-        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
-        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
-    },
-    {
-        "id": "function-bind:1.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "has:1.0.3",
-                "is-core-module:2.8.1",
-                "resolve:1.22.0",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
-        "md5": "ee976e75439af2b82e707f3a64c69684",
-        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
-    },
-    {
-        "id": "path-parse:1.0.7",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
-        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
-        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
-    },
-    {
-        "id": "decamelize:1.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
-        "md5": "330932e4de0e60c36114facb6d3dfafa",
-        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
-    },
-    {
-        "id": "@babel/helper-simple-access:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d656654b9ea08dbb9659b69d61063ccd343ff0f7",
-        "md5": "04fc4c5e57b1f7c07f524259c792b13c",
-        "sha256": "08e167f023c3100ec4cfc438eddb6c4945f0fdf85668e692b6ed016194da934a"
-    },
-    {
-        "id": "istanbul-lib-source-maps:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
-        "md5": "2b0cd1493c52493181871afc3c5a93be",
-        "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
-    },
-    {
-        "id": "pify:2.3.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
-        "md5": "475310192b9d153240ac82eb66b827e8",
-        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
-    },
-    {
-        "id": "istanbul-lib-coverage:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
-        "md5": "799503e96989c6a2906f2c58bc51f0d6",
-        "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
-    },
-    {
-        "id": "@babel/highlight:7.16.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "744f2eb81579d6eea753c227b0f570ad785aba88",
-        "md5": "bcf1f0f288a5a1b94bc794bb91330322",
-        "sha256": "cf3f6b5c1dd40d0ac1e8b9c2cbfeb56e6cedff940ecefd437d913a6662867f92"
-    },
-    {
-        "id": "@babel/types:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-environment-visitor:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-module-imports:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-simple-access:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-split-export-declaration:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-get-function-arity:7.16.7",
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-hoist-variables:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a826e368bccb6b3d84acd76acad5c0d87342390b",
-        "md5": "25c50552b3df248fdd6190d10d2a2504",
-        "sha256": "ed70b73777727e0693ffebd4f8bd3b292c0c09c4942346db1f56c26683043ba3"
-    },
-    {
-        "id": "has-flag:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:7.2.0",
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
-        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
-        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
-    },
-    {
-        "id": "require-main-filename:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
-        "md5": "8b45166659a670e83387649f79c641ad",
-        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
-    },
-    {
-        "id": "number-is-nan:1.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "is-fullwidth-code-point:1.0.0",
-                "string-width:1.0.2",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "097b602b53422a522c1afb8790318336941a011d",
-        "md5": "1c192095065e6b72a7e20a747b110469",
-        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
-    },
-    {
-        "id": "cross-spawn:7.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
-        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
-        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
-    },
-    {
-        "id": "@babel/generator:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "7bd890ba706cd86d3e2f727322346ffdbf98f65e",
-        "md5": "57c162fe94987cd2dc7fb8ca2275273c",
-        "sha256": "5e2b5025057fbd393e4272d81fe00a41590d4c3d8f1624beed6c2a331b8c2ea4"
-    },
-    {
-        "id": "html-escaper:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-reports:3.1.4",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
-        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
-        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
-    },
-    {
-        "id": "cliui:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
-        "md5": "9065a0615794d52f19cffa078701d382",
-        "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
-    },
-    {
-        "id": "pkg-conf:1.1.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "378e56d6fd13e88bfb6f4a25df7a83faabddba5b",
-        "md5": "1a332f846b47c4cf3a82746c5411647e",
-        "sha256": "725a988399da377a18d58872ac64b6a78351c3c7cdec80522fe0576c6829d517"
-    },
-    {
-        "id": "normalize-package-data:2.5.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
-        "md5": "b46c083aa373a30b8d2421e9f269d543",
-        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
-    },
-    {
-        "id": "is-core-module:2.8.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f59fdfca701d5879d0a6b100a40aa1560ce27211",
-        "md5": "b7203baea21d3312e5c49f374855b4b3",
-        "sha256": "a5476c788ef83b7ff627631136a2dfefe49e0f3c6ed00bee6ec426223c751e20"
-    },
-    {
-        "id": "ms:2.1.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "debug:4.3.3",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
-        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
-        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
-    },
-    {
-        "id": "p-try:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
-        "md5": "49994562e1f3cbe260710598cbb3edf7",
-        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
-    },
-    {
-        "id": "shebang-command:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
-        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
-        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
-    },
-    {
-        "id": "strip-bom:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "default-require-extensions:3.0.0",
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
-        "md5": "ba5ded28e859d1030ed2f1369e379f67",
-        "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
-    },
-    {
-        "id": "istanbul-lib-instrument:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
-        "md5": "ee314a8a3153abd9396916f9e141d374",
-        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
-    },
-    {
-        "id": "supports-color:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
-        "md5": "da58ae58b985905e1445bc447625dc1b",
-        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
-    },
-    {
-        "id": "code-point-at:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "string-width:1.0.2",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
-        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
-        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "minimatch:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "879ad447200773912898b46cd516a7abbb5e50b0",
-        "md5": "22992838af1452c5cccc92cdf6c21025",
-        "sha256": "2b4e6fc003c29d58cb6f21c9b235ffa6ad29c7e94eba24c60d42973113629280"
-    },
-    {
-        "id": "default-require-extensions:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
-        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
-        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
-    },
-    {
-        "id": "indent-string:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
-        "md5": "ad188c269f2d9181da4321f8803a4cde",
-        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
-    },
-    {
-        "id": "color-convert:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:4.3.0",
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
-        "md5": "0248ebc952524207e296a622372faa1f",
-        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
-    },
-    {
-        "id": "has:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "is-core-module:2.8.1",
-                "resolve:1.22.0",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
-        "md5": "b765203b0d733534ee6a58d84767223a",
-        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
-    },
-    {
-        "id": "@types/mocha:9.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "baf17ab2cca3fcce2d322ebc30454bff487efad5",
-        "md5": "74b1b3f63ad27956f486de6bdbd6b50e",
-        "sha256": "82be40614d99ca6f1ee20a8aaab46a57bf3f693b1ac28975761cb7f0b826abd7"
-    },
-    {
-        "id": "@ampproject/remapping:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "7922fb0817bf3166d8d9e258c57477e3fd1c3610",
-        "md5": "0ab52e552c4cb84b3a1ae54bb48e3c0d",
-        "sha256": "5dec92f5a1d89418c9c96318f5997efd1830c32963fcf2128532e86b53416249"
-    },
-    {
-        "id": "source-map:0.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
-        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
-        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
-    },
-    {
-        "id": "y18n:3.2.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
-        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
-        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
-    },
-    {
-        "id": "typedarray-to-buffer:3.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
-        "md5": "d693220f5eabe1359169bb992abaa064",
-        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
-    },
-    {
-        "id": "browserslist:4.19.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "4ac0435b35ab655896c31d53018b6dd5e9e4c9a3",
-        "md5": "98fbe518b74960ee170a1fe8877711c6",
-        "sha256": "f11e687a4210175a5a4e36f474fe806bd2546f77901e804664ec2525c3815b1c"
-    },
-    {
-        "id": "debug:4.3.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
-        "md5": "e0e3067fdf8e98f4d817683191280e8e",
-        "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
         "id": "concat-map:0.0.1",
         "scopes": [
             "dev"
@@ -2067,8 +820,8 @@
         "requestedBy": [
             [
                 "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "glob:7.2.0",
+                "minimatch:3.1.2",
+                "glob:7.2.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
@@ -2078,233 +831,21 @@
         "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
     },
     {
-        "id": "@babel/helper-validator-option:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b203ce62ce5fe153899b617c08957de860de4d23",
-        "md5": "b3ec7314cda7a9c17735693d598b560d",
-        "sha256": "a0ff716706e338847d605bca3044ce2b53e37dc428175681c960900f8f2d389a"
-    },
-    {
-        "id": "istanbul-lib-processinfo:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e1426514662244b2f25df728e8fd1ba35fe53b9c",
-        "md5": "93131ca838a58e819813b733c606bd8d",
-        "sha256": "7e529f7767219df1b357ae5b65949760f40516c6fd3743218c6b05b7ca86dd81"
-    },
-    {
-        "id": "pinkie:2.0.4",
+        "id": "parse-json:2.2.0",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
-            [
-                "pinkie-promise:2.0.1",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
-        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
-        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
-    },
-    {
-        "id": "lodash.flattendeep:4.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
-        "md5": "17ca06c4643969cb10e948854434eba0",
-        "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "@babel/compat-data:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "86850b8597ea6962089770952075dcaabb8dba34",
-        "md5": "4a1ac2c80c8418ec00238913eb7c0438",
-        "sha256": "25b1193ec09d93140d7f515e013143e87b65459aca093fa05633f81b4b57dea5"
-    },
-    {
-        "id": "path-exists:2.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
-        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
-    },
-    {
-        "id": "resolve:1.22.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "5e0b8c67c15df57a89bdbabe603a002f21731198",
-        "md5": "aaf15861cf0f8af2222bd383a475bc28",
-        "sha256": "06536fa0cbfbf8d6b2d5e6971437f4eb02110c84961b698d1b8ba5c6ae8f760d"
-    },
-    {
-        "id": "is-fullwidth-code-point:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "string-width:1.0.2",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
-        "md5": "edbd4281a6ac4fb8d1082592c411f250",
-        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
-    },
-    {
-        "id": "camelcase:5.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
-        "md5": "efcf73180d9b7001c92f574d4ae7f908",
-        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
-    },
-    {
-        "id": "graceful-fs:4.2.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
             [
                 "load-json-file:1.1.0",
                 "pkg-conf:1.1.3",
                 "yargs:4.1.0",
                 "build-info-go-tests"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
             ]
         ],
-        "sha1": "041b05df45755e587a24942279b9d113146e1c96",
-        "md5": "e387a6dfac11fd5d79bd2718100e08b6",
-        "sha256": "16677911bf936576c5c73447657a30b4c535ddf8dc2fa0c8109ae93fa9319f0a"
+        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "md5": "9b98b48019fa25c226348737831cf130",
+        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
     },
     {
         "id": "signal-exit:3.0.7",
@@ -2338,56 +879,266 @@
         "sha256": "439623fa6aab91600615ec757eaa137fcab40d3b35dda38df7444c15678f20a8"
     },
     {
-        "id": "fs.realpath:1.0.0",
+        "id": "decamelize:1.2.0",
         "scopes": [
-            "dev"
+            "prod"
         ],
         "requestedBy": [
             [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "p-map:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
             [
+                "yargs:15.4.1",
                 "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "yargs-parser:18.1.3",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
-        "md5": "3b38970091b03645f6f4d6680ada671d",
-        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
+        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+        "md5": "330932e4de0e60c36114facb6d3dfafa",
+        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
     },
     {
-        "id": "yargs-parser:18.1.3",
+        "id": "convert-source-map:1.8.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
-        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
-        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
+        "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
+        "md5": "d1c553aaaffba79be7073471b2619511",
+        "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
+    },
+    {
+        "id": "path-is-absolute:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "md5": "18bfccb10294ae19e7eb616ed1c05176",
+        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+        "id": "@jridgewell/resolve-uri:3.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@jridgewell/trace-mapping:0.3.14",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "2203b118c157721addfe69d47b70465463066d78",
+        "md5": "bdc32c6b7d0a978faf304b94ba607f93",
+        "sha256": "fe4cb2ab38b4813b27926d9e08852ad81d8c14d0034cfa4a23555ec134ee16b0"
+    },
+    {
+        "id": "@babel/types:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-module-imports:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-simple-access:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-split-export-declaration:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-function-name:7.18.9",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-hoist-variables:7.18.6",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "7148d64ba133d8d73a41b3172ac4b83a1452205f",
+        "md5": "a9bbb05787a9f2f0310fba1d42f84320",
+        "sha256": "1b309d075c4970b84308ab5055b56335e117969d4c9fbb34140adf3e6e4ac63a"
+    },
+    {
+        "id": "picocolors:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
+        "md5": "743f01bf24bb6492555959fdeb7e9918",
+        "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
+    },
+    {
+        "id": "@babel/helper-hoist-variables:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d4d2c8fb4baeaa5c68b99cc8245c56554f926678",
+        "md5": "f10ece88fdea253c1678a09bdfa85160",
+        "sha256": "cd91a6aef86fb2089e6798c395dffa5d59ca2801e348ef6259f78882082707ec"
+    },
+    {
+        "id": "@types/mocha:9.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4",
+        "md5": "af8133831578083c75040f5ab0981fff",
+        "sha256": "6587cb469be76e37c4be6cf9d70b002c78b37025c599ef6ffe5c132d93a88d9d"
+    },
+    {
+        "id": "release-zalgo:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
+        "md5": "2e431e2016bfc667a21974c2c818d769",
+        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
+    },
+    {
+        "id": "spawn-wrap:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
+        "md5": "300df23ba641ba293cd9907ddf1b7552",
+        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
     },
     {
         "id": "pinkie-promise:2.0.1",
@@ -2440,7 +1191,269 @@
         "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
     },
     {
-        "id": "require-main-filename:1.0.1",
+        "id": "strip-bom:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "default-require-extensions:3.0.0",
+                "append-transform:2.0.0",
+                "istanbul-lib-hook:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
+        "md5": "ba5ded28e859d1030ed2f1369e379f67",
+        "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
+    },
+    {
+        "id": "@babel/compat-data:7.18.8",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "2483f565faca607b8535590e84e7de323f27764d",
+        "md5": "7088ff85d6c89dea757ce152c9150565",
+        "sha256": "5756345fc4fe02547f9355988f4f923a0ca9ad868cca748a8cd94b9fdd202a5e"
+    },
+    {
+        "id": "update-browserslist-db:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "be06a5eedd62f107b7c19eb5bcefb194411abf38",
+        "md5": "2a4f39c3cad79d0f127387a479d7348c",
+        "sha256": "44ce49ceb80c9b30c8860ae914df75cc88b8a0a65a2aa471f87659af97777a15"
+    },
+    {
+        "id": "@babel/helper-environment-visitor:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0c0cee9b35d2ca190478756865bb3528422f51be",
+        "md5": "62eaa04ce85291b537bd92b4cba422a3",
+        "sha256": "00aa1c2f172719e15df07a13833cd9632c51ec20ce87c68bfa10deff44545af3"
+    },
+    {
+        "id": "istanbul-lib-processinfo:2.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "366d454cd0dcb7eb6e0e419378e60072c8626169",
+        "md5": "6053742aadc8e3ef55d8808d24ef2b59",
+        "sha256": "4df1e5e9927bb39e18ed3a2d2d567c8e66ce54ded31704e36d34d1d70697f99c"
+    },
+    {
+        "id": "clean-stack:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "aggregate-error:3.1.0",
+                "p-map:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
+        "md5": "98495454e4106c25e5ed97ae9a6b1148",
+        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
+    },
+    {
+        "id": "path-key:3.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cross-spawn:7.0.3",
+                "foreground-child:2.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
+        "md5": "4f4b9beb2d53481341e16133a8570dc5",
+        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
+    },
+    {
+        "id": "inflight:1.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+        "id": "lcid:1.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "os-locale:1.4.0",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
+        "md5": "33e24746875ebbcc37c40c7297388609",
+        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
+    },
+    {
+        "id": "resolve:1.22.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "27cb2ebb53f91abb49470a928bba7558066ac177",
+        "md5": "67a0957a5180922a45e1b1d326a15508",
+        "sha256": "b556a5d48802ed4d038cfe8804596e1cca2176599a776f12daf686dee92d12ea"
+    },
+    {
+        "id": "get-caller-file:2.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+        "md5": "1b9de5ead51b8886be998f58fdb96476",
+        "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
+    },
+    {
+        "id": "path-parse:1.0.7",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "resolve:1.22.1",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
+        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
+        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
+    },
+    {
+        "id": "graceful-fs:4.2.10",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+        "md5": "094ac6976c4cec6cced67915d6c726c0",
+        "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+        "id": "es6-error:4.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "release-zalgo:1.0.0",
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
+        "md5": "9aeb9c257e683268999655a2071219f2",
+        "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
+    },
+    {
+        "id": "pkg-conf:1.1.3",
         "scopes": [
             "prod"
         ],
@@ -2450,9 +1463,137 @@
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
-        "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
-        "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
+        "sha1": "378e56d6fd13e88bfb6f4a25df7a83faabddba5b",
+        "md5": "1a332f846b47c4cf3a82746c5411647e",
+        "sha256": "725a988399da377a18d58872ac64b6a78351c3c7cdec80522fe0576c6829d517"
+    },
+    {
+        "id": "imurmurhash:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+        "id": "istanbul-lib-report:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-reports:3.1.5",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
+        "md5": "87a16f7a36e489fdd042510550872167",
+        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
+    },
+    {
+        "id": "color-name:1.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "color-convert:1.9.3",
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "md5": "b45186c4fe76a2450ec484149ade0066",
+        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+        "id": "caniuse-lite:1.0.30001368",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "c5c06381c6051cd863c45021475434e81936f713",
+        "md5": "1762454bac8432336003f3f2740b008b",
+        "sha256": "174dceca41249223bdf0923ef3065692bb095161607d0ca5376ab63305b76e92"
+    },
+    {
+        "id": "node-releases:2.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "8a7088c63a55e493845683ebf3c828d8c51c5503",
+        "md5": "86970ccb7f3cf344f56b70be69b316cf",
+        "sha256": "8b34c017dbfac06f45d6c9de2e32d2d5335cafdffaa9c2ba5aa756c854617eff"
+    },
+    {
+        "id": "yargs:15.4.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
+        "md5": "091d0cc9d7347925d73455bd991e6639",
+        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
+    },
+    {
+        "id": "yargs-parser:18.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
+        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
+        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
     },
     {
         "id": "argparse:1.0.10",
@@ -2472,74 +1613,51 @@
         "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
     },
     {
-        "id": "p-limit:2.3.0",
+        "id": "@jridgewell/set-array:1.1.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
+                "@jridgewell/gen-mapping:0.1.1",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
-        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
-        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
-    },
-    {
-        "id": "@babel/helper-get-function-arity:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "ea08ac753117a669f1508ba06ebcc49156387419",
-        "md5": "f11bd3474d17bc12735a2462d08fa093",
-        "sha256": "0db0f2c529b0dc0cac0d8f2e1197ce16434f273d381a3a09d1fa39c627d7fd69"
+        "sha1": "7c6cf998d6d20b914c0a55a91ae928ff25965e72",
+        "md5": "b48ee5bc088b403daf0f66546312ef9a",
+        "sha256": "7585773292098c500f5e8a993357c0b91512696ad6a6f79bd10f2beb84e607ff"
     },
     {
-        "id": "yargs:15.4.1",
+        "id": "wrap-ansi:6.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "cliui:6.0.0",
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
-        "md5": "091d0cc9d7347925d73455bd991e6639",
-        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
+        "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
+        "md5": "f8917d0c5de3cfd4ab98a235260b3951",
+        "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
     },
     {
-        "id": "camelcase:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f",
-        "md5": "219dfe1eec3f9eaefff687dd09196776",
-        "sha256": "3dc15e1abb0eb9fa85846e661df399ccbcdbd1bf100506eadc610c8667c686a6"
-    },
-    {
-        "id": "strip-ansi:3.0.1",
+        "id": "string-width:1.0.2",
         "scopes": [
             "prod"
         ],
@@ -2556,33 +1674,28 @@
                 "build-info-go-tests"
             ],
             [
-                "string-width:1.0.2",
                 "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
-        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
-        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
+        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
+        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
     },
     {
-        "id": "is-arrayish:0.2.1",
+        "id": "y18n:3.2.2",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
-                "error-ex:1.3.2",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.3",
                 "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
-        "md5": "4bbbacda455ab73d86f5eda908989f24",
-        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
+        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
+        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
+        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
     },
     {
         "id": "camelcase:3.0.0",
@@ -2601,20 +1714,346 @@
         "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
     },
     {
+        "id": "p-try:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "p-limit:2.3.0",
+                "p-locate:4.1.0",
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
+        "md5": "49994562e1f3cbe260710598cbb3edf7",
+        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
+    },
+    {
+        "id": "@babel/highlight:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "81158601e93e2563795adcbfbdf5d64be3f2ecdf",
+        "md5": "6be4064f31d9e3fdd17994bd177ef426",
+        "sha256": "f54e6c10da061b163dd744a9ee2f0f3560d26d5cb1d4e81c9bc9ff6bcdcba664"
+    },
+    {
+        "id": "@jridgewell/gen-mapping:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e5d2e450306a9491e3bd77e323e38d7aff315996",
+        "md5": "0f933b56a27f4640e86c5c9662516c5a",
+        "sha256": "2d2055c259b61a7537644eb25c548d0c1d388caaca9c26766c0df91976b94ab6"
+    },
+    {
+        "id": "jsesc:2.5.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
+        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
+        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
+    },
+    {
+        "id": "@babel/helper-module-transforms:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "5a1079c005135ed627442df31a42887e80fcb712",
+        "md5": "19160955f01c62275ff14f0daa5706f6",
+        "sha256": "c6f2dbdfa8850bdbe650a350f419535e8cbb95339a0b15ab028e6a1b78ef2afc"
+    },
+    {
+        "id": "spdx-exceptions:2.3.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "spdx-expression-parse:3.0.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
+        "md5": "acbb50a4dc418357a51310b852eb2e38",
+        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
+    },
+    {
+        "id": "package-hash:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
+        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
+        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
+    },
+    {
+        "id": "once:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inflight:1.0.6",
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+        "id": "chalk:2.4.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+        "id": "ansi-styles:3.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+        "id": "require-directory:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "md5": "f3a9010155b6a46066afbe2d07f624bd",
+        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+        "id": "find-up:1.1.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
+        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
+    },
+    {
+        "id": "error-ex:1.3.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+        "md5": "5d2c673565060037f9e04d7975d04feb",
+        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
+    },
+    {
+        "id": "caching-transform:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
+        "md5": "82a03704703e883379f146caa805b457",
+        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
+    },
+    {
+        "id": "fs.realpath:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+        "md5": "9f790d7180667e1d8d1110f2cf321b62",
+        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+        "id": "typedarray-to-buffer:3.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
+        "md5": "d693220f5eabe1359169bb992abaa064",
+        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
+    },
+    {
+        "id": "locate-path:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
+        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
+        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
+    },
+    {
+        "id": "foreground-child:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
+        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
+        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
+    },
+    {
         "id": "semver:6.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
             [
-                "@babel/core:7.17.2",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
@@ -2635,557 +2074,20 @@
         "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
     },
     {
-        "id": "uuid:3.4.0",
+        "id": "archy:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "istanbul-lib-processinfo:2.0.2",
+                "istanbul-lib-processinfo:2.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "b23e4358afa8a202fe7a100af1f5f883f02007ee",
-        "md5": "2fa27207bb65f4e05c6f10bc0448f662",
-        "sha256": "ba77c9306dbc34c7ae503e9eb142e284f98ea9ab609f416052c2fbbefb6df4dd"
-    },
-    {
-        "id": "parse-json:2.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "md5": "9b98b48019fa25c226348737831cf130",
-        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
-    },
-    {
-        "id": "hasha:5.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
-        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
-        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
-    },
-    {
-        "id": "write-file-atomic:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
-        "md5": "53e54080c22253705daa1c3115c02220",
-        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
-    },
-    {
-        "id": "@babel/code-frame:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "44416b6bd7624b998f5b1af5d470856c40138789",
-        "md5": "31af46ce2c742b38161a12651c99e09e",
-        "sha256": "f45cf383e8c261cf4134b7800dd64d66e3b2d05aac2c20b5069da6b42531ab81"
-    },
-    {
-        "id": "test-exclude:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
-        "md5": "c9d2be086d4d740f9999b77971777008",
-        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
-    },
-    {
-        "id": "caching-transform:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
-        "md5": "82a03704703e883379f146caa805b457",
-        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "istanbul-reports:3.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1b6f068ecbc6c331040aab5741991273e609e40c",
-        "md5": "d83f11919b8678dd497985086178ebad",
-        "sha256": "91132ac58788279e61fae36c9ae623addfe577efc5b948c35e3a7521ef7c6b5a"
-    },
-    {
-        "id": "load-json-file:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
-        "md5": "939784db9c3c72c26262cebef2f9b631",
-        "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
-    },
-    {
-        "id": "get-caller-file:2.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
-        "md5": "1b9de5ead51b8886be998f58fdb96476",
-        "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
-    },
-    {
-        "id": "path-key:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
-        "md5": "4f4b9beb2d53481341e16133a8570dc5",
-        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
-    },
-    {
-        "id": "@babel/core:7.17.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "2c77fc430e95139d816d39b113b31bf40fb22337",
-        "md5": "8bfdd2d9e678789eca31534a2824cdff",
-        "sha256": "86d99fe6abf016cf563873bee1df5abdf3a7aae058dafd0777773c7716b0dadf"
-    },
-    {
-        "id": "@jridgewell/trace-mapping:0.3.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3",
-        "md5": "9a6904d400fcf90498340cb5137a0d08",
-        "sha256": "b960678706c5fb7bd27d291e3bcb9aa009c61445e15c9442e5885d70c6552d82"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "jsesc:2.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
-        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
-        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
-    },
-    {
-        "id": "clean-stack:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
-        "md5": "98495454e4106c25e5ed97ae9a6b1148",
-        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
-    },
-    {
-        "id": "object-assign:4.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
-        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
-        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
-    },
-    {
-        "id": "symbol:0.2.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.3",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3b9873b8a901e47c6efe21526a3ac372ef28bbc7",
-        "md5": "f21f7b178297af9a67a8aef376c7253a",
-        "sha256": "8b6166f4dfd4d930eca2775d3bb8e6e3d97e6e02f2594020cc3ff465c09d63d1"
-    },
-    {
-        "id": "read-pkg-up:1.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
-        "md5": "02cc53c7512931912dcbdcd9c1d55265",
-        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
-    },
-    {
-        "id": "hosted-git-info:2.8.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
-        "md5": "e50583bc39341b531466e5de5b6aef94",
-        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
-    },
-    {
-        "id": "@istanbuljs/schema:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
-        "md5": "868e08ce450f7d9d5cd29997f0865f17",
-        "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
-    },
-    {
-        "id": "package-hash:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
-        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
-        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
-    },
-    {
-        "id": "@jridgewell/sourcemap-codec:1.4.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@jridgewell/trace-mapping:0.3.4",
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec",
-        "md5": "616f1bb14acac428e4e045b4e686863f",
-        "sha256": "fb9875df19ed311535f95e919dcce064e971222fc94185d54091eebba4b3a804"
-    },
-    {
-        "id": "spawn-wrap:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
-        "md5": "300df23ba641ba293cd9907ddf1b7552",
-        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
-    },
-    {
-        "id": "emoji-regex:8.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
-        "md5": "598b731d8d33cfff04377ad55da187b0",
-        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
-    },
-    {
-        "id": "y18n:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
-        "md5": "182c1f29baf6577adccaf23ac94d5ed1",
-        "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
+        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+        "md5": "b2a24c65e2212f53168f984b5a693dbd",
+        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
     },
     {
         "id": "xml:1.0.1",
@@ -3200,24 +2102,6 @@
         "sha1": "78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5",
         "md5": "cd0657e89d77ec585fe29c9b568d16c9",
         "sha256": "38032bd701fa20427b2ee31ed55e6761ce1a881a6eabcd90005ebe74ab04a623"
-    },
-    {
-        "id": "validate-npm-package-license:3.0.4",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
-        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
-        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
     },
     {
         "id": "find-up:4.1.0",
@@ -3251,248 +2135,114 @@
         "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
     },
     {
-        "id": "make-dir:3.1.0",
+        "id": "get-package-type:0.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
-        "md5": "e47d13370c2b27671a13f28ebc27585f",
-        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
-    },
-    {
-        "id": "locate-path:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
-        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
-        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
-    },
-    {
-        "id": "semver:5.7.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
-    },
-    {
-        "id": "os-locale:1.4.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "md5": "fdb77de7d9374b72e7f466c27908a730",
-        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
                 "@istanbuljs/load-nyc-config:1.1.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
+            ],
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
             ]
         ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
+        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
+        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
     },
     {
-        "id": "@babel/helper-compilation-targets:7.16.7",
+        "id": "default-require-extensions:3.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "append-transform:2.0.0",
+                "istanbul-lib-hook:3.0.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "06e66c5f299601e6c7da350049315e83209d551b",
-        "md5": "09aff53f0695c886d7daaec61e3f6c4e",
-        "sha256": "77584007eb5b73f41a28175bb720dd5f24058151406a6dcf56506db77f69f649"
+        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
+        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
+        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
     },
     {
-        "id": "picocolors:1.0.0",
+        "id": "supports-color:5.5.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
-        "md5": "743f01bf24bb6492555959fdeb7e9918",
-        "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
+        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+        "md5": "17b1003344e0e0d2719205be85946698",
+        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
     },
     {
-        "id": "@babel/helper-module-transforms:7.16.7",
+        "id": "uuid:8.3.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "istanbul-lib-processinfo:2.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "7665faeb721a01ca5327ddc6bba15a5cb34b6a41",
-        "md5": "362ea04465b1e07ba23d74986d9284c2",
-        "sha256": "724450b68389e0fbe6639535ba3f543f5a92e19ea49ec96a0ce1ce71e32b611d"
+        "sha1": "80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+        "md5": "001956ff1c0a16e6bae8bae042ba226b",
+        "sha256": "f630703647a5821c735a542edcf8d26c989724efe9d9912ab6f6836a1e79924a"
     },
     {
-        "id": "@babel/helper-module-imports:7.16.7",
+        "id": "istanbul-lib-source-maps:4.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "25612a8091a999704461c8a222d0efec5d091437",
-        "md5": "33db5ddd8ebf2f13cbc13d94a7c3bc32",
-        "sha256": "fecd1c2cf4756ea17953c004ef9a257bd666484ca80cc94961aa1a0e9ad35e57"
+        "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
+        "md5": "2b0cd1493c52493181871afc3c5a93be",
+        "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
     },
     {
-        "id": "@babel/helpers:7.17.2",
+        "id": "color-convert:2.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "ansi-styles:4.3.0",
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "23f0a0746c8e287773ccd27c14be428891f63417",
-        "md5": "43ad01932216bb914a5eb67a58ac2acd",
-        "sha256": "2f8d991a4e3d5c8bc5ce84c0051fabafbd05c08ca30b766b4a543bd77f512c5a"
+        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+        "md5": "0248ebc952524207e296a622372faa1f",
+        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
     },
     {
-        "id": "cliui:3.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "120601537a916d29940f934da3b48d585a39213d",
-        "md5": "3a83794ba283c15042e429b11802766d",
-        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
-    },
-    {
-        "id": "lcid:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "os-locale:1.4.0",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "md5": "33e24746875ebbcc37c40c7297388609",
-        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
-    },
-    {
-        "id": "read-pkg:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
-        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
-    },
-    {
-        "id": "require-directory:2.1.1",
+        "id": "which-module:2.0.0",
         "scopes": [
             "dev"
         ],
@@ -3503,61 +2253,12 @@
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "md5": "ce028f30082fbbea9861a40437d17bd3",
+        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
     },
     {
-        "id": "nyc:15.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
-        "md5": "28c5baf103508c15fc352a367910f0c4",
-        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
-    },
-    {
-        "id": "es6-error:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "release-zalgo:1.0.0",
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
-        "md5": "9aeb9c257e683268999655a2071219f2",
-        "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
-    },
-    {
-        "id": "p-locate:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
-        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
-        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
-    },
-    {
-        "id": "glob:7.2.0",
+        "id": "@istanbuljs/schema:0.1.3",
         "scopes": [
             "dev"
         ],
@@ -3567,7 +2268,7 @@
                 "build-info-go-tests"
             ],
             [
-                "rimraf:3.0.2",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
@@ -3577,67 +2278,169 @@
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
+        "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
+        "md5": "868e08ce450f7d9d5cd29997f0865f17",
+        "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
     },
     {
-        "id": "caniuse-lite:1.0.30001312",
+        "id": "shebang-command:2.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "cross-spawn:7.0.3",
+                "foreground-child:2.0.0",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "e11eba4b87e24d22697dae05455d5aea28550d5f",
-        "md5": "06f30a7fae77d1e146fcd860cc433455",
-        "sha256": "84a2dd7e5b76f966d3e4f2563b834c0209604a94e360165de26ad18d1cd80a6b"
+        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
+        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
+        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
     },
     {
-        "id": "@babel/template:7.16.7",
+        "id": "ansi-regex:5.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "strip-ansi:6.0.1",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "build-info-go-tests"
-            ],
+            ]
+        ],
+        "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
+        "md5": "7a0bb891f3a7cd9b174af62beb4de186",
+        "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
+    },
+    {
+        "id": "is-fullwidth-code-point:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
             [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
+                "string-width:4.2.3",
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "build-info-go-tests"
-            ],
+            ]
+        ],
+        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
+        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
+        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
+    },
+    {
+        "id": "object-assign:4.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
             [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
                 "build-info-go-tests"
-            ],
+            ]
+        ],
+        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
+        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
+    },
+    {
+        "id": "function-bind:1.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
             [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
+                "has:1.0.3",
+                "is-core-module:2.9.0",
+                "resolve:1.22.1",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+        "md5": "ee976e75439af2b82e707f3a64c69684",
+        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
+    },
+    {
+        "id": "spdx-correct:3.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
+        "md5": "bd668e9b71960e76e867c11ec3ec2982",
+        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
+    },
+    {
+        "id": "@ampproject/remapping:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "8d126c8701fde4d66b264b3eba3d96f07666d155",
-        "md5": "65b3dea316742fdb1829b34e6c766f3b",
-        "sha256": "2cd40fc44dd41eb77c31f2c01af92b13eb2b264cc392423b4f5af0e01d897f84"
+        "sha1": "56c133824780de3174aed5ab6834f3026790154d",
+        "md5": "f89dd9045903be2cc7c10b3c31e75626",
+        "sha256": "2f2dacc9e8ed33330e4ad095403b9efb51736e06f9c57baf0ca73058406bb890"
+    },
+    {
+        "id": "@babel/helpers:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "4bef3b893f253a1eced04516824ede94dcfe7ff9",
+        "md5": "029dea1cf8f08d6602536f2650d9f25c",
+        "sha256": "912bfc1b1aaea6ffb32155c8f7c783ccf48d80a04b9ad9853080b4a10206d8d4"
+    },
+    {
+        "id": "@babel/helper-validator-option:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8",
+        "md5": "d22673cb3b1ea3e3127bb12d507a036c",
+        "sha256": "3efdfe87e7e6830c5091ee369a27368e263d9dab8cfc7f0f41e7f9b9c5aec9cf"
     },
     {
         "id": "isexe:2.0.0",
@@ -3657,30 +2460,22 @@
         "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
     },
     {
-        "id": "strip-bom:2.0.0",
+        "id": "spdx-expression-parse:3.0.1",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.3",
+                "spdx-correct:3.1.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
                 "yargs:4.1.0",
                 "build-info-go-tests"
-            ]
-        ],
-        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
-        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
-    },
-    {
-        "id": "supports-preserve-symlinks-flag:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
+            ],
             [
-                "resolve:1.22.0",
+                "validate-npm-package-license:3.0.4",
                 "normalize-package-data:2.5.0",
                 "read-pkg:1.1.0",
                 "read-pkg-up:1.0.1",
@@ -3688,9 +2483,415 @@
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
-        "md5": "2ecf7c03c814ab155c5278d61f65583f",
-        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
+        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
+        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
+        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
+    },
+    {
+        "id": "@babel/helper-validator-identifier:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/types:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9c97e30d31b2b8c72a1d08984f2ca9b574d7a076",
+        "md5": "f4d15f6582c54e6a9ad8dfda2c073c6b",
+        "sha256": "110e5d9854308bafa7de7e79e31b4ab34b8720e44cd28adb66ab19b790d57e19"
+    },
+    {
+        "id": "escape-string-regexp:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "md5": "02440084832abe665260d5db1da1dd9e",
+        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+        "id": "color-convert:1.9.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+        "id": "@babel/generator:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "68337e9ea8044d6ddc690fb29acae39359cca0a5",
+        "md5": "ced102e1a657c80aeac9c54297b0c51a",
+        "sha256": "ecfd6a96062cf06c56236cc2ddbd02e8a978c883b6d1e68d7ec7b7acf833a2ee"
+    },
+    {
+        "id": "electron-to-chromium:1.4.196",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e18cdc5c1c2c2ebf78da237d0c374cc3b244d4cb",
+        "md5": "e65dea46a634f06ef01bd9d9d84da73a",
+        "sha256": "fde9ab86721e9199b2a0b3ac946e4103ae1799a6813db0a4ef8881d0558750aa"
+    },
+    {
+        "id": "@babel/helper-function-name:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "940e6084a55dee867d33b4e487da2676365e86b0",
+        "md5": "5a360d6490679bc8050ae8342bce1d68",
+        "sha256": "089fc866e1349e85fe331ddf5388afae1d42271fe105a3951024fe6b55f88e0b"
+    },
+    {
+        "id": "cliui:6.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
+        "md5": "9065a0615794d52f19cffa078701d382",
+        "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
+    },
+    {
+        "id": "read-pkg-up:1.0.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
+        "md5": "02cc53c7512931912dcbdcd9c1d55265",
+        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
+    },
+    {
+        "id": "inherits:2.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+        "id": "minimatch:3.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "test-exclude:6.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+        "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+        "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+        "id": "code-point-at:1.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "string-width:1.0.2",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
+        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
+    },
+    {
+        "id": "commondir:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "md5": "329b8682e83ec34dfe1c58ae90b84988",
+        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
+    },
+    {
+        "id": "escalade:3.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
+        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
+    },
+    {
+        "id": "strip-ansi:6.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "string-width:4.2.3",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
+        "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
+        "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
+    },
+    {
+        "id": "y18n:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
+        "md5": "182c1f29baf6577adccaf23ac94d5ed1",
+        "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
+    },
+    {
+        "id": "os-locale:1.4.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
+        "md5": "fdb77de7d9374b72e7f466c27908a730",
+        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
+    },
+    {
+        "id": "sprintf-js:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "argparse:1.0.10",
+                "js-yaml:3.14.1",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+        "md5": "8e6b31a052754055683e4a35a317feab",
+        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+        "id": "is-stream:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "hasha:5.2.2",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
+        "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
+        "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
+    },
+    {
+        "id": "globals:11.12.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
+        "md5": "712d15395573404a3ddb37ce395d948b",
+        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
+    },
+    {
+        "id": "ansi-styles:4.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
+        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
+        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
+    },
+    {
+        "id": "is-core-module:2.9.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "resolve:1.22.1",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e1c34429cd51c6dd9e09e0799e396e27b19a9c69",
+        "md5": "9862dd9912e0d8158cdb2b339c0ee148",
+        "sha256": "2ba3f3317b3f4055f45e879068a1c37dafef035b407282e420ccf5fa8c13cc6d"
     },
     {
         "id": "@istanbuljs/load-nyc-config:1.1.0",
@@ -3706,6 +2907,625 @@
         "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
         "md5": "d46010939e33d1d4e7dfce54fc60d89a",
         "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
+    },
+    {
+        "id": "@babel/parser:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "f2dde0c682ccc264a9a8595efd030a5cc8fd2539",
+        "md5": "374150ff1ab6268dd1248d12950e392d",
+        "sha256": "a4fba8f4f3542a6b44e848fa989ba96e4ad4ee2c1020139c3dc0093260ba2ecc"
+    },
+    {
+        "id": "set-blocking:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "md5": "ff057cf430b35ecb25780f94cd051ab3",
+        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+        "id": "camelcase:2.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f",
+        "md5": "219dfe1eec3f9eaefff687dd09196776",
+        "sha256": "3dc15e1abb0eb9fa85846e661df399ccbcdbd1bf100506eadc610c8667c686a6"
+    },
+    {
+        "id": "hosted-git-info:2.8.9",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
+        "md5": "e50583bc39341b531466e5de5b6aef94",
+        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
+    },
+    {
+        "id": "esprima:4.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "js-yaml:3.14.1",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+        "md5": "c9d44a818c324d707a81b08dd36cd079",
+        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+        "id": "cross-spawn:7.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "foreground-child:2.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
+        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
+        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
+    },
+    {
+        "id": "@jridgewell/trace-mapping:0.3.14",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b231a081d8f66796e475ad588a1ef473112701ed",
+        "md5": "55173b301ee67c9e20d5b60835018a67",
+        "sha256": "7f5c917fa0abdcc4cbd99f49fe1dcccdac40151c0ec18d8163325c643c64a993"
+    },
+    {
+        "id": "gensync:1.0.0-beta.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
+        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
+        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
+    },
+    {
+        "id": "cliui:3.2.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "120601537a916d29940f934da3b48d585a39213d",
+        "md5": "3a83794ba283c15042e429b11802766d",
+        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
+    },
+    {
+        "id": "ansi-regex:2.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "strip-ansi:3.0.1",
+                "cliui:3.2.0",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
+        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
+    },
+    {
+        "id": "path-exists:2.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "find-up:1.1.2",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "find-up:1.1.2",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
+        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
+    },
+    {
+        "id": "require-main-filename:1.0.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+        "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
+        "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
+    },
+    {
+        "id": "js-yaml:3.14.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+        "md5": "2a522c3e23f7999abd8f852c012c20dd",
+        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+        "id": "find-cache-dir:3.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
+        "md5": "52bbc85bfe0ddab6259eb6618900ab61",
+        "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
+    },
+    {
+        "id": "is-fullwidth-code-point:1.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "string-width:1.0.2",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "md5": "edbd4281a6ac4fb8d1082592c411f250",
+        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
+    },
+    {
+        "id": "wrap-ansi:2.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "cliui:3.2.0",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
+        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
+    },
+    {
+        "id": "pinkie:2.0.4",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "pinkie-promise:2.0.1",
+                "find-up:1.1.2",
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
+        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
+    },
+    {
+        "id": "read-pkg:1.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
+        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
+    },
+    {
+        "id": "glob:7.2.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "rimraf:3.0.2",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "test-exclude:6.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b",
+        "md5": "16222090f290ce18931eb40cec43fa2a",
+        "sha256": "f0a38eb1318c06cb55dc28f3f32d2df7379e155cefc6a1e5ecc7a0ddad194381"
+    },
+    {
+        "id": "@jridgewell/sourcemap-codec:1.4.14",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@jridgewell/gen-mapping:0.1.1",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@jridgewell/trace-mapping:0.3.14",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "add4c98d341472a289190b424efbdb096991bb24",
+        "md5": "b462c7a5932255e273725bf451bd36ce",
+        "sha256": "b7430e808b04aeba42441a44b783068c1923b8aa3f6f91fc1d789383b0c53941"
+    },
+    {
+        "id": "emoji-regex:8.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "string-width:4.2.3",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
+        "md5": "598b731d8d33cfff04377ad55da187b0",
+        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
+    },
+    {
+        "id": "path-type:1.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "md5": "e14c138690b623db36532ff609b81b08",
+        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
+    },
+    {
+        "id": "resolve-from:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
+        "md5": "23cff3fc62d9dd916e67da9c9505603f",
+        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
+    },
+    {
+        "id": "json5:2.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "655d50ed1e6f95ad1a3caababd2b0efda10b395c",
+        "md5": "e7d2fc3e0299d8005b5f7f46161cc227",
+        "sha256": "1d044eb7a06ddb2429366e0630dd884d1e57f116e3704b293631fa4dde045a59"
+    },
+    {
+        "id": "to-fast-properties:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/types:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
+        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
+        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+    },
+    {
+        "id": "load-json-file:1.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "pkg-conf:1.1.3",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
+        "md5": "939784db9c3c72c26262cebef2f9b631",
+        "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
+    },
+    {
+        "id": "window-size:0.2.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
+        "md5": "250499d281e44d2783aec6cfc458e96a",
+        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
+    },
+    {
+        "id": "debug:4.3.3",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "istanbul-lib-source-maps:4.0.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
+        "md5": "e0e3067fdf8e98f4d817683191280e8e",
+        "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
+    },
+    {
+        "id": "brace-expansion:1.1.11",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "minimatch:3.1.2",
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+        "id": "@babel/helper-split-export-declaration:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "7367949bc75b20c6d5a5d4a97bba2824ae8ef075",
+        "md5": "d7c42328ad1e542ae3f255320630d31c",
+        "sha256": "a985fbbc087d43887197fbe6ee6ecab05a2bf71daa6e99929d4fd09f176f58f5"
+    },
+    {
+        "id": "@babel/traverse:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "deeff3e8f1bad9786874cb2feda7a2d77a904f98",
+        "md5": "4e01105ee87a3406c4a9c3617ebdba42",
+        "sha256": "a9d2fd8aa3dccf55f8057d42d02d620960875c5d283a7fc0f941afbd5680ac2d"
     },
     {
         "id": "which:2.0.2",
@@ -3730,39 +3550,62 @@
         "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
     },
     {
-        "id": "inherits:2.0.4",
+        "id": "js-tokens:4.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "escalade:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
-        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
-        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
+        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
+        "md5": "325b11b965688c69ae45a3cf771fbc5c",
+        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
+    },
+    {
+        "id": "has-flag:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-color:5.5.0",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "md5": "1fa1fa951639c7058277abcecca86922",
+        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+        "id": "@babel/helper-simple-access:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d6d8f51f4ac2978068df934b569f08f29788c7ea",
+        "md5": "d0e1a86f6785eb7548411ed182da8374",
+        "sha256": "7b37715bb3decd3b3a2144244d321aafb3b9b9ef034f53a22cd1e828a101c040"
     },
     {
         "id": "rimraf:3.0.2",
@@ -3771,7 +3614,7 @@
         ],
         "requestedBy": [
             [
-                "istanbul-lib-processinfo:2.0.2",
+                "istanbul-lib-processinfo:2.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
@@ -3788,6 +3631,26 @@
         "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
         "md5": "c794495fee118854a7cbd585a19a0fa8",
         "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
+    },
+    {
+        "id": "process-on-spawn:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "node-preload:0.2.1",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
+        "md5": "acaca9f6065528d5b79d3d3501b5a745",
+        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
     },
     {
         "id": "invert-kv:1.0.0",
@@ -3807,138 +3670,249 @@
         "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
     },
     {
-        "id": "window-size:0.2.0",
+        "id": "number-is-nan:1.0.1",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
+                "is-fullwidth-code-point:1.0.0",
+                "string-width:1.0.2",
                 "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
-        "md5": "250499d281e44d2783aec6cfc458e96a",
-        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
+        "sha1": "097b602b53422a522c1afb8790318336941a011d",
+        "md5": "1c192095065e6b72a7e20a747b110469",
+        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
     },
     {
-        "id": "sprintf-js:1.0.3",
+        "id": "nyc:15.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
+        "md5": "28c5baf103508c15fc352a367910f0c4",
+        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
     },
     {
-        "id": "resolve-from:5.0.0",
+        "id": "@babel/code-frame:7.18.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@istanbuljs/load-nyc-config:1.1.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
             [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
-            ]
-        ],
-        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
-        "md5": "23cff3fc62d9dd916e67da9c9505603f",
-        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
-    },
-    {
-        "id": "release-zalgo:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "build-info-go-tests"
-            ]
-        ],
-        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
-        "md5": "2e431e2016bfc667a21974c2c818d769",
-        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
-    },
-    {
-        "id": "to-fast-properties:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/types:7.17.0",
-                "@babel/core:7.17.2",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
-        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
-        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+        "sha1": "3b25d38c89600baa2dcc219edfa88a74eb2c427a",
+        "md5": "06bf74bedad2a91ac5c5950ee0d527a4",
+        "sha256": "069544665ad7c8eb0fd72fd2ebf2c651454fce88768e3a8d203041865e729977"
     },
     {
-        "id": "string-width:4.2.3",
+        "id": "@babel/core:7.18.9",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "build-info-go-tests"
             ],
             [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "805461f967c77ff46c74ca0460ccf4fe933ddd59",
+        "md5": "414e3ac6524d22ef6fe284e456051fb9",
+        "sha256": "9a1831b17a6a6b8524ffd957c70deb5b12f2ec90869c0b3b0bacd201bfbc338b"
+    },
+    {
+        "id": "@babel/template:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "@babel/helper-function-name:7.18.9",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "1283f4993e00b929d6e2d3c72fdc9168a2977a31",
+        "md5": "bc579b67a5099d381f57dc938f2c132d",
+        "sha256": "aef8c9facb86709c1cb53264cdeca13b86bb3eeeb53d86294f05fbfd54562e25"
+    },
+    {
+        "id": "has-flag:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-color:7.2.0",
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
+        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
+        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
+    },
+    {
+        "id": "istanbul-reports:3.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "cc9a6ab25cb25659810e4785ed9d9fb742578bae",
+        "md5": "37a18bd3f4140ff1690f1048aef18171",
+        "sha256": "a118d2013c68c83b81acabbfa2df3e2838e1e2f5a53d3045c208689540c48d85"
+    },
+    {
+        "id": "color-name:1.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "color-convert:2.0.1",
+                "ansi-styles:4.3.0",
                 "wrap-ansi:6.2.0",
                 "cliui:6.0.0",
                 "yargs:15.4.1",
                 "nyc:15.1.0",
                 "build-info-go-tests"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "build-info-go-tests"
             ]
         ],
-        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
-        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
-        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
+        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
+        "md5": "a8d4412852471526b8027af2532d0d2b",
+        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
     },
     {
-        "id": "ansi-regex:2.1.1",
+        "id": "supports-preserve-symlinks-flag:1.0.0",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
-                "strip-ansi:3.0.1",
-                "cliui:3.2.0",
+                "resolve:1.22.1",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
                 "yargs:4.1.0",
                 "build-info-go-tests"
             ]
         ],
-        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
-        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
-        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
+        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
+        "md5": "2ecf7c03c814ab155c5278d61f65583f",
+        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
+    },
+    {
+        "id": "write-file-atomic:3.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
+        "md5": "53e54080c22253705daa1c3115c02220",
+        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
+    },
+    {
+        "id": "balanced-match:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "brace-expansion:1.1.11",
+                "minimatch:3.1.2",
+                "glob:7.2.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+        "id": "is-windows:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "md5": "bcc9525ed3558792d281951c90ad366e",
+        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
     },
     {
         "id": "is-utf8:0.2.1",
@@ -3957,5 +3931,71 @@
         "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
         "md5": "7c483523b33b0640efedcc6561c545e2",
         "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
+    },
+    {
+        "id": "yargs-parser:2.4.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
+        "md5": "3ed28206e170b6c0cf902511c2d0534b",
+        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
+    },
+    {
+        "id": "is-typedarray:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "typedarray-to-buffer:3.1.5",
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
+        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
+    },
+    {
+        "id": "browserslist:4.21.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ],
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "build-info-go-tests"
+            ]
+        ],
+        "sha1": "59a400757465535954946a400b841ed37e2b4ecf",
+        "md5": "b7595f1787cc1f79d334efbfd10c7b0e",
+        "sha256": "cf0524be457eb24273a426cdf6651af11a8df6817bcb284366b0889591473f65"
     }
 ]

--- a/build/testdata/npm/project1/npmv8/package-lock.json
+++ b/build/testdata/npm/project1/npmv8/package-lock.json
@@ -22,58 +22,59 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.0.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
+        "json5": "^2.2.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -85,28 +86,42 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.16.4",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -117,149 +132,133 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -268,9 +267,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -280,33 +279,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -315,12 +314,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -352,25 +351,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -378,9 +399,9 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/aggregate-error": {
@@ -399,7 +420,7 @@
     "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -432,7 +453,7 @@
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -461,26 +482,31 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/caching-transform": {
@@ -508,14 +534,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -543,7 +575,7 @@
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -554,7 +586,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -572,19 +604,19 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -629,7 +661,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -648,9 +680,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -686,7 +718,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -771,7 +803,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/function-bind": {
@@ -808,15 +840,15 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -837,9 +869,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "inBundle": true
     },
     "node_modules/has": {
@@ -857,7 +889,7 @@
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -894,7 +926,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -912,7 +944,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -928,7 +960,7 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -937,13 +969,13 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "inBundle": true
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "inBundle": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -955,7 +987,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "inBundle": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -979,13 +1011,13 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "inBundle": true
     },
     "node_modules/is-windows": {
@@ -1000,7 +1032,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
@@ -1040,18 +1072,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -1106,19 +1137,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -1160,13 +1182,10 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -1177,7 +1196,7 @@
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "inBundle": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -1189,7 +1208,7 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -1205,7 +1224,7 @@
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "inBundle": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
@@ -1229,13 +1248,13 @@
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "inBundle": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/make-dir": {
@@ -1254,9 +1273,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1264,12 +1283,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1289,9 +1302,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -1318,7 +1331,7 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1517,7 +1530,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1526,7 +1539,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -1535,7 +1548,7 @@
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "inBundle": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -1610,7 +1623,7 @@
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "inBundle": true,
       "dependencies": {
         "error-ex": "^1.2.0"
@@ -1631,7 +1644,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1655,7 +1668,7 @@
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -1675,7 +1688,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1684,7 +1697,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1693,7 +1706,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "inBundle": true,
       "dependencies": {
         "pinkie": "^2.0.0"
@@ -1705,7 +1718,7 @@
     "node_modules/pkg-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+      "integrity": "sha512-9hHgE5+Xai/ChrnahNP8Ke0VNF/s41IZIB/d24eMHEaRamdPg+wwlRm2lTb5wMvE8eTIKrYZsrxfuOwt3dpsIQ==",
       "inBundle": true,
       "dependencies": {
         "find-up": "^1.0.0",
@@ -1720,7 +1733,7 @@
     "node_modules/pkg-conf/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "inBundle": true,
       "dependencies": {
         "path-exists": "^2.0.0",
@@ -1733,7 +1746,7 @@
     "node_modules/pkg-conf/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "inBundle": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
@@ -1769,7 +1782,7 @@
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "inBundle": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
@@ -1783,7 +1796,7 @@
     "node_modules/read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "inBundle": true,
       "dependencies": {
         "find-up": "^1.0.0",
@@ -1796,7 +1809,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "inBundle": true,
       "dependencies": {
         "path-exists": "^2.0.0",
@@ -1809,7 +1822,7 @@
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "inBundle": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
@@ -1821,7 +1834,7 @@
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
@@ -1833,7 +1846,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1842,16 +1855,16 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
       "inBundle": true
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "inBundle": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1904,7 +1917,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -1935,9 +1948,9 @@
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1995,13 +2008,13 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "inBundle": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -2015,7 +2028,7 @@
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "inBundle": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -2060,7 +2073,7 @@
     "node_modules/symbol": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+      "integrity": "sha512-IUW+ek7apEaW5bFhS6WpYoNtVpNTlNoqB/PH7YiMWQTxSPeXCzG4PILVakwXivJt3ZXWeO1fIJnUd/L9A/VeGA==",
       "inBundle": true
     },
     "node_modules/test-exclude": {
@@ -2080,7 +2093,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2104,14 +2117,39 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -2142,13 +2180,13 @@
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "node_modules/window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
       "inBundle": true,
       "bin": {
         "window-size": "cli.js"
@@ -2160,7 +2198,7 @@
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -2173,7 +2211,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write-file-atomic": {
@@ -2191,7 +2229,7 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "node_modules/y18n": {
       "version": "3.2.2",
@@ -2202,7 +2240,7 @@
     "node_modules/yargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.1.0.tgz",
-      "integrity": "sha1-A15epGasf+pYSwA1PjPq5AgrmJQ=",
+      "integrity": "sha512-0jOKdePiHshBUyJ5f1fVa7ximy3szbz3dJba1c5JFEN0a6slGOau+7RbSpRImq8VmZKzFUW5skEHpoxTv7bhAw==",
       "inBundle": true,
       "dependencies": {
         "camelcase": "^2.0.1",
@@ -2221,7 +2259,7 @@
     "node_modules/yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "inBundle": true,
       "dependencies": {
         "camelcase": "^3.0.0",
@@ -2231,7 +2269,7 @@
     "node_modules/yargs-parser/node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2240,7 +2278,7 @@
     "node_modules/yargs/node_modules/camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2249,232 +2287,233 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.0.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
+        "json5": "^2.2.1",
         "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.4",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
         "semver": "^6.3.0"
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2497,22 +2536,38 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2520,9 +2575,9 @@
       }
     },
     "@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "aggregate-error": {
@@ -2538,7 +2593,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2561,7 +2616,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "argparse": {
@@ -2590,16 +2645,15 @@
       }
     },
     "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       }
     },
     "caching-transform": {
@@ -2621,9 +2675,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "chalk": {
@@ -2646,7 +2700,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -2656,7 +2710,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -2670,19 +2724,19 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -2716,7 +2770,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -2728,9 +2782,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "emoji-regex": {
@@ -2762,7 +2816,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "esprima": {
@@ -2811,7 +2865,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "function-bind": {
@@ -2838,15 +2892,15 @@
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -2858,9 +2912,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "has": {
       "version": "1.0.3",
@@ -2873,7 +2927,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "hasha": {
@@ -2900,7 +2954,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -2912,7 +2966,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -2928,17 +2982,17 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -2946,7 +3000,7 @@
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -2960,13 +3014,13 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2977,7 +3031,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -3008,18 +3062,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       }
     },
     "istanbul-lib-report": {
@@ -3059,20 +3112,12 @@
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -3102,18 +3147,15 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -3121,7 +3163,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -3133,7 +3175,7 @@
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -3152,12 +3194,12 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "make-dir": {
@@ -3170,19 +3212,13 @@
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -3199,9 +3235,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "normalize-package-data": {
@@ -3225,7 +3261,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "nyc": {
       "version": "15.1.0",
@@ -3386,12 +3422,12 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -3400,7 +3436,7 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -3453,7 +3489,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -3467,7 +3503,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -3484,7 +3520,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -3500,17 +3536,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -3518,7 +3554,7 @@
     "pkg-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+      "integrity": "sha512-9hHgE5+Xai/ChrnahNP8Ke0VNF/s41IZIB/d24eMHEaRamdPg+wwlRm2lTb5wMvE8eTIKrYZsrxfuOwt3dpsIQ==",
       "requires": {
         "find-up": "^1.0.0",
         "load-json-file": "^1.1.0",
@@ -3529,7 +3565,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -3538,7 +3574,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -3566,7 +3602,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -3576,7 +3612,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -3585,7 +3621,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -3594,7 +3630,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -3604,7 +3640,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -3613,20 +3649,20 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -3661,7 +3697,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shebang-command": {
@@ -3686,9 +3722,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "spawn-wrap": {
@@ -3736,13 +3772,13 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -3752,7 +3788,7 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3780,7 +3816,7 @@
     "symbol": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
+      "integrity": "sha512-IUW+ek7apEaW5bFhS6WpYoNtVpNTlNoqB/PH7YiMWQTxSPeXCzG4PILVakwXivJt3ZXWeO1fIJnUd/L9A/VeGA=="
     },
     "test-exclude": {
       "version": "6.0.0",
@@ -3796,7 +3832,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "type-fest": {
@@ -3814,10 +3850,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -3841,18 +3887,18 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw=="
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -3861,7 +3907,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {
@@ -3879,7 +3925,7 @@
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "y18n": {
       "version": "3.2.2",
@@ -3889,7 +3935,7 @@
     "yargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.1.0.tgz",
-      "integrity": "sha1-A15epGasf+pYSwA1PjPq5AgrmJQ=",
+      "integrity": "sha512-0jOKdePiHshBUyJ5f1fVa7ximy3szbz3dJba1c5JFEN0a6slGOau+7RbSpRImq8VmZKzFUW5skEHpoxTv7bhAw==",
       "requires": {
         "camelcase": "^2.0.1",
         "cliui": "^3.0.3",
@@ -3907,14 +3953,14 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+          "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw=="
         }
       }
     },
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"
@@ -3923,7 +3969,7 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
         }
       }
     }

--- a/build/testdata/npm/project2/npmv8/linux/excpected_dependencies_list.json
+++ b/build/testdata/npm/project2/npmv8/linux/excpected_dependencies_list.json
@@ -1,3960 +1,4023 @@
 [
     {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "strip-ansi:6.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
-        "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
-        "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
-    },
-    {
-        "id": "escalade:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
-        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
-        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
-    },
-    {
-        "id": "spawn-wrap:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
-        "md5": "300df23ba641ba293cd9907ddf1b7552",
-        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
-    },
-    {
-        "id": "wrap-ansi:6.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
-        "md5": "f8917d0c5de3cfd4ab98a235260b3951",
-        "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
-    },
-    {
-        "id": "minimatch:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "5166e286457f03306064be5497e8dbb0c3d32083",
-        "md5": "6a2c6f3ffed6ed50faaff89ef8eab0a0",
-        "sha256": "426a24d79bb6f0d3bb133e62cec69021836d254b39d931c104ddd7c464adea71"
-    },
-    {
-        "id": "js-yaml:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
-        "md5": "fba4491839b7fa47c38f639ac243b22d",
-        "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
-    },
-    {
-        "id": "@istanbuljs/load-nyc-config:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
-        "md5": "d46010939e33d1d4e7dfce54fc60d89a",
-        "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
-    },
-    {
-        "id": "gensync:1.0.0-beta.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
-        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
-        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
-    },
-    {
-        "id": "source-map:0.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
-        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
-        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
-    },
-    {
-        "id": "@jridgewell/resolve-uri:3.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@jridgewell/trace-mapping:0.3.4",
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "68eb521368db76d040a6315cdb24bf2483037b9c",
-        "md5": "07cb06db0492aeeb70f4b82acd092497",
-        "sha256": "e619c16d899ea3357c44f5b5f7d7e1e756d56907cc5c61dc962920ed597df449"
-    },
-    {
-        "id": "@babel/generator:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7bd890ba706cd86d3e2f727322346ffdbf98f65e",
-        "md5": "57c162fe94987cd2dc7fb8ca2275273c",
-        "sha256": "5e2b5025057fbd393e4272d81fe00a41590d4c3d8f1624beed6c2a331b8c2ea4"
-    },
-    {
-        "id": "picocolors:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
-        "md5": "743f01bf24bb6492555959fdeb7e9918",
-        "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "he:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
-        "md5": "59dd519e72954845f5a01d23c2695903",
-        "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
-    },
-    {
-        "id": "yargs-parser:20.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b42890f14566796f85ae8e3a25290d205f154a54",
-        "md5": "dded5e7456c94ffc7f4ffddddcac0681",
-        "sha256": "4fe61652a7e5375530ef19f941238fec925f34c7cad78f45bc73afad66bd0121"
-    },
-    {
-        "id": "y18n:5.0.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
-        "md5": "6018afaa99207dafc81cb56404a31454",
-        "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
-    },
-    {
-        "id": "is-typedarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "typedarray-to-buffer:3.1.5",
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
-        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
-        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
-    },
-    {
-        "id": "workerpool:6.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "827d93c9ba23ee2019c3ffaff5c27fccea289e8b",
-        "md5": "a1e0bfe26fa42fcc8898777d366b3457",
-        "sha256": "5cbec29ff60e6176083cdfe869eaf15b32a2410746730b3ce424dc84e9f8472b"
-    },
-    {
-        "id": "pkg-dir:4.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
-        "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
-        "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
-    },
-    {
-        "id": "shebang-regex:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shebang-command:2.0.0",
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
-        "md5": "800d00b53670160a44fa6116b1cbb6e5",
-        "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
-    },
-    {
-        "id": "find-up:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
-        "md5": "f30df2388d75158c7361f549edfe9bef",
-        "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
-    },
-    {
-        "id": "locate-path:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:5.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "55321eb309febbc59c4801d931a72452a681d286",
-        "md5": "88dec34f94138c96fd50374b3ff54935",
-        "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
-    },
-    {
-        "id": "yocto-queue:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:3.1.0",
-                "p-locate:5.0.0",
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
-        "md5": "69e27040e38c5b03127488546dc282ea",
-        "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "serialize-javascript:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
-        "md5": "900d6fc6f653ed171f0e54507edb0e43",
-        "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
-    },
-    {
-        "id": "to-fast-properties:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/types:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
-        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
-        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
-    },
-    {
-        "id": "fromentries:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "process-on-spawn:1.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
-        "md5": "f13c076f7541b0f2993f537b46768314",
-        "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
-    },
-    {
-        "id": "braces:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
-        "md5": "3ed11e666a13cb0da288c6f445b2601f",
-        "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
-    },
-    {
-        "id": "convert-source-map:1.8.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
-        "md5": "d1c553aaaffba79be7073471b2619511",
-        "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
-    },
-    {
-        "id": "istanbul-lib-hook:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
-        "md5": "5602d9c25a554fbcca017c4df471866e",
-        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
-    },
-    {
-        "id": "@babel/highlight:7.16.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "744f2eb81579d6eea753c227b0f570ad785aba88",
-        "md5": "bcf1f0f288a5a1b94bc794bb91330322",
-        "sha256": "cf3f6b5c1dd40d0ac1e8b9c2cbfeb56e6cedff940ecefd437d913a6662867f92"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "get-caller-file:2.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
-        "md5": "1b9de5ead51b8886be998f58fdb96476",
-        "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "test-exclude:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
-        "md5": "c9d2be086d4d740f9999b77971777008",
-        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
-    },
-    {
-        "id": "@babel/helper-split-export-declaration:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0b648c0c42da9d3920d85ad585f2778620b8726b",
-        "md5": "cce660616c0b0f8c1c699b95ad639d03",
-        "sha256": "0bf2cab0c3fb41fb2d3ef0b24a31dad8d781ca53ce6765c09e3243e04b52750f"
-    },
-    {
-        "id": "@babel/helper-get-function-arity:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ea08ac753117a669f1508ba06ebcc49156387419",
-        "md5": "f11bd3474d17bc12735a2462d08fa093",
-        "sha256": "0db0f2c529b0dc0cac0d8f2e1197ce16434f273d381a3a09d1fa39c627d7fd69"
-    },
-    {
-        "id": "anymatch:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
-        "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
-        "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.0.4",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randombytes:2.1.0",
-                "serialize-javascript:6.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "convert-source-map:1.8.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "@babel/compat-data:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "86850b8597ea6962089770952075dcaabb8dba34",
-        "md5": "4a1ac2c80c8418ec00238913eb7c0438",
-        "sha256": "25b1193ec09d93140d7f515e013143e87b65459aca093fa05633f81b4b57dea5"
-    },
-    {
-        "id": "decamelize:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
-        "md5": "17113f86fb93e54ad64017cac7c80002",
-        "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
-    },
-    {
-        "id": "hasha:5.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
-        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
-        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
-    },
-    {
-        "id": "electron-to-chromium:1.4.71",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "17056914465da0890ce00351a3b946fd4cd51ff6",
-        "md5": "2c5f79188dd916f93d015bd43e40eb43",
-        "sha256": "c3c060dd6e61b6949eb800e540a83830a144210402b1b5e09a577d8efe162c3f"
-    },
-    {
-        "id": "process-on-spawn:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-preload:0.2.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
-        "md5": "acaca9f6065528d5b79d3d3501b5a745",
-        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
-    },
-    {
-        "id": "is-glob:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-parent:5.1.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
-    },
-    {
-        "id": "p-locate:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
-        "md5": "f179aa668706b232c29cb580eea96619",
-        "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
-    },
-    {
-        "id": "jsesc:2.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
-        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
-        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
-    },
-    {
-        "id": "clean-stack:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
-        "md5": "98495454e4106c25e5ed97ae9a6b1148",
-        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
-    },
-    {
-        "id": "yargs-parser:18.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
-        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
-        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
-    },
-    {
-        "id": "supports-color:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
-        "md5": "da58ae58b985905e1445bc447625dc1b",
-        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
-    },
-    {
-        "id": "p-locate:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
-        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
-        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
-    },
-    {
-        "id": "istanbul-lib-coverage:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
-        "md5": "799503e96989c6a2906f2c58bc51f0d6",
-        "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
-    },
-    {
-        "id": "@jridgewell/sourcemap-codec:1.4.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@jridgewell/trace-mapping:0.3.4",
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec",
-        "md5": "616f1bb14acac428e4e045b4e686863f",
-        "sha256": "fb9875df19ed311535f95e919dcce064e971222fc94185d54091eebba4b3a804"
-    },
-    {
-        "id": "write-file-atomic:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
-        "md5": "53e54080c22253705daa1c3115c02220",
-        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
-    },
-    {
-        "id": "log-symbols:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
-        "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
-        "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
-    },
-    {
-        "id": "is-plain-obj:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
-        "md5": "23b716d73535a85a95b57d53d7ac5df6",
-        "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
-    },
-    {
-        "id": "yargs:16.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
-        "md5": "23787ef1801c6394b3bdee59580dd6c8",
-        "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
-    },
-    {
-        "id": "is-fullwidth-code-point:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
-        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
-        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
-    },
-    {
-        "id": "p-limit:2.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
-        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
-        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
-    },
-    {
-        "id": "package-hash:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
-        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
-        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
-    },
-    {
-        "id": "graceful-fs:4.2.9",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "041b05df45755e587a24942279b9d113146e1c96",
-        "md5": "e387a6dfac11fd5d79bd2718100e08b6",
-        "sha256": "16677911bf936576c5c73447657a30b4c535ddf8dc2fa0c8109ae93fa9319f0a"
-    },
-    {
-        "id": "foreground-child:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
-        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
-        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
-    },
-    {
-        "id": "js-tokens:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
-        "md5": "325b11b965688c69ae45a3cf771fbc5c",
-        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
-    },
-    {
-        "id": "globals:11.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
-        "md5": "712d15395573404a3ddb37ce395d948b",
-        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
-    },
-    {
-        "id": "wrap-ansi:7.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
-        "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
-        "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
-    },
-    {
-        "id": "get-package-type:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
-        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
-        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
-    },
-    {
-        "id": "@babel/types:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-environment-visitor:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-imports:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-simple-access:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-split-export-declaration:7.16.7",
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-get-function-arity:7.16.7",
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-hoist-variables:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a826e368bccb6b3d84acd76acad5c0d87342390b",
-        "md5": "25c50552b3df248fdd6190d10d2a2504",
-        "sha256": "ed70b73777727e0693ffebd4f8bd3b292c0c09c4942346db1f56c26683043ba3"
-    },
-    {
-        "id": "@babel/helper-function-name:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1ec51551fb1c8956bc8dd95f38523b6cf375f8f",
-        "md5": "fe6ef594ab8e9c55fa7acc2f44e800d3",
-        "sha256": "da1772107abcf286f381db20854100ae0f7736d26780781ac47ba56ac54c045f"
-    },
-    {
-        "id": "@babel/helper-hoist-variables:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "86bcb19a77a509c7b77d0e22323ef588fa58c246",
-        "md5": "757d50721db19a62b2b9411b070d6e58",
-        "sha256": "72b2c9684e5628ed942f7e608ff79ddc74e4a66a088c5ef10597b4050a4b88bb"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "es6-error:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "release-zalgo:1.0.0",
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
-        "md5": "9aeb9c257e683268999655a2071219f2",
-        "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
-    },
-    {
-        "id": "node-preload:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
-        "md5": "120f936cf9cfb9aaf63819850ee25dab",
-        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
-    },
-    {
-        "id": "@types/mocha:9.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "baf17ab2cca3fcce2d322ebc30454bff487efad5",
-        "md5": "74b1b3f63ad27956f486de6bdbd6b50e",
-        "sha256": "82be40614d99ca6f1ee20a8aaab46a57bf3f693b1ac28975761cb7f0b826abd7"
-    },
-    {
-        "id": "ansi-colors:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cbb9ae256bf750af1eab344f229aa27fe94ba348",
-        "md5": "ce72bb5360d8326616cae64d8ae9bdfe",
-        "sha256": "24d803210289f2afc6448276aa9d5a9608e86e584698307d2365d93195cf1f44"
-    },
-    {
-        "id": "picomatch:2.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "readdirp:3.6.0",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3ba3833733646d9d3e4995946c1365a67fb07a42",
-        "md5": "fa0a8505a751a04b4cff2285257ddf73",
-        "sha256": "1b14ee9ec867c090d7b52c77193d83e77910553b3d18b2f86dd2b7b55e82c11f"
-    },
-    {
-        "id": "color-name:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:2.0.1",
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
-        "md5": "a8d4412852471526b8027af2532d0d2b",
-        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:2.0.2",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "istanbul-lib-report:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-reports:3.1.4",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
-        "md5": "87a16f7a36e489fdd042510550872167",
-        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
-    },
-    {
-        "id": "istanbul-lib-source-maps:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
-        "md5": "2b0cd1493c52493181871afc3c5a93be",
-        "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
-    },
-    {
-        "id": "istanbul-reports:3.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b6f068ecbc6c331040aab5741991273e609e40c",
-        "md5": "d83f11919b8678dd497985086178ebad",
-        "sha256": "91132ac58788279e61fae36c9ae623addfe577efc5b948c35e3a7521ef7c6b5a"
-    },
-    {
-        "id": "is-extglob:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-glob:4.0.3",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "emoji-regex:8.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
-        "md5": "598b731d8d33cfff04377ad55da187b0",
-        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
-    },
-    {
-        "id": "is-stream:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
-        "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
-        "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
-    },
-    {
-        "id": "@jridgewell/trace-mapping:0.3.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@ampproject/remapping:2.1.1",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3",
-        "md5": "9a6904d400fcf90498340cb5137a0d08",
-        "sha256": "b960678706c5fb7bd27d291e3bcb9aa009c61445e15c9442e5885d70c6552d82"
-    },
-    {
-        "id": "@babel/template:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.16.7",
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8d126c8701fde4d66b264b3eba3d96f07666d155",
-        "md5": "65b3dea316742fdb1829b34e6c766f3b",
-        "sha256": "2cd40fc44dd41eb77c31f2c01af92b13eb2b264cc392423b4f5af0e01d897f84"
-    },
-    {
-        "id": "fill-range:7.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:3.0.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
-        "md5": "279e60751b8b0e89226a9e9bd5b8f275",
-        "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
-    },
-    {
-        "id": "commondir:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
-        "md5": "329b8682e83ec34dfe1c58ae90b84988",
-        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
-    },
-    {
-        "id": "browserslist:4.19.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4ac0435b35ab655896c31d53018b6dd5e9e4c9a3",
-        "md5": "98fbe518b74960ee170a1fe8877711c6",
-        "sha256": "f11e687a4210175a5a4e36f474fe806bd2546f77901e804664ec2525c3815b1c"
-    },
-    {
-        "id": "strip-json-comments:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
-        "md5": "58e65c07bc47365a2acc9129b810130c",
-        "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
-    },
-    {
-        "id": "cliui:7.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
-        "md5": "c3a8fba555857874ad0dffba34a2289f",
-        "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "is-number:7.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "to-regex-range:5.0.1",
-                "fill-range:7.0.1",
-                "braces:3.0.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7535345b896734d5f80c4d06c50955527a14f12b",
-        "md5": "6c6e00114e00c2815fc0aeae3da1af23",
-        "sha256": "7b75c1057198cf97696909a9bee176c9c5e9bcb5b03bf3ecef2f484defadd51e"
-    },
-    {
-        "id": "glob-parent:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
-        "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
-        "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
-    },
-    {
-        "id": "p-limit:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:5.0.0",
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e1daccbe78d0d1388ca18c64fea38e3e57e3706b",
-        "md5": "1362f362e00b9e967f1f922cf1a0a872",
-        "sha256": "36e6519736cafaa158dc1bca8137683f5bf1bc1c476d40519028b3f3a96bc9e0"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "rimraf:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "argparse:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
-        "md5": "864f41f5cacfed3315deeba37ba7954b",
-        "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
-    },
-    {
-        "id": "type-fest:0.8.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
-        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
-        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
-    },
-    {
-        "id": "lodash.flattendeep:4.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
-        "md5": "17ca06c4643969cb10e948854434eba0",
-        "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
-    },
-    {
-        "id": "html-escaper:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-reports:3.1.4",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
-        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
-        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
-    },
-    {
-        "id": "mocha:9.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "2bfba73d46e392901f877ab9a47b7c9c5d0275cc",
-        "md5": "398fd9e6b2f3403d06c04366aea88a4d",
-        "sha256": "04e18cee9f83ed363b8b9a477be3f136850bf4b67f31851ef8f00d07b6a09adf"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "archy:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
-        "md5": "b2a24c65e2212f53168f984b5a693dbd",
-        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
-    },
-    {
-        "id": "yargs:15.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
-        "md5": "091d0cc9d7347925d73455bd991e6639",
-        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
-    },
-    {
-        "id": "readdirp:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
-        "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
-        "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
-    },
-    {
-        "id": "flat:5.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
-        "md5": "c215e59da15d7b8eccb1db3e47366cb5",
-        "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
-    },
-    {
-        "id": "find-cache-dir:3.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
-        "md5": "52bbc85bfe0ddab6259eb6618900ab61",
-        "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
-    },
-    {
-        "id": "@babel/helper-module-imports:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "25612a8091a999704461c8a222d0efec5d091437",
-        "md5": "33db5ddd8ebf2f13cbc13d94a7c3bc32",
-        "sha256": "fecd1c2cf4756ea17953c004ef9a257bd666484ca80cc94961aa1a0e9ad35e57"
-    },
-    {
-        "id": "p-map:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
-        "md5": "3b38970091b03645f6f4d6680ada671d",
-        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
-    },
-    {
-        "id": "@babel/helper-simple-access:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d656654b9ea08dbb9659b69d61063ccd343ff0f7",
-        "md5": "04fc4c5e57b1f7c07f524259c792b13c",
-        "sha256": "08e167f023c3100ec4cfc438eddb6c4945f0fdf85668e692b6ed016194da934a"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
-    },
-    {
-        "id": "nyc:15.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
-        "md5": "28c5baf103508c15fc352a367910f0c4",
-        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "path-key:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
-        "md5": "4f4b9beb2d53481341e16133a8570dc5",
-        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
-    },
-    {
-        "id": "shebang-command:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
-        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
-        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
-    },
-    {
-        "id": "is-binary-path:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
-        "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
-        "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
-    },
-    {
-        "id": "ms:2.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "camelcase:5.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
-        "md5": "efcf73180d9b7001c92f574d4ae7f908",
-        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "caniuse-lite:1.0.30001312",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e11eba4b87e24d22697dae05455d5aea28550d5f",
-        "md5": "06f30a7fae77d1e146fcd860cc433455",
-        "sha256": "84a2dd7e5b76f966d3e4f2563b834c0209604a94e360165de26ad18d1cd80a6b"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "node-releases:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "browserslist:4.19.1",
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7139fe71e2f4f11b47d4d2986aaf8c48699e0c01",
-        "md5": "206a057876754acbeb1d795a17f2017b",
-        "sha256": "cf2ed799dedf5a349363551f1a94508188260aa0e207ab82f09846453c58adbb"
-    },
-    {
-        "id": "@babel/helpers:7.17.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "23f0a0746c8e287773ccd27c14be428891f63417",
-        "md5": "43ad01932216bb914a5eb67a58ac2acd",
-        "sha256": "2f8d991a4e3d5c8bc5ce84c0051fabafbd05c08ca30b766b4a543bd77f512c5a"
-    },
-    {
-        "id": "to-regex-range:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:7.0.1",
-                "braces:3.0.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
-        "md5": "5ef0a1bd28f353c14bf940103a879257",
-        "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "supports-color:8.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
-        "md5": "16e8e38709a4675f8ea1482806cb050c",
-        "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
-    },
-    {
-        "id": "ansi-regex:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:6.0.1",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
-        "md5": "7a0bb891f3a7cd9b174af62beb4de186",
-        "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
-    },
-    {
-        "id": "caching-transform:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
-        "md5": "82a03704703e883379f146caa805b457",
-        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "y18n:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
-        "md5": "182c1f29baf6577adccaf23ac94d5ed1",
-        "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
-    },
-    {
-        "id": "ansi-styles:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
-        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
-        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
-    },
-    {
-        "id": "is-unicode-supported:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
-        "md5": "5fa12001af4a22129166b9c7262d5fb2",
-        "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
-    },
-    {
-        "id": "sprintf-js:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
-    },
-    {
-        "id": "decamelize:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
-        "md5": "330932e4de0e60c36114facb6d3dfafa",
-        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
-    },
-    {
-        "id": "@babel/helper-compilation-targets:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "06e66c5f299601e6c7da350049315e83209d551b",
-        "md5": "09aff53f0695c886d7daaec61e3f6c4e",
-        "sha256": "77584007eb5b73f41a28175bb720dd5f24058151406a6dcf56506db77f69f649"
-    },
-    {
-        "id": "debug:4.3.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
-        "md5": "e0e3067fdf8e98f4d817683191280e8e",
-        "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "growl:1.10.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
-        "md5": "47fb3a576f5916564687b683b1bcea68",
-        "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
-    },
-    {
-        "id": "string-width:4.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:16.2.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
-        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
-        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
-    },
-    {
-        "id": "locate-path:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
-        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
-        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:2.2.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "which:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
-        "md5": "9556a736013ff5223cc9731d9f32b55f",
-        "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
-    },
-    {
-        "id": "camelcase:6.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "5685b95eb209ac9c0c177467778c9c84df58ba9a",
-        "md5": "cde9397a5c3cbfcdb6a5e559f5c00cd4",
-        "sha256": "2851fe487cf5607b5196895b13d6db4620200b225eec753897a9759f8912adb6"
-    },
-    {
-        "id": "@istanbuljs/schema:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
-        "md5": "868e08ce450f7d9d5cd29997f0865f17",
-        "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
-    },
-    {
-        "id": "@babel/helper-module-transforms:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7665faeb721a01ca5327ddc6bba15a5cb34b6a41",
-        "md5": "362ea04465b1e07ba23d74986d9284c2",
-        "sha256": "724450b68389e0fbe6639535ba3f543f5a92e19ea49ec96a0ce1ce71e32b611d"
-    },
-    {
-        "id": "browser-stdout:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
-        "md5": "82ebb0cdcee39bc8953381ac71cad549",
-        "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
-    },
-    {
-        "id": "ms:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:4.3.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
-        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
-        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
-    },
-    {
-        "id": "resolve-from:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
-        "md5": "23cff3fc62d9dd916e67da9c9505603f",
-        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
-    },
-    {
-        "id": "default-require-extensions:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
-        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
-        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
-    },
-    {
-        "id": "uuid:3.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b23e4358afa8a202fe7a100af1f5f883f02007ee",
-        "md5": "2fa27207bb65f4e05c6f10bc0448f662",
-        "sha256": "ba77c9306dbc34c7ae503e9eb142e284f98ea9ab609f416052c2fbbefb6df4dd"
-    },
-    {
-        "id": "istanbul-lib-processinfo:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e1426514662244b2f25df728e8fd1ba35fe53b9c",
-        "md5": "93131ca838a58e819813b733c606bd8d",
-        "sha256": "7e529f7767219df1b357ae5b65949760f40516c6fd3743218c6b05b7ca86dd81"
-    },
-    {
-        "id": "chokidar:3.5.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1cf37c8707b932bd1af1ae22c0432e2acd1903bd",
-        "md5": "058cc35293e3dfdf9cf4f122206e9ed6",
-        "sha256": "2ecbd23217998661de76f061e65e01263882c5a88bffb28f362323b185935c1a"
-    },
-    {
-        "id": "normalize-path:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
-        "md5": "2821b760c1df5dcc38328f154a6ea3cb",
-        "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
-    },
-    {
-        "id": "balanced-match:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
-        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
-        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
-    },
-    {
-        "id": "append-transform:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
-        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
-        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
-    },
-    {
-        "id": "@babel/traverse:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.17.2",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3143e5066796408ccc880a33ecd3184f3e75cd30",
-        "md5": "3a4cd8b0047b7c1f442688a933b98885",
-        "sha256": "9711bf0f5c6ef0b1c4e256ab3da16c4b2e514606f443b5504910ba45859b79ae"
-    },
-    {
-        "id": "@babel/core:7.17.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "2c77fc430e95139d816d39b113b31bf40fb22337",
-        "md5": "8bfdd2d9e678789eca31534a2824cdff",
-        "sha256": "86d99fe6abf016cf563873bee1df5abdf3a7aae058dafd0777773c7716b0dadf"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "@babel/parser:7.17.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f0ac33eddbe214e4105363bb17c3341c5ffcc43c",
-        "md5": "5d7976d85b1ab0763660e53d67b768be",
-        "sha256": "b835d7e17844d74a455bed9de58b5787a9b9ead1d82a2985a6b9b73895b29896"
-    },
-    {
-        "id": "@ungap/promise-all-settled:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
-        "md5": "b2752b39b9322878e731606f6ec568a1",
-        "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
-    },
-    {
-        "id": "color-convert:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
-        "md5": "0248ebc952524207e296a622372faa1f",
-        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
-    },
-    {
-        "id": "yargs-unparser:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f131f9226911ae5d9ad38c432fe809366c2325eb",
-        "md5": "f9482cf08bacd4b85c2f4aa27215e73b",
-        "sha256": "c9224d53839022b885216ed18127198abc15e38a242ced14d74b11fafc0ba97c"
-    },
-    {
-        "id": "p-try:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
-        "md5": "49994562e1f3cbe260710598cbb3edf7",
-        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
-    },
-    {
-        "id": "typedarray-to-buffer:3.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
-        "md5": "d693220f5eabe1359169bb992abaa064",
-        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
-    },
-    {
-        "id": "indent-string:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
-        "md5": "ad188c269f2d9181da4321f8803a4cde",
-        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
-    },
-    {
-        "id": "cliui:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
-        "md5": "9065a0615794d52f19cffa078701d382",
-        "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
-    },
-    {
-        "id": "which-module:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "md5": "ce028f30082fbbea9861a40437d17bd3",
-        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "aggregate-error:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "92670ff50f5359bdb7a3e0d40d0ec30c5737687a",
-        "md5": "16dd9122f632da20697f8ed47c7bbcc1",
-        "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
-    },
-    {
-        "id": "diff:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
-        "md5": "a6db67e2eeb11fd4cf5135da638e2157",
-        "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
-    },
-    {
-        "id": "find-up:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
-        "md5": "aa0b377135f4af38d106db8b84606924",
-        "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
-    },
-    {
-        "id": "make-dir:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
-        "md5": "e47d13370c2b27671a13f28ebc27585f",
-        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
-    },
-    {
-        "id": "@babel/helper-validator-identifier:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/types:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e8c602438c4a8195751243da9031d1607d247cad",
-        "md5": "01d9e7c98c18ad2aa95344c17478b185",
-        "sha256": "f647395ab3d4535d85e87df8b3c9979e0bf91f8065145227fbf92c89b3070214"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "@babel/helper-environment-visitor:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ff484094a839bde9d89cd63cba017d7aae80ecd7",
-        "md5": "c5728d1ab5fea8959f6be3e4afb2e0cb",
-        "sha256": "ba9a21976a417bceb8aa7023b06cfdac5e5d1c27b194aeb00d401a932cc75787"
-    },
-    {
-        "id": "json5:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "2dfefe720c6ba525d9ebd909950f0515316c89a3",
-        "md5": "e4711e39d31c4887d0c727ee258c7b40",
-        "sha256": "37875a2bd12417df58f547acc8b909db3a2cb437511f44516a6871e344c0b1fe"
-    },
-    {
-        "id": "chalk:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
-        "md5": "cf76e256de1debce9c7a21cd18df954d",
-        "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
-    },
-    {
-        "id": "randombytes:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "serialize-javascript:6.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
-        "md5": "efb164d8addf215512a3bb6dd19a1496",
-        "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
-    },
-    {
-        "id": "release-zalgo:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
-        "md5": "2e431e2016bfc667a21974c2c818d769",
-        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
-    },
-    {
-        "id": "cross-spawn:7.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
-        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
-        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
-    },
-    {
-        "id": "istanbul-lib-instrument:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
-        "md5": "ee314a8a3153abd9396916f9e141d374",
-        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
-    },
-    {
-        "id": "rimraf:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
-        "md5": "c794495fee118854a7cbd585a19a0fa8",
-        "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
-    },
-    {
-        "id": "binary-extensions:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:2.1.0",
-                "chokidar:3.5.3",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
-        "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
-        "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
-    },
-    {
-        "id": "escape-string-regexp:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
-        "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
-        "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
-    },
-    {
-        "id": "path-exists:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:5.0.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
-        "md5": "d3652d47b80b1aa623e820d7d276b27b",
-        "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
-    },
-    {
-        "id": "require-main-filename:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
-        "md5": "8b45166659a670e83387649f79c641ad",
-        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
-    },
-    {
-        "id": "@babel/code-frame:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.17.0",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "44416b6bd7624b998f5b1af5d470856c40138789",
-        "md5": "31af46ce2c742b38161a12651c99e09e",
-        "sha256": "f45cf383e8c261cf4134b7800dd64d66e3b2d05aac2c20b5069da6b42531ab81"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.16.10",
-                "@babel/code-frame:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "@babel/helper-validator-option:7.16.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b203ce62ce5fe153899b617c08957de860de4d23",
-        "md5": "b3ec7314cda7a9c17735693d598b560d",
-        "sha256": "a0ff716706e338847d605bca3044ce2b53e37dc428175681c960900f8f2d389a"
-    },
-    {
-        "id": "has-flag:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:7.2.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:8.1.1",
-                "mocha:9.2.0",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:7.2.0",
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
-        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
-        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
-    },
-    {
-        "id": "nanoid:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.2.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "62667522da6673971cca916a6d3eff3f415ff80c",
-        "md5": "044ae2ac093047923b789e20df03e34f",
-        "sha256": "835597982cfa992fad421182b48fbcf455e780e9ceabefceca38e69c3598677c"
-    },
-    {
-        "id": "signal-exit:3.0.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a9a1767f8af84155114eaabd73f99273c8f59ad9",
-        "md5": "05cf0ff414a9fc6e30abb6d20780c762",
-        "sha256": "439623fa6aab91600615ec757eaa137fcab40d3b35dda38df7444c15678f20a8"
-    },
-    {
-        "id": "strip-bom:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "default-require-extensions:3.0.0",
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
-        "md5": "ba5ded28e859d1030ed2f1369e379f67",
-        "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
-    },
-    {
-        "id": "@ampproject/remapping:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7922fb0817bf3166d8d9e258c57477e3fd1c3610",
-        "md5": "0ab52e552c4cb84b3a1ae54bb48e3c0d",
-        "sha256": "5dec92f5a1d89418c9c96318f5997efd1830c32963fcf2128532e86b53416249"
-    },
-    {
-        "id": "semver:6.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-compilation-targets:7.16.7",
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.17.2",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "make-dir:3.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
-        "md5": "e0836faadf4b192c3987c5117d62fff6",
-        "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
+    "id": "chalk:4.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
+    "md5": "cf76e256de1debce9c7a21cd18df954d",
+    "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
+    },
+    {
+    "id": "es6-error:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "release-zalgo:1.0.0",
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
+    "md5": "9aeb9c257e683268999655a2071219f2",
+    "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
+    },
+    {
+    "id": "write-file-atomic:3.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
+    "md5": "53e54080c22253705daa1c3115c02220",
+    "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
+    },
+    {
+    "id": "is-typedarray:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "typedarray-to-buffer:3.1.5",
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+    "md5": "d5efec2afc8b29ff367a2127cd1890b2",
+    "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
+    },
+    {
+    "id": "istanbul-lib-hook:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
+    "md5": "5602d9c25a554fbcca017c4df471866e",
+    "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
+    },
+    {
+    "id": "yargs:15.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
+    "md5": "091d0cc9d7347925d73455bd991e6639",
+    "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
+    },
+    {
+    "id": "p-limit:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:5.0.0",
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e1daccbe78d0d1388ca18c64fea38e3e57e3706b",
+    "md5": "1362f362e00b9e967f1f922cf1a0a872",
+    "sha256": "36e6519736cafaa158dc1bca8137683f5bf1bc1c476d40519028b3f3a96bc9e0"
+    },
+    {
+    "id": "has-flag:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:7.2.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "supports-color:8.1.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "supports-color:7.2.0",
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
+    "md5": "d48b4e68ca6cd00a3f95a43f88625684",
+    "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
+    },
+    {
+    "id": "is-unicode-supported:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
+    "md5": "5fa12001af4a22129166b9c7262d5fb2",
+    "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
+    },
+    {
+    "id": "p-limit:2.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
+    "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
+    "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
+    },
+    {
+    "id": "to-regex-range:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:7.0.1",
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
+    "md5": "5ef0a1bd28f353c14bf940103a879257",
+    "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
+    },
+    {
+    "id": "concat-map:0.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+    "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+    "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+    "id": "shebang-command:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
+    "md5": "aa7675df57afd8404d9aaa55e659f7a8",
+    "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
+    },
+    {
+    "id": "@ampproject/remapping:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "56c133824780de3174aed5ab6834f3026790154d",
+    "md5": "f89dd9045903be2cc7c10b3c31e75626",
+    "sha256": "2f2dacc9e8ed33330e4ad095403b9efb51736e06f9c57baf0ca73058406bb890"
+    },
+    {
+    "id": "jsesc:2.5.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
+    "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
+    "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
+    },
+    {
+    "id": "@babel/compat-data:7.18.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "2483f565faca607b8535590e84e7de323f27764d",
+    "md5": "7088ff85d6c89dea757ce152c9150565",
+    "sha256": "5756345fc4fe02547f9355988f4f923a0ca9ad868cca748a8cd94b9fdd202a5e"
+    },
+    {
+    "id": "json5:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "655d50ed1e6f95ad1a3caababd2b0efda10b395c",
+    "md5": "e7d2fc3e0299d8005b5f7f46161cc227",
+    "sha256": "1d044eb7a06ddb2429366e0630dd884d1e57f116e3704b293631fa4dde045a59"
+    },
+    {
+    "id": "indent-string:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "aggregate-error:3.1.0",
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
+    "md5": "ad188c269f2d9181da4321f8803a4cde",
+    "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
+    },
+    {
+    "id": "fs.realpath:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+    "md5": "9f790d7180667e1d8d1110f2cf321b62",
+    "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+    "id": "spawn-wrap:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
+    "md5": "300df23ba641ba293cd9907ddf1b7552",
+    "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
+    },
+    {
+    "id": "growl:1.10.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
+    "md5": "47fb3a576f5916564687b683b1bcea68",
+    "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
+    },
+    {
+    "id": "yargs-unparser:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f131f9226911ae5d9ad38c432fe809366c2325eb",
+    "md5": "f9482cf08bacd4b85c2f4aa27215e73b",
+    "sha256": "c9224d53839022b885216ed18127198abc15e38a242ced14d74b11fafc0ba97c"
+    },
+    {
+    "id": "strip-ansi:6.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
+    "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
+    "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
+    },
+    {
+    "id": "ansi-regex:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "strip-ansi:6.0.1",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
+    "md5": "7a0bb891f3a7cd9b174af62beb4de186",
+    "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
+    },
+    {
+    "id": "@babel/helper-module-imports:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1e3ebdbbd08aad1437b428c50204db13c5a3ca6e",
+    "md5": "3549438c2b0b59c539a58c4cb733f4a0",
+    "sha256": "9b450e94445d86395e12d74981be606bb90d4e92e99ae358093d1318d78c6568"
+    },
+    {
+    "id": "rimraf:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
+    "md5": "c794495fee118854a7cbd585a19a0fa8",
+    "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
+    },
+    {
+    "id": "fromentries:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "process-on-spawn:1.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
+    "md5": "f13c076f7541b0f2993f537b46768314",
+    "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
+    },
+    {
+    "id": "readdirp:3.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
+    "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
+    "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
+    },
+    {
+    "id": "inflight:1.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+    "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+    "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+    "id": "js-yaml:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
+    "md5": "fba4491839b7fa47c38f639ac243b22d",
+    "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
+    },
+    {
+    "id": "log-symbols:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
+    "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
+    "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
+    },
+    {
+    "id": "source-map:0.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+    "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
+    "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
+    },
+    {
+    "id": "html-escaper:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-reports:3.1.5",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
+    "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
+    "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
+    },
+    {
+    "id": "aggregate-error:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "92670ff50f5359bdb7a3e0d40d0ec30c5737687a",
+    "md5": "16dd9122f632da20697f8ed47c7bbcc1",
+    "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
+    },
+    {
+    "id": "is-binary-path:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
+    "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
+    "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
+    },
+    {
+    "id": "p-locate:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
+    "md5": "f179aa668706b232c29cb580eea96619",
+    "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
+    },
+    {
+    "id": "sprintf-js:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "argparse:1.0.10",
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+    "md5": "8e6b31a052754055683e4a35a317feab",
+    "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+    "id": "hasha:5.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
+    "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
+    "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
+    },
+    {
+    "id": "release-zalgo:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "09700b7e5074329739330e535c5a90fb67851730",
+    "md5": "2e431e2016bfc667a21974c2c818d769",
+    "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
+    },
+    {
+    "id": "foreground-child:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
+    "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
+    "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
+    },
+    {
+    "id": "@babel/core:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "805461f967c77ff46c74ca0460ccf4fe933ddd59",
+    "md5": "414e3ac6524d22ef6fe284e456051fb9",
+    "sha256": "9a1831b17a6a6b8524ffd957c70deb5b12f2ec90869c0b3b0bacd201bfbc338b"
+    },
+    {
+    "id": "@babel/code-frame:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3b25d38c89600baa2dcc219edfa88a74eb2c427a",
+    "md5": "06bf74bedad2a91ac5c5950ee0d527a4",
+    "sha256": "069544665ad7c8eb0fd72fd2ebf2c651454fce88768e3a8d203041865e729977"
+    },
+    {
+    "id": "find-up:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
+    "md5": "f30df2388d75158c7361f549edfe9bef",
+    "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
+    },
+    {
+    "id": "@babel/helper-hoist-variables:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d4d2c8fb4baeaa5c68b99cc8245c56554f926678",
+    "md5": "f10ece88fdea253c1678a09bdfa85160",
+    "sha256": "cd91a6aef86fb2089e6798c395dffa5d59ca2801e348ef6259f78882082707ec"
+    },
+    {
+    "id": "@babel/traverse:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "deeff3e8f1bad9786874cb2feda7a2d77a904f98",
+    "md5": "4e01105ee87a3406c4a9c3617ebdba42",
+    "sha256": "a9d2fd8aa3dccf55f8057d42d02d620960875c5d283a7fc0f941afbd5680ac2d"
+    },
+    {
+    "id": "strip-json-comments:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
+    "md5": "58e65c07bc47365a2acc9129b810130c",
+    "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
+    },
+    {
+    "id": "camelcase:6.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "5685b95eb209ac9c0c177467778c9c84df58ba9a",
+    "md5": "cde9397a5c3cbfcdb6a5e559f5c00cd4",
+    "sha256": "2851fe487cf5607b5196895b13d6db4620200b225eec753897a9759f8912adb6"
+    },
+    {
+    "id": "require-directory:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+    "md5": "f3a9010155b6a46066afbe2d07f624bd",
+    "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+    "id": "is-fullwidth-code-point:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
+    "md5": "87c5848714e5ed8e25abbdc13cfe3995",
+    "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
+    },
+    {
+    "id": "@jridgewell/gen-mapping:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e5d2e450306a9491e3bd77e323e38d7aff315996",
+    "md5": "0f933b56a27f4640e86c5c9662516c5a",
+    "sha256": "2d2055c259b61a7537644eb25c548d0c1d388caaca9c26766c0df91976b94ab6"
+    },
+    {
+    "id": "@babel/helper-split-export-declaration:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7367949bc75b20c6d5a5d4a97bba2824ae8ef075",
+    "md5": "d7c42328ad1e542ae3f255320630d31c",
+    "sha256": "a985fbbc087d43887197fbe6ee6ecab05a2bf71daa6e99929d4fd09f176f58f5"
+    },
+    {
+    "id": "diff:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
+    "md5": "a6db67e2eeb11fd4cf5135da638e2157",
+    "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
+    },
+    {
+    "id": "@babel/helper-validator-option:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8",
+    "md5": "d22673cb3b1ea3e3127bb12d507a036c",
+    "sha256": "3efdfe87e7e6830c5091ee369a27368e263d9dab8cfc7f0f41e7f9b9c5aec9cf"
+    },
+    {
+    "id": "ms:2.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:4.3.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
+    "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
+    "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
+    },
+    {
+    "id": "browser-stdout:1.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
+    "md5": "82ebb0cdcee39bc8953381ac71cad549",
+    "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
+    },
+    {
+    "id": "binary-extensions:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-binary-path:2.1.0",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
+    "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
+    "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
+    },
+    {
+    "id": "locate-path:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "55321eb309febbc59c4801d931a72452a681d286",
+    "md5": "88dec34f94138c96fd50374b3ff54935",
+    "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
+    },
+    {
+    "id": "find-up:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
+    "md5": "aa0b377135f4af38d106db8b84606924",
+    "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
+    },
+    {
+    "id": "js-tokens:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
+    "md5": "325b11b965688c69ae45a3cf771fbc5c",
+    "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
+    },
+    {
+    "id": "@babel/helper-environment-visitor:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0c0cee9b35d2ca190478756865bb3528422f51be",
+    "md5": "62eaa04ce85291b537bd92b4cba422a3",
+    "sha256": "00aa1c2f172719e15df07a13833cd9632c51ec20ce87c68bfa10deff44545af3"
+    },
+    {
+    "id": "@babel/parser:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f2dde0c682ccc264a9a8595efd030a5cc8fd2539",
+    "md5": "374150ff1ab6268dd1248d12950e392d",
+    "sha256": "a4fba8f4f3542a6b44e848fa989ba96e4ad4ee2c1020139c3dc0093260ba2ecc"
+    },
+    {
+    "id": "mocha:9.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d70db46bdb93ca57402c809333e5a84977a88fb9",
+    "md5": "efdae5243a066904827b3adfc3393733",
+    "sha256": "829065fecd9d6eb25c755a05d5ca748da3ad775e6d30d24abba5791039218492"
+    },
+    {
+    "id": "test-exclude:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
+    "md5": "c9d2be086d4d740f9999b77971777008",
+    "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
+    },
+    {
+    "id": "get-caller-file:2.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+    "md5": "1b9de5ead51b8886be998f58fdb96476",
+    "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
+    },
+    {
+    "id": "resolve-from:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
+    "md5": "23cff3fc62d9dd916e67da9c9505603f",
+    "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
+    },
+    {
+    "id": "lodash.flattendeep:4.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
+    "md5": "17ca06c4643969cb10e948854434eba0",
+    "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
+    },
+    {
+    "id": "commondir:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+    "md5": "329b8682e83ec34dfe1c58ae90b84988",
+    "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
+    },
+    {
+    "id": "escape-string-regexp:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+    "md5": "02440084832abe665260d5db1da1dd9e",
+    "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+    "id": "supports-color:5.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+    "md5": "17b1003344e0e0d2719205be85946698",
+    "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
+    },
+    {
+    "id": "istanbul-reports:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cc9a6ab25cb25659810e4785ed9d9fb742578bae",
+    "md5": "37a18bd3f4140ff1690f1048aef18171",
+    "sha256": "a118d2013c68c83b81acabbfa2df3e2838e1e2f5a53d3045c208689540c48d85"
+    },
+    {
+    "id": "yargs:16.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+    "md5": "23787ef1801c6394b3bdee59580dd6c8",
+    "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
+    },
+    {
+    "id": "clean-stack:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "aggregate-error:3.1.0",
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
+    "md5": "98495454e4106c25e5ed97ae9a6b1148",
+    "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
+    },
+    {
+    "id": "nanoid:3.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "6347a18cac88af88f58af0b3594b723d5e99bb35",
+    "md5": "1a27cf077cc40c51811677adab047a31",
+    "sha256": "ad5542a3de899dbd0c2728a94b844ebb00794bb7762d3c1676de14de83f6135e"
+    },
+    {
+    "id": "isexe:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which:2.0.2",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+    "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+    "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+    "id": "workerpool:6.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "827d93c9ba23ee2019c3ffaff5c27fccea289e8b",
+    "md5": "a1e0bfe26fa42fcc8898777d366b3457",
+    "sha256": "5cbec29ff60e6176083cdfe869eaf15b32a2410746730b3ce424dc84e9f8472b"
+    },
+    {
+    "id": "make-dir:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
+    "md5": "e47d13370c2b27671a13f28ebc27585f",
+    "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
+    },
+    {
+    "id": "globals:11.12.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
+    "md5": "712d15395573404a3ddb37ce395d948b",
+    "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
+    },
+    {
+    "id": "brace-expansion:1.1.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "minimatch:3.1.2",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "minimatch:3.1.2",
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+    "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+    "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+    "id": "cliui:7.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
+    "md5": "c3a8fba555857874ad0dffba34a2289f",
+    "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
+    },
+    {
+    "id": "node-releases:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8a7088c63a55e493845683ebf3c828d8c51c5503",
+    "md5": "86970ccb7f3cf344f56b70be69b316cf",
+    "sha256": "8b34c017dbfac06f45d6c9de2e32d2d5335cafdffaa9c2ba5aa756c854617eff"
+    },
+    {
+    "id": "@babel/helpers:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4bef3b893f253a1eced04516824ede94dcfe7ff9",
+    "md5": "029dea1cf8f08d6602536f2650d9f25c",
+    "sha256": "912bfc1b1aaea6ffb32155c8f7c783ccf48d80a04b9ad9853080b4a10206d8d4"
+    },
+    {
+    "id": "chokidar:3.5.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1cf37c8707b932bd1af1ae22c0432e2acd1903bd",
+    "md5": "058cc35293e3dfdf9cf4f122206e9ed6",
+    "sha256": "2ecbd23217998661de76f061e65e01263882c5a88bffb28f362323b185935c1a"
+    },
+    {
+    "id": "graceful-fs:4.2.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+    "md5": "094ac6976c4cec6cced67915d6c726c0",
+    "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+    "id": "decamelize:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs-parser:18.1.3",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+    "md5": "330932e4de0e60c36114facb6d3dfafa",
+    "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
+    },
+    {
+    "id": "append-transform:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
+    "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
+    "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
+    },
+    {
+    "id": "default-require-extensions:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "append-transform:2.0.0",
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
+    "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
+    "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
+    },
+    {
+    "id": "@babel/helper-validator-identifier:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/types:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9c97e30d31b2b8c72a1d08984f2ca9b574d7a076",
+    "md5": "f4d15f6582c54e6a9ad8dfda2c073c6b",
+    "sha256": "110e5d9854308bafa7de7e79e31b4ab34b8720e44cd28adb66ab19b790d57e19"
+    },
+    {
+    "id": "picocolors:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
+    "md5": "743f01bf24bb6492555959fdeb7e9918",
+    "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
+    },
+    {
+    "id": "@babel/helper-simple-access:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d6d8f51f4ac2978068df934b569f08f29788c7ea",
+    "md5": "d0e1a86f6785eb7548411ed182da8374",
+    "sha256": "7b37715bb3decd3b3a2144244d321aafb3b9b9ef034f53a22cd1e828a101c040"
+    },
+    {
+    "id": "@ungap/promise-all-settled:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
+    "md5": "b2752b39b9322878e731606f6ec568a1",
+    "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
+    },
+    {
+    "id": "color-convert:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:4.3.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+    "md5": "0248ebc952524207e296a622372faa1f",
+    "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
+    },
+    {
+    "id": "escalade:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+    "md5": "61feaad8ca2ae37eff46aa4818a7b045",
+    "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
+    },
+    {
+    "id": "locate-path:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
+    "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
+    "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
+    },
+    {
+    "id": "p-try:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
+    "md5": "49994562e1f3cbe260710598cbb3edf7",
+    "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
+    },
+    {
+    "id": "imurmurhash:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+    "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+    "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+    "id": "yocto-queue:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:3.1.0",
+    "p-locate:5.0.0",
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
+    "md5": "69e27040e38c5b03127488546dc282ea",
+    "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
+    },
+    {
+    "id": "path-exists:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
+    "md5": "d3652d47b80b1aa623e820d7d276b27b",
+    "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
+    },
+    {
+    "id": "inherits:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+    "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+    "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+    "id": "p-locate:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
+    "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
+    "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
+    },
+    {
+    "id": "get-package-type:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
+    "md5": "53c447a09cbf8afb25d97e78bf4a1397",
+    "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
+    },
+    {
+    "id": "@jridgewell/gen-mapping:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9",
+    "md5": "de5b5402b140d1634f9bbf189b298ee3",
+    "sha256": "8176fad9663205ddefe81637fcc24097dded9716ad300a3d8ede3062e4cfc6fd"
+    },
+    {
+    "id": "p-map:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
+    "md5": "3b38970091b03645f6f4d6680ada671d",
+    "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
+    },
+    {
+    "id": "cliui:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
+    "md5": "9065a0615794d52f19cffa078701d382",
+    "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
+    },
+    {
+    "id": "@types/mocha:9.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4",
+    "md5": "af8133831578083c75040f5ab0981fff",
+    "sha256": "6587cb469be76e37c4be6cf9d70b002c78b37025c599ef6ffe5c132d93a88d9d"
+    },
+    {
+    "id": "cross-spawn:7.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
+    "md5": "e8b91e2f179097df541bc96ebb11b8bf",
+    "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
+    },
+    {
+    "id": "path-key:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
+    "md5": "4f4b9beb2d53481341e16133a8570dc5",
+    "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
+    },
+    {
+    "id": "caniuse-lite:1.0.30001368",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c5c06381c6051cd863c45021475434e81936f713",
+    "md5": "1762454bac8432336003f3f2740b008b",
+    "sha256": "174dceca41249223bdf0923ef3065692bb095161607d0ca5376ab63305b76e92"
+    },
+    {
+    "id": "require-main-filename:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
+    "md5": "8b45166659a670e83387649f79c641ad",
+    "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
+    },
+    {
+    "id": "js-yaml:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+    "md5": "2a522c3e23f7999abd8f852c012c20dd",
+    "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+    "id": "minimatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+    "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+    "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+    "id": "color-name:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:2.0.1",
+    "ansi-styles:4.3.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
+    "md5": "a8d4412852471526b8027af2532d0d2b",
+    "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
+    },
+    {
+    "id": "decamelize:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
+    "md5": "17113f86fb93e54ad64017cac7c80002",
+    "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
+    },
+    {
+    "id": "@jridgewell/resolve-uri:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/trace-mapping:0.3.14",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "2203b118c157721addfe69d47b70465463066d78",
+    "md5": "bdc32c6b7d0a978faf304b94ba607f93",
+    "sha256": "fe4cb2ab38b4813b27926d9e08852ad81d8c14d0034cfa4a23555ec134ee16b0"
+    },
+    {
+    "id": "node-preload:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
+    "md5": "120f936cf9cfb9aaf63819850ee25dab",
+    "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
+    },
+    {
+    "id": "braces:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
+    "md5": "3ed11e666a13cb0da288c6f445b2601f",
+    "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
+    },
+    {
+    "id": "randombytes:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "serialize-javascript:6.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
+    "md5": "efb164d8addf215512a3bb6dd19a1496",
+    "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
+    },
+    {
+    "id": "string-width:4.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
+    "md5": "41b9a8984f249b332c0ae05f8b4688a9",
+    "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
+    },
+    {
+    "id": "caching-transform:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
+    "md5": "82a03704703e883379f146caa805b457",
+    "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
+    },
+    {
+    "id": "browserslist:4.21.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "59a400757465535954946a400b841ed37e2b4ecf",
+    "md5": "b7595f1787cc1f79d334efbfd10c7b0e",
+    "sha256": "cf0524be457eb24273a426cdf6651af11a8df6817bcb284366b0889591473f65"
+    },
+    {
+    "id": "update-browserslist-db:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "be06a5eedd62f107b7c19eb5bcefb194411abf38",
+    "md5": "2a4f39c3cad79d0f127387a479d7348c",
+    "sha256": "44ce49ceb80c9b30c8860ae914df75cc88b8a0a65a2aa471f87659af97777a15"
+    },
+    {
+    "id": "@babel/helper-function-name:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "940e6084a55dee867d33b4e487da2676365e86b0",
+    "md5": "5a360d6490679bc8050ae8342bce1d68",
+    "sha256": "089fc866e1349e85fe331ddf5388afae1d42271fe105a3951024fe6b55f88e0b"
+    },
+    {
+    "id": "normalize-path:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:3.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
+    "md5": "2821b760c1df5dcc38328f154a6ea3cb",
+    "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
+    },
+    {
+    "id": "supports-color:7.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
+    "md5": "da58ae58b985905e1445bc447625dc1b",
+    "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
+    },
+    {
+    "id": "@istanbuljs/load-nyc-config:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
+    "md5": "d46010939e33d1d4e7dfce54fc60d89a",
+    "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
+    },
+    {
+    "id": "esprima:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+    "md5": "c9d44a818c324d707a81b08dd36cd079",
+    "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+    "id": "istanbul-lib-coverage:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
+    "md5": "799503e96989c6a2906f2c58bc51f0d6",
+    "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
+    },
+    {
+    "id": "color-name:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:1.9.3",
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+    "md5": "b45186c4fe76a2450ec484149ade0066",
+    "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+    "id": "has-flag:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:5.5.0",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+    "md5": "1fa1fa951639c7058277abcecca86922",
+    "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+    "id": "argparse:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
+    "md5": "864f41f5cacfed3315deeba37ba7954b",
+    "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
+    },
+    {
+    "id": "path-is-absolute:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+    "md5": "18bfccb10294ae19e7eb616ed1c05176",
+    "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+    "id": "balanced-match:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+    "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+    "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+    "id": "type-fest:0.8.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "hasha:5.2.2",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
+    "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
+    "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
+    },
+    {
+    "id": "@babel/highlight:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "81158601e93e2563795adcbfbdf5d64be3f2ecdf",
+    "md5": "6be4064f31d9e3fdd17994bd177ef426",
+    "sha256": "f54e6c10da061b163dd744a9ee2f0f3560d26d5cb1d4e81c9bc9ff6bcdcba664"
+    },
+    {
+    "id": "istanbul-lib-report:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-reports:3.1.5",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
+    "md5": "87a16f7a36e489fdd042510550872167",
+    "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
+    },
+    {
+    "id": "glob:7.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "rimraf:3.0.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
+    "md5": "05f5ea4a12aecafd90fe04c32385ce80",
+    "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
+    },
+    {
+    "id": "is-glob:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob-parent:5.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+    "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+    "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+    "id": "wrap-ansi:7.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
+    "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
+    "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
+    },
+    {
+    "id": "is-stream:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "hasha:5.2.2",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
+    "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
+    "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
+    },
+    {
+    "id": "ansi-styles:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+    "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+    "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+    "id": "@babel/helper-compilation-targets:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf",
+    "md5": "e4bb285eb8cfaafeb0964e277713e836",
+    "sha256": "b1045536c086bdc82da52399401e7fabeacf8c52f38c653f04e921d3def4b74f"
+    },
+    {
+    "id": "yargs-parser:18.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
+    "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
+    "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
+    },
+    {
+    "id": "anymatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
+    "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
+    "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
+    },
+    {
+    "id": "which:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
+    "md5": "9556a736013ff5223cc9731d9f32b55f",
+    "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
+    },
+    {
+    "id": "@jridgewell/sourcemap-codec:1.4.14",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/gen-mapping:0.1.1",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/trace-mapping:0.3.14",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "add4c98d341472a289190b424efbdb096991bb24",
+    "md5": "b462c7a5932255e273725bf451bd36ce",
+    "sha256": "b7430e808b04aeba42441a44b783068c1923b8aa3f6f91fc1d789383b0c53941"
+    },
+    {
+    "id": "chalk:2.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+    "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+    "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+    "id": "archy:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+    "md5": "b2a24c65e2212f53168f984b5a693dbd",
+    "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
+    },
+    {
+    "id": "istanbul-lib-source-maps:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
+    "md5": "2b0cd1493c52493181871afc3c5a93be",
+    "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
+    },
+    {
+    "id": "debug:4.3.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
+    "md5": "e0e3067fdf8e98f4d817683191280e8e",
+    "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
+    },
+    {
+    "id": "is-extglob:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-glob:4.0.3",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+    "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+    "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+    "id": "y18n:5.0.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+    "md5": "6018afaa99207dafc81cb56404a31454",
+    "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
+    },
+    {
+    "id": "fill-range:7.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
+    "md5": "279e60751b8b0e89226a9e9bd5b8f275",
+    "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
+    },
+    {
+    "id": "once:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+    "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+    "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+    "id": "safe-buffer:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randombytes:2.1.0",
+    "serialize-javascript:6.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "convert-source-map:1.8.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+    "md5": "dc7142b470e0957c5c34098b6fced0ab",
+    "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+    "id": "@istanbuljs/schema:0.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
+    "md5": "868e08ce450f7d9d5cd29997f0865f17",
+    "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
+    },
+    {
+    "id": "@babel/generator:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "68337e9ea8044d6ddc690fb29acae39359cca0a5",
+    "md5": "ced102e1a657c80aeac9c54297b0c51a",
+    "sha256": "ecfd6a96062cf06c56236cc2ddbd02e8a978c883b6d1e68d7ec7b7acf833a2ee"
+    },
+    {
+    "id": "uuid:8.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+    "md5": "001956ff1c0a16e6bae8bae042ba226b",
+    "sha256": "f630703647a5821c735a542edcf8d26c989724efe9d9912ab6f6836a1e79924a"
+    },
+    {
+    "id": "set-blocking:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+    "md5": "ff057cf430b35ecb25780f94cd051ab3",
+    "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+    "id": "escape-string-regexp:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
+    "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
+    "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
+    },
+    {
+    "id": "@babel/helper-module-transforms:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "5a1079c005135ed627442df31a42887e80fcb712",
+    "md5": "19160955f01c62275ff14f0daa5706f6",
+    "sha256": "c6f2dbdfa8850bdbe650a350f419535e8cbb95339a0b15ab028e6a1b78ef2afc"
+    },
+    {
+    "id": "is-windows:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+    "md5": "bcc9525ed3558792d281951c90ad366e",
+    "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+    "id": "camelcase:5.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs-parser:18.1.3",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
+    "md5": "efcf73180d9b7001c92f574d4ae7f908",
+    "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
+    },
+    {
+    "id": "package-hash:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
+    "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
+    "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
+    },
+    {
+    "id": "electron-to-chromium:1.4.196",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e18cdc5c1c2c2ebf78da237d0c374cc3b244d4cb",
+    "md5": "e65dea46a634f06ef01bd9d9d84da73a",
+    "sha256": "fde9ab86721e9199b2a0b3ac946e4103ae1799a6813db0a4ef8881d0558750aa"
+    },
+    {
+    "id": "process-on-spawn:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-preload:0.2.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
+    "md5": "acaca9f6065528d5b79d3d3501b5a745",
+    "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
+    },
+    {
+    "id": "is-number:7.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "to-regex-range:5.0.1",
+    "fill-range:7.0.1",
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7535345b896734d5f80c4d06c50955527a14f12b",
+    "md5": "6c6e00114e00c2815fc0aeae3da1af23",
+    "sha256": "7b75c1057198cf97696909a9bee176c9c5e9bcb5b03bf3ecef2f484defadd51e"
+    },
+    {
+    "id": "supports-color:8.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
+    "md5": "16e8e38709a4675f8ea1482806cb050c",
+    "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
+    },
+    {
+    "id": "emoji-regex:8.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
+    "md5": "598b731d8d33cfff04377ad55da187b0",
+    "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
+    },
+    {
+    "id": "convert-source-map:1.8.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
+    "md5": "d1c553aaaffba79be7073471b2619511",
+    "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
+    },
+    {
+    "id": "pkg-dir:4.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
+    "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
+    "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
+    },
+    {
+    "id": "shebang-regex:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shebang-command:2.0.0",
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
+    "md5": "800d00b53670160a44fa6116b1cbb6e5",
+    "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
+    },
+    {
+    "id": "istanbul-lib-processinfo:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "366d454cd0dcb7eb6e0e419378e60072c8626169",
+    "md5": "6053742aadc8e3ef55d8808d24ef2b59",
+    "sha256": "4df1e5e9927bb39e18ed3a2d2d567c8e66ce54ded31704e36d34d1d70697f99c"
+    },
+    {
+    "id": "picomatch:2.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:3.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "readdirp:3.6.0",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3ba3833733646d9d3e4995946c1365a67fb07a42",
+    "md5": "fa0a8505a751a04b4cff2285257ddf73",
+    "sha256": "1b14ee9ec867c090d7b52c77193d83e77910553b3d18b2f86dd2b7b55e82c11f"
+    },
+    {
+    "id": "@jridgewell/trace-mapping:0.3.14",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b231a081d8f66796e475ad588a1ef473112701ed",
+    "md5": "55173b301ee67c9e20d5b60835018a67",
+    "sha256": "7f5c917fa0abdcc4cbd99f49fe1dcccdac40151c0ec18d8163325c643c64a993"
+    },
+    {
+    "id": "to-fast-properties:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/types:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
+    "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
+    "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+    },
+    {
+    "id": "ansi-styles:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
+    "md5": "0534616a9bab55e3e2d350f9ab77ea22",
+    "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
+    },
+    {
+    "id": "typedarray-to-buffer:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
+    "md5": "d693220f5eabe1359169bb992abaa064",
+    "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
+    },
+    {
+    "id": "find-cache-dir:3.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
+    "md5": "52bbc85bfe0ddab6259eb6618900ab61",
+    "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
+    },
+    {
+    "id": "istanbul-lib-instrument:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "873c6fff897450118222774696a3f28902d77c1d",
+    "md5": "ee314a8a3153abd9396916f9e141d374",
+    "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
+    },
+    {
+    "id": "color-convert:1.9.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+    "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+    "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+    "id": "ansi-colors:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cbb9ae256bf750af1eab344f229aa27fe94ba348",
+    "md5": "ce72bb5360d8326616cae64d8ae9bdfe",
+    "sha256": "24d803210289f2afc6448276aa9d5a9608e86e584698307d2365d93195cf1f44"
+    },
+    {
+    "id": "is-plain-obj:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
+    "md5": "23b716d73535a85a95b57d53d7ac5df6",
+    "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
+    },
+    {
+    "id": "argparse:1.0.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+    "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+    "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+    "id": "@babel/types:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-imports:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-simple-access:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-split-export-declaration:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-function-name:7.18.9",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-hoist-variables:7.18.6",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7148d64ba133d8d73a41b3172ac4b83a1452205f",
+    "md5": "a9bbb05787a9f2f0310fba1d42f84320",
+    "sha256": "1b309d075c4970b84308ab5055b56335e117969d4c9fbb34140adf3e6e4ac63a"
+    },
+    {
+    "id": "which-module:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+    "md5": "ce028f30082fbbea9861a40437d17bd3",
+    "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
+    },
+    {
+    "id": "he:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
+    "md5": "59dd519e72954845f5a01d23c2695903",
+    "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
+    },
+    {
+    "id": "strip-bom:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "default-require-extensions:3.0.0",
+    "append-transform:2.0.0",
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
+    "md5": "ba5ded28e859d1030ed2f1369e379f67",
+    "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
+    },
+    {
+    "id": "@jridgewell/set-array:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/gen-mapping:0.1.1",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7c6cf998d6d20b914c0a55a91ae928ff25965e72",
+    "md5": "b48ee5bc088b403daf0f66546312ef9a",
+    "sha256": "7585773292098c500f5e8a993357c0b91512696ad6a6f79bd10f2beb84e607ff"
+    },
+    {
+    "id": "gensync:1.0.0-beta.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
+    "md5": "3d1e68bdacb4e8046ccabff0019e916b",
+    "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
+    },
+    {
+    "id": "y18n:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
+    "md5": "182c1f29baf6577adccaf23ac94d5ed1",
+    "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
+    },
+    {
+    "id": "wrappy:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "once:1.4.0",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+    "md5": "567b1699cfae49cb20f598571a6c90c7",
+    "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
+    },
+    {
+    "id": "minimatch:4.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "40d9d511a46bdc4e563c22c3080cde9c0d8299b4",
+    "md5": "145e5c35d2aa8d7ade9fcfd6cac624b2",
+    "sha256": "2afcebdaa72e6a049a8b37600f996b86a27e8c755bdb442d8eccd2f2746639b5"
+    },
+    {
+    "id": "ms:2.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+    "md5": "a50e4bf82f754914316bfca3dfbcf352",
+    "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+    "id": "serialize-javascript:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
+    "md5": "900d6fc6f653ed171f0e54507edb0e43",
+    "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
+    },
+    {
+    "id": "yargs-parser:20.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b42890f14566796f85ae8e3a25290d205f154a54",
+    "md5": "dded5e7456c94ffc7f4ffddddcac0681",
+    "sha256": "4fe61652a7e5375530ef19f941238fec925f34c7cad78f45bc73afad66bd0121"
+    },
+    {
+    "id": "flat:5.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
+    "md5": "c215e59da15d7b8eccb1db3e47366cb5",
+    "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
+    },
+    {
+    "id": "nyc:15.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
+    "md5": "28c5baf103508c15fc352a367910f0c4",
+    "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
+    },
+    {
+    "id": "signal-exit:3.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a9a1767f8af84155114eaabd73f99273c8f59ad9",
+    "md5": "05cf0ff414a9fc6e30abb6d20780c762",
+    "sha256": "439623fa6aab91600615ec757eaa137fcab40d3b35dda38df7444c15678f20a8"
+    },
+    {
+    "id": "glob-parent:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
+    "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
+    "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
+    },
+    {
+    "id": "@babel/template:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-function-name:7.18.9",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1283f4993e00b929d6e2d3c72fdc9168a2977a31",
+    "md5": "bc579b67a5099d381f57dc938f2c132d",
+    "sha256": "aef8c9facb86709c1cb53264cdeca13b86bb3eeeb53d86294f05fbfd54562e25"
+    },
+    {
+    "id": "wrap-ansi:6.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
+    "md5": "f8917d0c5de3cfd4ab98a235260b3951",
+    "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
+    },
+    {
+    "id": "semver:6.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "make-dir:3.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
+    "md5": "e0836faadf4b192c3987c5117d62fff6",
+    "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
     }
-]
+    ]

--- a/build/testdata/npm/project2/npmv8/linux/package-lock.json
+++ b/build/testdata/npm/project2/npmv8/linux/package-lock.json
@@ -18,58 +18,59 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.0.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
+        "json5": "^2.2.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -81,28 +82,42 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.16.4",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -113,149 +128,133 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -301,13 +300,13 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -316,7 +315,7 @@
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -335,9 +334,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -347,33 +346,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -382,12 +381,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -493,25 +492,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -519,9 +540,9 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -604,7 +625,7 @@
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -657,26 +678,31 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/caching-transform": {
@@ -704,14 +730,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -809,13 +841,13 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -867,7 +899,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -895,9 +927,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1036,7 +1068,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -1112,6 +1144,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1122,9 +1166,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/growl": {
@@ -1179,7 +1223,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -1197,7 +1241,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -1225,7 +1269,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1285,7 +1329,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/is-unicode-supported": {
@@ -1312,7 +1356,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
@@ -1352,18 +1396,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -1409,19 +1452,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -1462,13 +1496,10 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -1494,7 +1525,7 @@
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -1529,27 +1560,21 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -1565,9 +1590,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -1596,9 +1621,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1620,9 +1645,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -1796,7 +1821,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -1880,7 +1905,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2013,7 +2038,7 @@
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
@@ -2025,7 +2050,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2088,7 +2113,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -2119,9 +2144,9 @@
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2147,7 +2172,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/string-width": {
@@ -2226,10 +2251,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2265,14 +2302,39 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -2293,7 +2355,7 @@
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "node_modules/workerpool": {
@@ -2322,7 +2384,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write-file-atomic": {
@@ -2427,186 +2489,187 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.0.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
+        "json5": "^2.2.1",
         "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.4",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
         "semver": "^6.3.0"
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2643,19 +2706,19 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -2670,47 +2733,47 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
-        "@babel/types": "^7.17.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2791,22 +2854,38 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2814,9 +2893,9 @@
       }
     },
     "@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -2878,7 +2957,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "argparse": {
@@ -2925,16 +3004,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       }
     },
     "caching-transform": {
@@ -2956,9 +3034,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "chalk": {
@@ -3033,13 +3111,13 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -3082,7 +3160,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "default-require-extensions": {
@@ -3101,9 +3179,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "emoji-regex": {
@@ -3191,7 +3269,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -3231,6 +3309,17 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -3249,9 +3338,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "growl": {
@@ -3291,7 +3380,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -3303,7 +3392,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -3328,7 +3417,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -3367,7 +3456,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -3385,7 +3474,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -3416,18 +3505,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       }
     },
     "istanbul-lib-report": {
@@ -3461,20 +3549,12 @@
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -3503,13 +3583,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -3523,7 +3600,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "log-symbols": {
@@ -3546,24 +3623,18 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -3579,9 +3650,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -3599,9 +3670,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "node-preload": {
@@ -3614,9 +3685,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "normalize-path": {
@@ -3759,7 +3830,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -3819,7 +3890,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -3918,7 +3989,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -3927,7 +3998,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {
@@ -3975,7 +4046,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shebang-command": {
@@ -4000,9 +4071,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "spawn-wrap": {
@@ -4022,7 +4093,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string-width": {
@@ -4075,12 +4146,23 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -4107,10 +4189,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "which": {
@@ -4125,7 +4217,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "workerpool": {
@@ -4148,7 +4240,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {

--- a/build/testdata/npm/project2/npmv8/macos/excpected_dependencies_list.json
+++ b/build/testdata/npm/project2/npmv8/macos/excpected_dependencies_list.json
@@ -1,299 +1,191 @@
 [
     {
-        "id": "p-map:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
-        "md5": "3b38970091b03645f6f4d6680ada671d",
-        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
-    },
-    {
-        "id": "istanbul-lib-report:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-reports:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
-        "md5": "87a16f7a36e489fdd042510550872167",
-        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "is-plain-obj:2.1.0",
+        "id": "decamelize:4.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
                 "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
-        "md5": "23b716d73535a85a95b57d53d7ac5df6",
-        "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
+        "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
+        "md5": "17113f86fb93e54ad64017cac7c80002",
+        "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
     },
     {
-        "id": "escalade:3.1.1",
+        "id": "hasha:5.2.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
                 "jfrogtest"
-            ]
-        ],
-        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
-        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
-        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
-    },
-    {
-        "id": "spawn-wrap:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
-        "md5": "300df23ba641ba293cd9907ddf1b7552",
-        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
+        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
+        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
+        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
     },
     {
-        "id": "test-exclude:6.0.0",
+        "id": "@babel/helper-split-export-declaration:7.18.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
-        "md5": "c9d2be086d4d740f9999b77971777008",
-        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
-    },
-    {
-        "id": "color-convert:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
-        "md5": "0248ebc952524207e296a622372faa1f",
-        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
-    },
-    {
-        "id": "serialize-javascript:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
-        "md5": "900d6fc6f653ed171f0e54507edb0e43",
-        "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
-    },
-    {
-        "id": "@babel/parser:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "cc31257419d2c3189d394081635703f549fc1ed4",
-        "md5": "f573e5455fa39afadc1bb30f724622dd",
-        "sha256": "33a407b6bf6c30fdeda12d1373fb192b49be135a0c48bc58040d9dfcebefd210"
+        "sha1": "7367949bc75b20c6d5a5d4a97bba2824ae8ef075",
+        "md5": "d7c42328ad1e542ae3f255320630d31c",
+        "sha256": "a985fbbc087d43887197fbe6ee6ecab05a2bf71daa6e99929d4fd09f176f58f5"
     },
     {
-        "id": "gensync:1.0.0-beta.2",
+        "id": "argparse:2.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
+                "js-yaml:4.1.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
-        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
-        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
+        "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
+        "md5": "864f41f5cacfed3315deeba37ba7954b",
+        "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
     },
     {
-        "id": "semver:5.7.1",
+        "id": "to-regex-range:5.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
+                "fill-range:7.0.1",
+                "braces:3.0.2",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
+        "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
+        "md5": "5ef0a1bd28f353c14bf940103a879257",
+        "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
     },
     {
-        "id": "set-blocking:2.0.0",
+        "id": "yocto-queue:0.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "p-locate:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "p-limit:3.1.0",
+                "p-locate:5.0.0",
                 "locate-path:6.0.0",
                 "find-up:5.0.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
-        "md5": "f179aa668706b232c29cb580eea96619",
-        "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
+        "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
+        "md5": "69e27040e38c5b03127488546dc282ea",
+        "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
     },
     {
-        "id": "strip-json-comments:3.1.1",
+        "id": "glob:7.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "rimraf:3.0.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "test-exclude:6.0.0",
+                "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
-        "md5": "58e65c07bc47365a2acc9129b810130c",
-        "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
+        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
+        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
+        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
     },
     {
-        "id": "find-up:4.1.0",
+        "id": "brace-expansion:1.1.11",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
+                "minimatch:3.1.2",
+                "glob:7.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
+                "minimatch:4.2.1",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
+                "minimatch:3.1.2",
+                "test-exclude:6.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
-        "md5": "aa0b377135f4af38d106db8b84606924",
-        "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
+        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+        "id": "growl:1.10.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
+        "md5": "47fb3a576f5916564687b683b1bcea68",
+        "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
     },
     {
         "id": "@istanbuljs/schema:0.1.3",
@@ -321,231 +213,6 @@
         "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
     },
     {
-        "id": "write-file-atomic:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
-        "md5": "53e54080c22253705daa1c3115c02220",
-        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "@babel/helper-module-transforms:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "01afb052dcad2044289b7b20beb3fa8bd0265bea",
-        "md5": "35ed5d6f6c5aca458691c5729eb86c20",
-        "sha256": "224d45efb03f780a2b7fb9cf0b300c2e12e1901cc61dfe8dfc1943aa3b3b2542"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:2.2.0",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "ansi-styles:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
-        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
-        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
-    },
-    {
-        "id": "color-name:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:2.0.1",
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
-        "md5": "a8d4412852471526b8027af2532d0d2b",
-        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
-    },
-    {
-        "id": "caching-transform:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
-        "md5": "82a03704703e883379f146caa805b457",
-        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
-    },
-    {
-        "id": "@babel/helper-validator-identifier:7.12.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c9a1f021917dcb5ccf0d4e453e399022981fc9ed",
-        "md5": "7a8722e18203cfdb8c195ad276589390",
-        "sha256": "be0aac74011d70fcf9b20951c875572c0ed8f4738d3f00999f15393e7628f40a"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "jsesc:2.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
-        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
-        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
-    },
-    {
-        "id": "uuid:3.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b23e4358afa8a202fe7a100af1f5f883f02007ee",
-        "md5": "2fa27207bb65f4e05c6f10bc0448f662",
-        "sha256": "ba77c9306dbc34c7ae503e9eb142e284f98ea9ab609f416052c2fbbefb6df4dd"
-    },
-    {
         "id": "aggregate-error:3.1.0",
         "scopes": [
             "dev"
@@ -562,13 +229,35 @@
         "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
     },
     {
+        "id": "normalize-path:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "anymatch:3.1.2",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
+        "md5": "2821b760c1df5dcc38328f154a6ea3cb",
+        "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
+    },
+    {
         "id": "ansi-colors:4.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
@@ -577,113 +266,178 @@
         "sha256": "24d803210289f2afc6448276aa9d5a9608e86e584698307d2365d93195cf1f44"
     },
     {
-        "id": "which-module:2.0.0",
+        "id": "picomatch:2.3.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
+                "anymatch:3.1.2",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "readdirp:3.6.0",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "md5": "ce028f30082fbbea9861a40437d17bd3",
-        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
+        "sha1": "3ba3833733646d9d3e4995946c1365a67fb07a42",
+        "md5": "fa0a8505a751a04b4cff2285257ddf73",
+        "sha256": "1b14ee9ec867c090d7b52c77193d83e77910553b3d18b2f86dd2b7b55e82c11f"
     },
     {
-        "id": "hasha:5.2.2",
+        "id": "is-unicode-supported:0.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "caching-transform:4.0.0",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
+        "md5": "5fa12001af4a22129166b9c7262d5fb2",
+        "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
+    },
+    {
+        "id": "supports-color:8.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
+        "md5": "16e8e38709a4675f8ea1482806cb050c",
+        "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
+    },
+    {
+        "id": "is-fullwidth-code-point:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "string-width:4.2.3",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
+        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
+        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
+    },
+    {
+        "id": "istanbul-lib-coverage:3.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-source-maps:4.0.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
-        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
-        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
+        "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
+        "md5": "799503e96989c6a2906f2c58bc51f0d6",
+        "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
     },
     {
-        "id": "ansi-styles:3.2.1",
+        "id": "@babel/helper-simple-access:7.18.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+        "sha1": "d6d8f51f4ac2978068df934b569f08f29788c7ea",
+        "md5": "d0e1a86f6785eb7548411ed182da8374",
+        "sha256": "7b37715bb3decd3b3a2144244d321aafb3b9b9ef034f53a22cd1e828a101c040"
     },
     {
-        "id": "@babel/helper-optimise-call-expression:7.12.13",
+        "id": "mocha:9.2.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d70db46bdb93ca57402c809333e5a84977a88fb9",
+        "md5": "efdae5243a066904827b3adfc3393733",
+        "sha256": "829065fecd9d6eb25c755a05d5ca748da3ad775e6d30d24abba5791039218492"
+    },
+    {
+        "id": "p-map:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "5c02d171b4c8615b1e7163f888c1c81c30a2aaea",
-        "md5": "b06d494852b8183bbceff5cedb7b35d4",
-        "sha256": "bf99da6d67ff090a4b3d417a8c6724a2f6f9315d6dfc7da7b64d4eba76e588f4"
+        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
+        "md5": "3b38970091b03645f6f4d6680ada671d",
+        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
     },
     {
-        "id": "@istanbuljs/load-nyc-config:1.1.0",
+        "id": "anymatch:3.1.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
-        "md5": "d46010939e33d1d4e7dfce54fc60d89a",
-        "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
-    },
-    {
-        "id": "binary-extensions:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:2.1.0",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
-        "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
-        "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
+        "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
+        "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
+        "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
     },
     {
         "id": "p-limit:3.1.0",
@@ -695,7 +449,7 @@
                 "p-locate:5.0.0",
                 "locate-path:6.0.0",
                 "find-up:5.0.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
@@ -704,242 +458,158 @@
         "sha256": "36e6519736cafaa158dc1bca8137683f5bf1bc1c476d40519028b3f3a96bc9e0"
     },
     {
-        "id": "minimatch:3.0.4",
+        "id": "typedarray-to-buffer:3.1.5",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "5166e286457f03306064be5497e8dbb0c3d32083",
-        "md5": "6a2c6f3ffed6ed50faaff89ef8eab0a0",
-        "sha256": "426a24d79bb6f0d3bb133e62cec69021836d254b39d931c104ddd7c464adea71"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "make-dir:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "write-file-atomic:3.0.3",
                 "caching-transform:4.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
-            ],
+            ]
+        ],
+        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
+        "md5": "d693220f5eabe1359169bb992abaa064",
+        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
+    },
+    {
+        "id": "@jridgewell/set-array:1.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
             [
-                "find-cache-dir:3.3.1",
+                "@jridgewell/gen-mapping:0.1.1",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "istanbul-lib-processinfo:2.0.2",
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "7c6cf998d6d20b914c0a55a91ae928ff25965e72",
+        "md5": "b48ee5bc088b403daf0f66546312ef9a",
+        "sha256": "7585773292098c500f5e8a993357c0b91512696ad6a6f79bd10f2beb84e607ff"
+    },
+    {
+        "id": "@jridgewell/trace-mapping:0.3.14",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "b231a081d8f66796e475ad588a1ef473112701ed",
+        "md5": "55173b301ee67c9e20d5b60835018a67",
+        "sha256": "7f5c917fa0abdcc4cbd99f49fe1dcccdac40151c0ec18d8163325c643c64a993"
+    },
+    {
+        "id": "chokidar:3.5.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1cf37c8707b932bd1af1ae22c0432e2acd1903bd",
+        "md5": "058cc35293e3dfdf9cf4f122206e9ed6",
+        "sha256": "2ecbd23217998661de76f061e65e01263882c5a88bffb28f362323b185935c1a"
+    },
+    {
+        "id": "supports-color:7.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:4.1.2",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
                 "istanbul-lib-report:3.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
             ]
         ],
-        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
-        "md5": "e47d13370c2b27671a13f28ebc27585f",
-        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
+        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
+        "md5": "da58ae58b985905e1445bc447625dc1b",
+        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
     },
     {
-        "id": "shebang-regex:3.0.0",
+        "id": "string-width:4.2.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "shebang-command:2.0.0",
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
-        "md5": "800d00b53670160a44fa6116b1cbb6e5",
-        "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
-    },
-    {
-        "id": "default-require-extensions:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
-        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
-        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
-    },
-    {
-        "id": "is-glob:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-parent:5.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
+                "cliui:7.0.4",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
+                "wrap-ansi:7.0.0",
+                "cliui:7.0.4",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
-            ]
-        ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
-    },
-    {
-        "id": "@babel/helper-member-expression-to-functions:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
-            ]
-        ],
-        "sha1": "41e0916b99f8d5f43da4f05d85f4930fa3d62b22",
-        "md5": "619982af14ec79e31231427db61fc8dd",
-        "sha256": "cbfff31d7b38d87e1511a3762aac2a797f77d353806228ad10edda9808050641"
-    },
-    {
-        "id": "globals:11.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
-        "md5": "712d15395573404a3ddb37ce395d948b",
-        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
-    },
-    {
-        "id": "indent-string:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
-        "md5": "ad188c269f2d9181da4321f8803a4cde",
-        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "chalk:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
-        "md5": "cf76e256de1debce9c7a21cd18df954d",
-        "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
+        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
+        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
+        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
     },
     {
         "id": "strip-ansi:6.0.1",
@@ -950,20 +620,33 @@
             [
                 "cliui:7.0.4",
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
                 "wrap-ansi:7.0.0",
                 "cliui:7.0.4",
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
                 "string-width:4.2.3",
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "wrap-ansi:6.2.0",
+                "cliui:6.0.0",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
@@ -972,146 +655,12 @@
         "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
     },
     {
-        "id": "signal-exit:3.0.3",
+        "id": "p-limit:2.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a1410c2edd8f077b08b4e253c8eacfcaf057461c",
-        "md5": "ae863f6e95a6a6050bc0e70c9ddb0688",
-        "sha256": "15efc9bad612c82f7bea7037c0ae575d015452ae383df94424d489b0f67101c7"
-    },
-    {
-        "id": "@babel/template:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "530265be8a2589dbb37523844c5bcb55947fb327",
-        "md5": "0326d436b3127e3419765111a116a58b",
-        "sha256": "36d2d87b053e91827083d0d94364c7f673536aa963add7a3c10129d816a2ef71"
-    },
-    {
-        "id": "@babel/helpers:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3c75e993632e4dadc0274eae219c73eb7645ba47",
-        "md5": "580610ed8e4e8c7a416fa66bf972b22c",
-        "sha256": "146b595a980720a5e0e98c7e04fdab2b72c41843a3c0189978b2bd5489439364"
-    },
-    {
-        "id": "yargs:15.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
-        "md5": "091d0cc9d7347925d73455bd991e6639",
-        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
-    },
-    {
-        "id": "diff:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
-        "md5": "a6db67e2eeb11fd4cf5135da638e2157",
-        "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
-    },
-    {
-        "id": "y18n:5.0.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
-        "md5": "6018afaa99207dafc81cb56404a31454",
-        "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
-    },
-    {
-        "id": "p-try:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:2.3.0",
                 "p-locate:4.1.0",
                 "locate-path:5.0.0",
                 "find-up:4.1.0",
@@ -1120,17 +669,15 @@
                 "jfrogtest"
             ],
             [
-                "p-limit:2.3.0",
                 "p-locate:4.1.0",
                 "locate-path:5.0.0",
                 "find-up:4.1.0",
                 "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
+                "find-cache-dir:3.3.2",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "p-limit:2.3.0",
                 "p-locate:4.1.0",
                 "locate-path:5.0.0",
                 "find-up:4.1.0",
@@ -1138,92 +685,12 @@
                 "jfrogtest"
             ]
         ],
-        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
-        "md5": "49994562e1f3cbe260710598cbb3edf7",
-        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
+        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
+        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
+        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
     },
     {
-        "id": "append-transform:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
-        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
-        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
-    },
-    {
-        "id": "archy:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
-        "md5": "b2a24c65e2212f53168f984b5a693dbd",
-        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
-    },
-    {
-        "id": "fsevents:2.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a526f78b8fdf4623b709e0b975c52c24c02fd1a",
-        "md5": "3cf04486705de7ad22df4b2e51ec4893",
-        "sha256": "e17ade950c193fe09adfc7915fe29ac26166c8782d00e7c3879e7e9de02c5428"
-    },
-    {
-        "id": "is-unicode-supported:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
-        "md5": "5fa12001af4a22129166b9c7262d5fb2",
-        "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
-    },
-    {
-        "id": "camelcase:6.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "250fd350cfd555d0d2160b1d51510eaf8326e86e",
-        "md5": "d14a653ec4c2bdbc4a054b0dbce79d87",
-        "sha256": "07b3b755b39bbc93fed6f67753d4ed3f1a606ebeedc860678162bd9fe30b45c1"
-    },
-    {
-        "id": "camelcase:5.3.1",
+        "id": "get-package-type:0.1.0",
         "scopes": [
             "dev"
         ],
@@ -1234,15 +701,29 @@
                 "jfrogtest"
             ],
             [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
-        "md5": "efcf73180d9b7001c92f574d4ae7f908",
-        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
+        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
+        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
+        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
+    },
+    {
+        "id": "write-file-atomic:3.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
+        "md5": "53e54080c22253705daa1c3115c02220",
+        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
     },
     {
         "id": "decamelize:1.2.0",
@@ -1271,632 +752,94 @@
         "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
     },
     {
-        "id": "foreground-child:2.0.0",
+        "id": "minimatch:3.1.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
+                "glob:7.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
-                "spawn-wrap:2.0.0",
+                "test-exclude:6.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
-        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
-        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
+        "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+        "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+        "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
     },
     {
-        "id": "chalk:2.4.2",
+        "id": "@babel/compat-data:7.18.8",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+        "sha1": "2483f565faca607b8535590e84e7de323f27764d",
+        "md5": "7088ff85d6c89dea757ce152c9150565",
+        "sha256": "5756345fc4fe02547f9355988f4f923a0ca9ad868cca748a8cd94b9fdd202a5e"
     },
     {
-        "id": "@babel/helper-get-function-arity:7.12.13",
+        "id": "@babel/helper-validator-option:7.18.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "bc63451d403a3b3082b97e1d8b3fe5bd4091e583",
-        "md5": "7a40ffef4058eead9c8b98d56d03ccc4",
-        "sha256": "516342bff750abb2e2200520e63156dbf7b58cd3764cf5a26517a0c45ec32b9f"
+        "sha1": "bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8",
+        "md5": "d22673cb3b1ea3e3127bb12d507a036c",
+        "sha256": "3efdfe87e7e6830c5091ee369a27368e263d9dab8cfc7f0f41e7f9b9c5aec9cf"
     },
     {
-        "id": "js-yaml:4.1.0",
+        "id": "source-map:0.6.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
-        "md5": "fba4491839b7fa47c38f639ac243b22d",
-        "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
-    },
-    {
-        "id": "istanbul-lib-source-maps:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "istanbul-lib-source-maps:4.0.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9",
-        "md5": "fc78a9f50db7d57da55a839bac0e65da",
-        "sha256": "001db60e8967172df66953d5377a521fa02f167d8bdf3c25a748d8eb896f7fd8"
+        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
+        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
     },
     {
-        "id": "rimraf:3.0.2",
+        "id": "path-key:3.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
-        "md5": "c794495fee118854a7cbd585a19a0fa8",
-        "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
-    },
-    {
-        "id": "is-binary-path:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
-        "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
-        "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
-    },
-    {
-        "id": "is-stream:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bde9c32680d6fae04129d6ac9d921ce7815f78e3",
-        "md5": "d4612a02df79da69a9743e26e8a37da6",
-        "sha256": "d6412611e731caafb1796ca17f9aa3104e8ae72517d122c2b313bcf2bb43de54"
-    },
-    {
-        "id": "process-on-spawn:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-preload:0.2.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
-        "md5": "acaca9f6065528d5b79d3d3501b5a745",
-        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
-    },
-    {
-        "id": "ansi-regex:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:6.0.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "388539f55179bf39339c81af30a654d69f87cb75",
-        "md5": "69fd1c7bc68c850139d20aefed955a71",
-        "sha256": "6ee1bda34e578b6da23ca5ffda9dc971748c3c542f5fa999f818df5dc0323b99"
-    },
-    {
-        "id": "@types/mocha:9.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3205bcd15ada9bc681ac20bef64e9e6df88fd297",
-        "md5": "bf15e99c50d65300ef0110e5742ea07b",
-        "sha256": "077e99cc0d2957b15ce5620565b49e790cf4bda0243883af048d72e90cedc05b"
-    },
-    {
-        "id": "path-exists:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
-        "md5": "d3652d47b80b1aa623e820d7d276b27b",
-        "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
-    },
-    {
-        "id": "workerpool:6.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0f7cf076b6215fd7e1da903ff6f22ddd1886b581",
-        "md5": "d94ad5a124d3e57d0a4d9367ab982088",
-        "sha256": "dbe03b6ff8657ea015656292577c97fbc8d628fe24794799f751a66d753a70aa"
-    },
-    {
-        "id": "is-fullwidth-code-point:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
-        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
-        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
-    },
-    {
-        "id": "p-limit:2.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
-        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
-        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
-    },
-    {
-        "id": "debug:4.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
-        "md5": "690937c36f84e02c3d67193c2b867b76",
-        "sha256": "34ccfe056d27979867bc08e7449f3a2b1170e9d16591532d4202fb08eb39a38c"
-    },
-    {
-        "id": "json5:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "2dfefe720c6ba525d9ebd909950f0515316c89a3",
-        "md5": "e4711e39d31c4887d0c727ee258c7b40",
-        "sha256": "37875a2bd12417df58f547acc8b909db3a2cb437511f44516a6871e344c0b1fe"
-    },
-    {
-        "id": "to-regex-range:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:7.0.1",
-                "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
-        "md5": "5ef0a1bd28f353c14bf940103a879257",
-        "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "which:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
             [
                 "cross-spawn:7.0.3",
                 "foreground-child:2.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
             ]
         ],
-        "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
-        "md5": "9556a736013ff5223cc9731d9f32b55f",
-        "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
-    },
-    {
-        "id": "p-locate:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
-        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
-        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "escape-string-regexp:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
-        "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
-        "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
-    },
-    {
-        "id": "supports-color:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
-        "md5": "da58ae58b985905e1445bc447625dc1b",
-        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
-    },
-    {
-        "id": "package-hash:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
-        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
-        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
-    },
-    {
-        "id": "is-typedarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "typedarray-to-buffer:3.1.5",
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
-        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
-        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
-    },
-    {
-        "id": "cross-spawn:7.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
-        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
-        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
-    },
-    {
-        "id": "he:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
-        "md5": "59dd519e72954845f5a01d23c2695903",
-        "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
-    },
-    {
-        "id": "picomatch:2.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "readdirp:3.6.0",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1f061de8f6a4bf022892e2d128234fb98302972",
-        "md5": "21b93be8448e9e1f9167e305ad1b4c79",
-        "sha256": "ec81cbb36546358b4369be6521148b129569dc0a51fd0154af618326f89a3596"
-    },
-    {
-        "id": "has-flag:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:7.2.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:8.1.1",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:7.2.0",
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
-        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
-        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
+        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
+        "md5": "4f4b9beb2d53481341e16133a8570dc5",
+        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
     },
     {
         "id": "yargs-unparser:2.0.0",
@@ -1905,163 +848,13 @@
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
         "sha1": "f131f9226911ae5d9ad38c432fe809366c2325eb",
         "md5": "f9482cf08bacd4b85c2f4aa27215e73b",
         "sha256": "c9224d53839022b885216ed18127198abc15e38a242ced14d74b11fafc0ba97c"
-    },
-    {
-        "id": "wrap-ansi:7.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
-        "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
-        "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
-    },
-    {
-        "id": "graceful-fs:4.2.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ff040b2b0853b23c3d31027523706f1885d76bee",
-        "md5": "daa4c01f4d01fa7976a43c17cf2f9454",
-        "sha256": "25334251eddf26a85b59b6c7c994b954cbae4831640881fba46bef3f26cbe537"
-    },
-    {
-        "id": "shebang-command:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
-        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
-        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "normalize-path:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
-        "md5": "2821b760c1df5dcc38328f154a6ea3cb",
-        "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
-    },
-    {
-        "id": "lodash:4.17.21",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
-        "md5": "25247d3dd7029d08a6ac99adab09086b",
-        "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
-    },
-    {
-        "id": "@babel/helper-module-imports:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ec67e4404f41750463e455cc3203f6a32e93fcb0",
-        "md5": "e2c6246894aa90be1363b5a444fe4f2a",
-        "sha256": "68b836938f51fac48c1bd8d6d70ed65e76ee52d31798b57ef728d1530c8746c8"
     },
     {
         "id": "ansi-regex:5.0.1",
@@ -2073,7 +866,7 @@
                 "strip-ansi:6.0.1",
                 "cliui:7.0.4",
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
@@ -2082,52 +875,113 @@
         "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
     },
     {
-        "id": "require-main-filename:2.0.0",
+        "id": "@jridgewell/resolve-uri:3.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:15.4.1",
+                "@jridgewell/trace-mapping:0.3.14",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
-        "md5": "8b45166659a670e83387649f79c641ad",
-        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
+        "sha1": "2203b118c157721addfe69d47b70465463066d78",
+        "md5": "bdc32c6b7d0a978faf304b94ba607f93",
+        "sha256": "fe4cb2ab38b4813b27926d9e08852ad81d8c14d0034cfa4a23555ec134ee16b0"
     },
     {
-        "id": "y18n:4.0.1",
+        "id": "color-name:1.1.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "yargs:15.4.1",
+                "color-convert:1.9.3",
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "8db2b83c31c5d75099bb890b23f3094891e247d4",
-        "md5": "cb26f5963c1a3702dbb487448bd1f052",
-        "sha256": "cd11c323020c227a1dbebbae09c435d255a12a62586789129e5f178694f49fd8"
+        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "md5": "b45186c4fe76a2450ec484149ade0066",
+        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
     },
     {
-        "id": "glob-parent:5.1.2",
+        "id": "caniuse-lite:1.0.30001368",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
-        "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
-        "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
+        "sha1": "c5c06381c6051cd863c45021475434e81936f713",
+        "md5": "1762454bac8432336003f3f2740b008b",
+        "sha256": "174dceca41249223bdf0923ef3065692bb095161607d0ca5376ab63305b76e92"
+    },
+    {
+        "id": "semver:6.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "make-dir:3.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
+        "md5": "e0836faadf4b192c3987c5117d62fff6",
+        "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
+    },
+    {
+        "id": "@ungap/promise-all-settled:1.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
+        "md5": "b2752b39b9322878e731606f6ec568a1",
+        "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
     },
     {
         "id": "yargs-parser:20.2.4",
@@ -2136,96 +990,18 @@
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
         "sha1": "b42890f14566796f85ae8e3a25290d205f154a54",
         "md5": "dded5e7456c94ffc7f4ffddddcac0681",
         "sha256": "4fe61652a7e5375530ef19f941238fec925f34c7cad78f45bc73afad66bd0121"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "convert-source-map:1.7.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "rimraf:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "randombytes:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "serialize-javascript:6.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
-        "md5": "efb164d8addf215512a3bb6dd19a1496",
-        "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
     },
     {
         "id": "es6-error:4.1.1",
@@ -2246,124 +1022,260 @@
         "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
     },
     {
-        "id": "find-cache-dir:3.3.1",
+        "id": "convert-source-map:1.8.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "89b33fad4a4670daa94f855f7fbe31d6d84fe880",
-        "md5": "d3957f330dbccdcb14916e19c68ad692",
-        "sha256": "c78bf4bf2e8a6d55e7d41cd5f3ead9ef1d0b03e47cfa60ceb0b2cf7f8be1da0e"
-    },
-    {
-        "id": "commondir:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
-        "md5": "329b8682e83ec34dfe1c58ae90b84988",
-        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
-    },
-    {
-        "id": "@babel/traverse:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
+        "md5": "d1c553aaaffba79be7073471b2619511",
+        "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
+    },
+    {
+        "id": "json5:2.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "655d50ed1e6f95ad1a3caababd2b0efda10b395c",
+        "md5": "e7d2fc3e0299d8005b5f7f46161cc227",
+        "sha256": "1d044eb7a06ddb2429366e0630dd884d1e57f116e3704b293631fa4dde045a59"
+    },
+    {
+        "id": "diff:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
+        "md5": "a6db67e2eeb11fd4cf5135da638e2157",
+        "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
+    },
+    {
+        "id": "color-convert:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ansi-styles:4.3.0",
+                "chalk:4.1.2",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+        "md5": "0248ebc952524207e296a622372faa1f",
+        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
+    },
+    {
+        "id": "has-flag:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-color:7.2.0",
+                "chalk:4.1.2",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "supports-color:8.1.1",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "supports-color:7.2.0",
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
+        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
+        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
+    },
+    {
+        "id": "which:2.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "cross-spawn:7.0.3",
+                "foreground-child:2.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
+        "md5": "9556a736013ff5223cc9731d9f32b55f",
+        "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
+    },
+    {
+        "id": "camelcase:6.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs-unparser:2.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "5685b95eb209ac9c0c177467778c9c84df58ba9a",
+        "md5": "cde9397a5c3cbfcdb6a5e559f5c00cd4",
+        "sha256": "2851fe487cf5607b5196895b13d6db4620200b225eec753897a9759f8912adb6"
+    },
+    {
+        "id": "nyc:15.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
+        "md5": "28c5baf103508c15fc352a367910f0c4",
+        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
+    },
+    {
+        "id": "resolve-from:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "689f0e4b4c08587ad26622832632735fb8c4e0c0",
-        "md5": "cba92dc1fa690a08b0973ce36cb0b3af",
-        "sha256": "b4fcdc925b833ad532b6e68a276c6f1b9b5d26d07c63464c8f00dddc82f06be7"
+        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
+        "md5": "23cff3fc62d9dd916e67da9c9505603f",
+        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
     },
     {
-        "id": "to-fast-properties:2.0.0",
+        "id": "find-cache-dir:3.3.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
-        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
-        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+        "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
+        "md5": "52bbc85bfe0ddab6259eb6618900ab61",
+        "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
     },
     {
-        "id": "source-map:0.6.1",
+        "id": "inherits:2.0.4",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
+                "glob:7.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
-        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
-        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
+        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
     },
     {
-        "id": "argparse:2.0.1",
+        "id": "esprima:4.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "js-yaml:4.1.0",
-                "mocha:9.1.3",
+                "js-yaml:3.14.1",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
-        "md5": "864f41f5cacfed3315deeba37ba7954b",
-        "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
+        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+        "md5": "c9d44a818c324d707a81b08dd36cd079",
+        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+        "id": "default-require-extensions:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "append-transform:2.0.0",
+                "istanbul-lib-hook:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
+        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
+        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
+    },
+    {
+        "id": "node-preload:0.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
+        "md5": "120f936cf9cfb9aaf63819850ee25dab",
+        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
     },
     {
         "id": "cliui:6.0.0",
@@ -2380,6 +1292,38 @@
         "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
         "md5": "9065a0615794d52f19cffa078701d382",
         "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
+    },
+    {
+        "id": "flat:5.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs-unparser:2.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
+        "md5": "c215e59da15d7b8eccb1db3e47366cb5",
+        "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
+    },
+    {
+        "id": "cliui:7.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
+        "md5": "c3a8fba555857874ad0dffba34a2289f",
+        "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
     },
     {
         "id": "lodash.flattendeep:4.4.0",
@@ -2399,725 +1343,13 @@
         "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
     },
     {
-        "id": "@babel/generator:7.12.15",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4617b5d0b25cc572474cc1aafee1edeaf9b5368f",
-        "md5": "76f9f743c12a36ed324ac0957e3194ff",
-        "sha256": "c0c80724343fde3d974a40d37dc1362473fa078f85eccdda032190e827146a16"
-    },
-    {
-        "id": "@babel/helper-simple-access:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4",
-        "md5": "e84bc3d78539d7dfdf173b23509b9110",
-        "sha256": "2e4854abdaebdb65d6fde6d39cf8606245a8e8f89c922eab28166433d6cd2105"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "growl:1.10.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
-        "md5": "47fb3a576f5916564687b683b1bcea68",
-        "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "typedarray-to-buffer:3.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
-        "md5": "d693220f5eabe1359169bb992abaa064",
-        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
-    },
-    {
-        "id": "@babel/highlight:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8ab538393e00370b26271b01fa08f7f27f2e795c",
-        "md5": "55ef0df1b744cf4957c1ac4c8283ad13",
-        "sha256": "0b7c3a161e990fc34f22549b01436e8116c2d0038e47b6aaecb27be602ea852d"
-    },
-    {
-        "id": "html-escaper:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-reports:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
-        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
-        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "debug:4.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f0a49c18ac8779e31d4a0c6029dfb76873c7428b",
-        "md5": "e6cb523b95d83bb1d087255046eb4d0b",
-        "sha256": "06b5b98471dc02410003e8bf34cf9e96afbadc30a83b19f5c9376faa817fa7bb"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "safe-buffer:5.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randombytes:2.1.0",
-                "serialize-javascript:6.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
-        "md5": "ea7cf66fcf04485e195b1bd3a3551fc9",
-        "sha256": "5d181804516c4a693a384272a7bd0e42d17e0d4b301ccfbe408669ccafdcb3e8"
-    },
-    {
-        "id": "emoji-regex:8.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
-        "md5": "598b731d8d33cfff04377ad55da187b0",
-        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
-    },
-    {
-        "id": "nyc:15.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
-        "md5": "28c5baf103508c15fc352a367910f0c4",
-        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
-    },
-    {
-        "id": "istanbul-lib-instrument:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
-        "md5": "ee314a8a3153abd9396916f9e141d374",
-        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
-    },
-    {
-        "id": "@babel/code-frame:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dcfc826beef65e75c50e21d3837d7d95798dd658",
-        "md5": "6727735f1d373c0716142eb14e7260e3",
-        "sha256": "b5faeba1c9a62366179479a572b09a898a78e5d4dd07e06c98318a48dac0236f"
-    },
-    {
-        "id": "@babel/helper-function-name:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a",
-        "md5": "e71e30bb9170aca538674078c5cf4188",
-        "sha256": "f8fe08fb616ea9442dbf6ef6fff18970188705d2f41a2e120e8c6472c49608cb"
-    },
-    {
-        "id": "chokidar:3.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dba3976fcadb016f66fd365021d91600d01c1e75",
-        "md5": "99944b98cf9fc62c83010c80c2c12e7b",
-        "sha256": "5e3a0ebe621c47dc9348991eaed90e59221d40edd555556df15e46b3b36888da"
-    },
-    {
-        "id": "node-preload:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
-        "md5": "120f936cf9cfb9aaf63819850ee25dab",
-        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "clean-stack:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
-        "md5": "98495454e4106c25e5ed97ae9a6b1148",
-        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
-    },
-    {
-        "id": "flat:5.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
-        "md5": "c215e59da15d7b8eccb1db3e47366cb5",
-        "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
-    },
-    {
-        "id": "yocto-queue:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:3.1.0",
-                "p-locate:5.0.0",
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
-        "md5": "69e27040e38c5b03127488546dc282ea",
-        "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
-    },
-    {
-        "id": "yargs:16.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
-        "md5": "23787ef1801c6394b3bdee59580dd6c8",
-        "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
-    },
-    {
-        "id": "type-fest:0.8.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
-        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
-        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
-    },
-    {
-        "id": "release-zalgo:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
-        "md5": "2e431e2016bfc667a21974c2c818d769",
-        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
-    },
-    {
-        "id": "istanbul-lib-hook:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
-        "md5": "5602d9c25a554fbcca017c4df471866e",
-        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
-    },
-    {
-        "id": "js-tokens:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
-        "md5": "325b11b965688c69ae45a3cf771fbc5c",
-        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
-    },
-    {
-        "id": "@babel/types:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-imports:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-member-expression-to-functions:7.12.16",
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-optimise-call-expression:7.12.13",
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-simple-access:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-split-export-declaration:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-get-function-arity:7.12.13",
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8be1aa8f2c876da11a9cf650c0ecf656913ad611",
-        "md5": "3ce6b4a1e29cf8b4ef61d92e899b05a0",
-        "sha256": "2843deaf5baef5bacee86f17b2814c64668a42fba87c8e0a14f7e224022458d5"
-    },
-    {
-        "id": "readdirp:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
-        "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
-        "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
-    },
-    {
-        "id": "locate-path:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
-        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
-        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
-    },
-    {
-        "id": "@babel/core:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8c6ba456b23b680a6493ddcfcd9d3c3ad51cab7c",
-        "md5": "fc251c62b2de391930fd421ca5debd1b",
-        "sha256": "407b393b5e00eecf5f597665815fd196395479958f18be218a932374aa339d12"
-    },
-    {
-        "id": "log-symbols:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
-        "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
-        "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
-    },
-    {
-        "id": "get-package-type:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
-        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
-        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
-    },
-    {
         "id": "pkg-dir:4.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "find-cache-dir:3.3.1",
+                "find-cache-dir:3.3.2",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
@@ -3127,167 +1359,66 @@
         "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
     },
     {
-        "id": "color-convert:1.9.3",
+        "id": "append-transform:2.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "istanbul-lib-hook:3.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
+        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
+        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
     },
     {
-        "id": "@babel/helper-replace-supers:7.12.13",
+        "id": "browser-stdout:1.3.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
+        "md5": "82ebb0cdcee39bc8953381ac71cad549",
+        "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
+    },
+    {
+        "id": "set-blocking:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "00ec4fb6862546bd3d0aff9aac56074277173121",
-        "md5": "1b61afebfcef69d7e33415f68fce3913",
-        "sha256": "774bb7c311010fc27d82dd8546b22e3fa7c5af922928ca86a9377807e57dda54"
+        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "md5": "ff057cf430b35ecb25780f94cd051ab3",
+        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
     },
     {
-        "id": "string-width:4.2.3",
+        "id": "strip-json-comments:3.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
-        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
-        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
-    },
-    {
-        "id": "ms:2.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "nanoid:3.1.25",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09ca32747c0e543f0e1814b7d3793477f9c8e152",
-        "md5": "cf82465d90a5f488901aa5b70eeed864",
-        "sha256": "1835a342a119a6ad8bcff0c9290ff73d87c8f6f760a16a32de6adec2f3e04a2d"
+        "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
+        "md5": "58e65c07bc47365a2acc9129b810130c",
+        "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
     },
     {
         "id": "get-caller-file:2.0.5",
@@ -3297,7 +1428,7 @@
         "requestedBy": [
             [
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
@@ -3329,163 +1460,318 @@
         "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
     },
     {
-        "id": "fromentries:1.3.2",
+        "id": "rimraf:3.0.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "process-on-spawn:1.0.0",
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "spawn-wrap:2.0.0",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
-        "md5": "f13c076f7541b0f2993f537b46768314",
-        "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
+        "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
+        "md5": "c794495fee118854a7cbd585a19a0fa8",
+        "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
     },
     {
-        "id": "yargs-parser:18.1.3",
+        "id": "html-escaper:2.0.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
+            [
+                "istanbul-reports:3.1.5",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
+        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
+        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
+    },
+    {
+        "id": "find-up:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
+        "md5": "f30df2388d75158c7361f549edfe9bef",
+        "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
+    },
+    {
+        "id": "p-locate:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "locate-path:6.0.0",
+                "find-up:5.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
+        "md5": "f179aa668706b232c29cb580eea96619",
+        "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
+    },
+    {
+        "id": "chalk:4.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
+        "md5": "cf76e256de1debce9c7a21cd18df954d",
+        "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
+    },
+    {
+        "id": "isexe:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "which:2.0.2",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+        "id": "find-up:4.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "pkg-dir:4.2.0",
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
             [
                 "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
-        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
-        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
+        "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
+        "md5": "aa0b377135f4af38d106db8b84606924",
+        "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
     },
     {
-        "id": "braces:3.0.2",
+        "id": "commondir:1.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
-        "md5": "3ed11e666a13cb0da288c6f445b2601f",
-        "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
-    },
-    {
-        "id": "browser-stdout:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
-        "md5": "82ebb0cdcee39bc8953381ac71cad549",
-        "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
-    },
-    {
-        "id": "anymatch:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
-        "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
-        "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
-    },
-    {
-        "id": "ms:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:4.3.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "debug:4.3.1",
-                "istanbul-lib-source-maps:4.0.0",
+                "find-cache-dir:3.3.2",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
-        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
-        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
+        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "md5": "329b8682e83ec34dfe1c58ae90b84988",
+        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
     },
     {
-        "id": "locate-path:6.0.0",
+        "id": "@babel/types:7.18.9",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "55321eb309febbc59c4801d931a72452a681d286",
-        "md5": "88dec34f94138c96fd50374b3ff54935",
-        "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "convert-source-map:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/core:7.12.16",
+                "@babel/helper-module-imports:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-simple-access:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-split-export-declaration:7.18.6",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-function-name:7.18.9",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-hoist-variables:7.18.6",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "17a2cb882d7f77d3490585e2ce6c524424a3a442",
-        "md5": "0e5204f1f071e85179a46cb16f500ac1",
-        "sha256": "2c691638758a2d21562c31b10f2784d8be585158da080877ea7b6da0d82503d9"
+        "sha1": "7148d64ba133d8d73a41b3172ac4b83a1452205f",
+        "md5": "a9bbb05787a9f2f0310fba1d42f84320",
+        "sha256": "1b309d075c4970b84308ab5055b56335e117969d4c9fbb34140adf3e6e4ac63a"
+    },
+    {
+        "id": "is-extglob:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-glob:4.0.3",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+        "id": "safe-buffer:5.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "randombytes:2.1.0",
+                "serialize-javascript:6.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "convert-source-map:1.8.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "md5": "dc7142b470e0957c5c34098b6fced0ab",
+        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+        "id": "@babel/code-frame:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "3b25d38c89600baa2dcc219edfa88a74eb2c427a",
+        "md5": "06bf74bedad2a91ac5c5950ee0d527a4",
+        "sha256": "069544665ad7c8eb0fd72fd2ebf2c651454fce88768e3a8d203041865e729977"
     },
     {
         "id": "wrap-ansi:6.2.0",
@@ -3505,65 +1791,6 @@
         "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
     },
     {
-        "id": "mocha:9.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a623be6b323810493d8c8f6f7667440fa469fdb",
-        "md5": "6d0631780adf286526d8e07e316cfe2c",
-        "sha256": "5c2b78c19bb5508986be1cbb3a0eda7e291b804fbda9307669505d2767a59953"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:2.0.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "string-width:4.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "952182c46cc7b2c313d1596e623992bd163b72b5",
-        "md5": "d7e1202535d01c2d692f15b4259d6130",
-        "sha256": "b6b0c19edc66b57cea414591d74a0ea206b4baa1deebbf4b06193759f6233e3e"
-    },
-    {
         "id": "wrappy:1.0.2",
         "scopes": [
             "dev"
@@ -3571,14 +1798,14 @@
         "requestedBy": [
             [
                 "inflight:1.0.6",
-                "glob:7.1.7",
-                "mocha:9.1.3",
+                "glob:7.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
                 "once:1.4.0",
-                "glob:7.1.7",
-                "mocha:9.1.3",
+                "glob:7.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
@@ -3587,22 +1814,1498 @@
         "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
     },
     {
-        "id": "supports-color:8.1.1",
+        "id": "js-yaml:4.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
-        "md5": "16e8e38709a4675f8ea1482806cb050c",
-        "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
+        "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
+        "md5": "fba4491839b7fa47c38f639ac243b22d",
+        "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
     },
     {
-        "id": "path-key:3.1.1",
+        "id": "is-plain-obj:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs-unparser:2.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
+        "md5": "23b716d73535a85a95b57d53d7ac5df6",
+        "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
+    },
+    {
+        "id": "graceful-fs:4.2.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+        "md5": "094ac6976c4cec6cced67915d6c726c0",
+        "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+        "id": "signal-exit:3.0.7",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "foreground-child:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "a9a1767f8af84155114eaabd73f99273c8f59ad9",
+        "md5": "05cf0ff414a9fc6e30abb6d20780c762",
+        "sha256": "439623fa6aab91600615ec757eaa137fcab40d3b35dda38df7444c15678f20a8"
+    },
+    {
+        "id": "indent-string:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "aggregate-error:3.1.0",
+                "p-map:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
+        "md5": "ad188c269f2d9181da4321f8803a4cde",
+        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
+    },
+    {
+        "id": "yargs:15.4.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
+        "md5": "091d0cc9d7347925d73455bd991e6639",
+        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
+    },
+    {
+        "id": "braces:3.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
+        "md5": "3ed11e666a13cb0da288c6f445b2601f",
+        "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
+    },
+    {
+        "id": "escape-string-regexp:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
+        "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
+        "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
+    },
+    {
+        "id": "minimatch:4.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "40d9d511a46bdc4e563c22c3080cde9c0d8299b4",
+        "md5": "145e5c35d2aa8d7ade9fcfd6cac624b2",
+        "sha256": "2afcebdaa72e6a049a8b37600f996b86a27e8c755bdb442d8eccd2f2746639b5"
+    },
+    {
+        "id": "balanced-match:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "brace-expansion:1.1.11",
+                "minimatch:4.2.1",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+        "id": "wrap-ansi:7.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cliui:7.0.4",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
+        "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
+        "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
+    },
+    {
+        "id": "type-fest:0.8.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "hasha:5.2.2",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
+        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
+        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
+    },
+    {
+        "id": "shebang-regex:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "shebang-command:2.0.0",
+                "cross-spawn:7.0.3",
+                "foreground-child:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
+        "md5": "800d00b53670160a44fa6116b1cbb6e5",
+        "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
+    },
+    {
+        "id": "istanbul-lib-processinfo:2.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "366d454cd0dcb7eb6e0e419378e60072c8626169",
+        "md5": "6053742aadc8e3ef55d8808d24ef2b59",
+        "sha256": "4df1e5e9927bb39e18ed3a2d2d567c8e66ce54ded31704e36d34d1d70697f99c"
+    },
+    {
+        "id": "fill-range:7.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "braces:3.0.2",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
+        "md5": "279e60751b8b0e89226a9e9bd5b8f275",
+        "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
+    },
+    {
+        "id": "glob-parent:5.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
+        "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
+        "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
+    },
+    {
+        "id": "path-exists:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-up:5.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "find-up:4.1.0",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "find-up:4.1.0",
+                "pkg-dir:4.2.0",
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
+        "md5": "d3652d47b80b1aa623e820d7d276b27b",
+        "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
+    },
+    {
+        "id": "log-symbols:4.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
+        "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
+        "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
+    },
+    {
+        "id": "emoji-regex:8.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "string-width:4.2.3",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
+        "md5": "598b731d8d33cfff04377ad55da187b0",
+        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
+    },
+    {
+        "id": "@babel/parser:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/template:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f2dde0c682ccc264a9a8595efd030a5cc8fd2539",
+        "md5": "374150ff1ab6268dd1248d12950e392d",
+        "sha256": "a4fba8f4f3542a6b44e848fa989ba96e4ad4ee2c1020139c3dc0093260ba2ecc"
+    },
+    {
+        "id": "fsevents:2.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "8a526f78b8fdf4623b709e0b975c52c24c02fd1a",
+        "md5": "3cf04486705de7ad22df4b2e51ec4893",
+        "sha256": "e17ade950c193fe09adfc7915fe29ac26166c8782d00e7c3879e7e9de02c5428"
+    },
+    {
+        "id": "ms:2.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+        "md5": "a50e4bf82f754914316bfca3dfbcf352",
+        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+        "id": "make-dir:3.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-report:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
+        "md5": "e47d13370c2b27671a13f28ebc27585f",
+        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
+    },
+    {
+        "id": "package-hash:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
+        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
+        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
+    },
+    {
+        "id": "update-browserslist-db:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "be06a5eedd62f107b7c19eb5bcefb194411abf38",
+        "md5": "2a4f39c3cad79d0f127387a479d7348c",
+        "sha256": "44ce49ceb80c9b30c8860ae914df75cc88b8a0a65a2aa471f87659af97777a15"
+    },
+    {
+        "id": "to-fast-properties:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/types:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
+        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
+        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+    },
+    {
+        "id": "is-glob:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob-parent:5.1.2",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+        "id": "he:1.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
+        "md5": "59dd519e72954845f5a01d23c2695903",
+        "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
+    },
+    {
+        "id": "require-directory:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "md5": "f3a9010155b6a46066afbe2d07f624bd",
+        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+        "id": "release-zalgo:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "package-hash:4.0.0",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
+        "md5": "2e431e2016bfc667a21974c2c818d769",
+        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
+    },
+    {
+        "id": "@ampproject/remapping:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "56c133824780de3174aed5ab6834f3026790154d",
+        "md5": "f89dd9045903be2cc7c10b3c31e75626",
+        "sha256": "2f2dacc9e8ed33330e4ad095403b9efb51736e06f9c57baf0ca73058406bb890"
+    },
+    {
+        "id": "chalk:2.4.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+        "id": "jsesc:2.5.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
+        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
+        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
+    },
+    {
+        "id": "archy:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+        "md5": "b2a24c65e2212f53168f984b5a693dbd",
+        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
+    },
+    {
+        "id": "debug:4.3.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-source-maps:4.0.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
+        "md5": "e0e3067fdf8e98f4d817683191280e8e",
+        "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
+    },
+    {
+        "id": "inflight:1.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+        "id": "istanbul-lib-hook:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
+        "md5": "5602d9c25a554fbcca017c4df471866e",
+        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
+    },
+    {
+        "id": "istanbul-lib-instrument:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
+        "md5": "ee314a8a3153abd9396916f9e141d374",
+        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
+    },
+    {
+        "id": "@babel/core:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "805461f967c77ff46c74ca0460ccf4fe933ddd59",
+        "md5": "414e3ac6524d22ef6fe284e456051fb9",
+        "sha256": "9a1831b17a6a6b8524ffd957c70deb5b12f2ec90869c0b3b0bacd201bfbc338b"
+    },
+    {
+        "id": "@babel/traverse:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "deeff3e8f1bad9786874cb2feda7a2d77a904f98",
+        "md5": "4e01105ee87a3406c4a9c3617ebdba42",
+        "sha256": "a9d2fd8aa3dccf55f8057d42d02d620960875c5d283a7fc0f941afbd5680ac2d"
+    },
+    {
+        "id": "@babel/helpers:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "4bef3b893f253a1eced04516824ede94dcfe7ff9",
+        "md5": "029dea1cf8f08d6602536f2650d9f25c",
+        "sha256": "912bfc1b1aaea6ffb32155c8f7c783ccf48d80a04b9ad9853080b4a10206d8d4"
+    },
+    {
+        "id": "@babel/helper-hoist-variables:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d4d2c8fb4baeaa5c68b99cc8245c56554f926678",
+        "md5": "f10ece88fdea253c1678a09bdfa85160",
+        "sha256": "cd91a6aef86fb2089e6798c395dffa5d59ca2801e348ef6259f78882082707ec"
+    },
+    {
+        "id": "readdirp:3.6.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
+        "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
+        "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
+    },
+    {
+        "id": "y18n:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
+        "md5": "182c1f29baf6577adccaf23ac94d5ed1",
+        "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
+    },
+    {
+        "id": "istanbul-reports:3.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "cc9a6ab25cb25659810e4785ed9d9fb742578bae",
+        "md5": "37a18bd3f4140ff1690f1048aef18171",
+        "sha256": "a118d2013c68c83b81acabbfa2df3e2838e1e2f5a53d3045c208689540c48d85"
+    },
+    {
+        "id": "concat-map:0.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "brace-expansion:1.1.11",
+                "minimatch:4.2.1",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+        "id": "@babel/helper-compilation-targets:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf",
+        "md5": "e4bb285eb8cfaafeb0964e277713e836",
+        "sha256": "b1045536c086bdc82da52399401e7fabeacf8c52f38c653f04e921d3def4b74f"
+    },
+    {
+        "id": "@babel/helper-function-name:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "940e6084a55dee867d33b4e487da2676365e86b0",
+        "md5": "5a360d6490679bc8050ae8342bce1d68",
+        "sha256": "089fc866e1349e85fe331ddf5388afae1d42271fe105a3951024fe6b55f88e0b"
+    },
+    {
+        "id": "fromentries:1.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "process-on-spawn:1.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
+        "md5": "f13c076f7541b0f2993f537b46768314",
+        "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
+    },
+    {
+        "id": "which-module:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "md5": "ce028f30082fbbea9861a40437d17bd3",
+        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
+    },
+    {
+        "id": "ms:2.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "debug:4.3.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
+        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
+        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
+    },
+    {
+        "id": "p-try:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "p-limit:2.3.0",
+                "p-locate:4.1.0",
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "p-limit:2.3.0",
+                "p-locate:4.1.0",
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "pkg-dir:4.2.0",
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "p-limit:2.3.0",
+                "p-locate:4.1.0",
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
+        "md5": "49994562e1f3cbe260710598cbb3edf7",
+        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
+    },
+    {
+        "id": "color-convert:1.9.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+        "id": "browserslist:4.21.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "59a400757465535954946a400b841ed37e2b4ecf",
+        "md5": "b7595f1787cc1f79d334efbfd10c7b0e",
+        "sha256": "cf0524be457eb24273a426cdf6651af11a8df6817bcb284366b0889591473f65"
+    },
+    {
+        "id": "serialize-javascript:6.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
+        "md5": "900d6fc6f653ed171f0e54507edb0e43",
+        "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
+    },
+    {
+        "id": "once:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inflight:1.0.6",
+                "glob:7.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "glob:7.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+        "id": "workerpool:6.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "827d93c9ba23ee2019c3ffaff5c27fccea289e8b",
+        "md5": "a1e0bfe26fa42fcc8898777d366b3457",
+        "sha256": "5cbec29ff60e6176083cdfe869eaf15b32a2410746730b3ce424dc84e9f8472b"
+    },
+    {
+        "id": "escalade:3.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:16.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ],
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
+        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
+    },
+    {
+        "id": "caching-transform:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
+        "md5": "82a03704703e883379f146caa805b457",
+        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
+    },
+    {
+        "id": "globals:11.12.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
+        "md5": "712d15395573404a3ddb37ce395d948b",
+        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
+    },
+    {
+        "id": "fs.realpath:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+        "md5": "9f790d7180667e1d8d1110f2cf321b62",
+        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+        "id": "color-name:1.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "color-convert:2.0.1",
+                "ansi-styles:4.3.0",
+                "chalk:4.1.2",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
+        "md5": "a8d4412852471526b8027af2532d0d2b",
+        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
+    },
+    {
+        "id": "@types/mocha:9.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4",
+        "md5": "af8133831578083c75040f5ab0981fff",
+        "sha256": "6587cb469be76e37c4be6cf9d70b002c78b37025c599ef6ffe5c132d93a88d9d"
+    },
+    {
+        "id": "ansi-styles:3.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+        "id": "electron-to-chromium:1.4.196",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e18cdc5c1c2c2ebf78da237d0c374cc3b244d4cb",
+        "md5": "e65dea46a634f06ef01bd9d9d84da73a",
+        "sha256": "fde9ab86721e9199b2a0b3ac946e4103ae1799a6813db0a4ef8881d0558750aa"
+    },
+    {
+        "id": "@babel/helper-module-imports:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1e3ebdbbd08aad1437b428c50204db13c5a3ca6e",
+        "md5": "3549438c2b0b59c539a58c4cb733f4a0",
+        "sha256": "9b450e94445d86395e12d74981be606bb90d4e92e99ae358093d1318d78c6568"
+    },
+    {
+        "id": "gensync:1.0.0-beta.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
+        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
+        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
+    },
+    {
+        "id": "cross-spawn:7.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "foreground-child:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
+        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
+        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
+    },
+    {
+        "id": "randombytes:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "serialize-javascript:6.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
+        "md5": "efb164d8addf215512a3bb6dd19a1496",
+        "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
+    },
+    {
+        "id": "@istanbuljs/load-nyc-config:1.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
+        "md5": "d46010939e33d1d4e7dfce54fc60d89a",
+        "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
+    },
+    {
+        "id": "locate-path:5.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-up:4.1.0",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "find-up:4.1.0",
+                "pkg-dir:4.2.0",
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
+        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
+        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
+    },
+    {
+        "id": "js-yaml:3.14.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+        "md5": "2a522c3e23f7999abd8f852c012c20dd",
+        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+        "id": "@babel/helper-module-transforms:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "5a1079c005135ed627442df31a42887e80fcb712",
+        "md5": "19160955f01c62275ff14f0daa5706f6",
+        "sha256": "c6f2dbdfa8850bdbe650a350f419535e8cbb95339a0b15ab028e6a1b78ef2afc"
+    },
+    {
+        "id": "@babel/helper-environment-visitor:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "0c0cee9b35d2ca190478756865bb3528422f51be",
+        "md5": "62eaa04ce85291b537bd92b4cba422a3",
+        "sha256": "00aa1c2f172719e15df07a13833cd9632c51ec20ce87c68bfa10deff44545af3"
+    },
+    {
+        "id": "process-on-spawn:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "node-preload:0.2.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
+        "md5": "acaca9f6065528d5b79d3d3501b5a745",
+        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
+    },
+    {
+        "id": "binary-extensions:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-binary-path:2.1.0",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
+        "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
+        "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
+    },
+    {
+        "id": "yargs-parser:18.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
+        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
+        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
+    },
+    {
+        "id": "istanbul-lib-source-maps:4.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
+        "md5": "2b0cd1493c52493181871afc3c5a93be",
+        "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
+    },
+    {
+        "id": "test-exclude:6.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
+        "md5": "c9d2be086d4d740f9999b77971777008",
+        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
+    },
+    {
+        "id": "shebang-command:2.0.0",
         "scopes": [
             "dev"
         ],
@@ -3614,160 +3317,27 @@
                 "jfrogtest"
             ]
         ],
-        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
-        "md5": "4f4b9beb2d53481341e16133a8570dc5",
-        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
+        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
+        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
+        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
     },
     {
-        "id": "istanbul-lib-coverage:3.0.0",
+        "id": "ansi-styles:4.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nyc:15.1.0",
+                "chalk:4.1.2",
+                "log-symbols:4.1.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f5944a37c70b550b02a78a5c3b2055b280cec8ec",
-        "md5": "08af9082d6a9899699db1c8742ba1aa6",
-        "sha256": "0e39da48fc4d638d67545543b0d0ed604a41b9e977cc74e96bcd1010ff8db0af"
-    },
-    {
-        "id": "semver:6.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "make-dir:3.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
-        "md5": "e0836faadf4b192c3987c5117d62fff6",
-        "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
-    },
-    {
-        "id": "istanbul-reports:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d593210e5000683750cb09fc0644e4b6e27fd53b",
-        "md5": "1a146a208081fca710ec9ac5686ff870",
-        "sha256": "ac20ddc4f84e2135f064d94014e190d9a2d4f4b73e2f6b4513b896409d1bc1db"
-    },
-    {
-        "id": "fill-range:7.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
-        "md5": "279e60751b8b0e89226a9e9bd5b8f275",
-        "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
-    },
-    {
-        "id": "balanced-match:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "89b4d199ab2bee49de164ea02b89ce462d71b767",
-        "md5": "83d3f9f047e9700f6c4ac4028c4c5c53",
-        "sha256": "2896602c12d3cef566bfbed7ccdef79232f4f1e00622fc5c9b40737465baffad"
-    },
-    {
-        "id": "resolve-from:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
-        "md5": "23cff3fc62d9dd916e67da9c9505603f",
-        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
-    },
-    {
-        "id": "istanbul-lib-processinfo:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e1426514662244b2f25df728e8fd1ba35fe53b9c",
-        "md5": "93131ca838a58e819813b733c606bd8d",
-        "sha256": "7e529f7767219df1b357ae5b65949760f40516c6fd3743218c6b05b7ca86dd81"
-    },
-    {
-        "id": "strip-ansi:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
+                "wrap-ansi:7.0.0",
+                "cliui:7.0.4",
+                "yargs:16.2.0",
+                "mocha:9.2.2",
                 "jfrogtest"
             ],
             [
@@ -3776,111 +3346,408 @@
                 "yargs:15.4.1",
                 "nyc:15.1.0",
                 "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
             ]
         ],
-        "sha1": "0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
-        "md5": "767c76e38fb2bb82a3da65412b4610ad",
-        "sha256": "26bc5904a8e6afdf4d2d05d69fa91fec48879917582aa892029695506a0b5653"
+        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
+        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
+        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
     },
     {
-        "id": "@ungap/promise-all-settled:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
-        "md5": "b2752b39b9322878e731606f6ec568a1",
-        "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
-    },
-    {
-        "id": "is-extglob:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-glob:4.0.3",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "find-up:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
-        "md5": "f30df2388d75158c7361f549edfe9bef",
-        "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
-    },
-    {
-        "id": "glob:7.1.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3b193e9233f01d42d0b3f78294bbeeb418f94a90",
-        "md5": "b76e2faffe41be9df3f1ff4605ee1a63",
-        "sha256": "0504b3ddde68d1a93b4b9ef150cdff61e033df5f17cf7858c0d9fe1b412e9bee"
-    },
-    {
-        "id": "decamelize:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
-        "md5": "17113f86fb93e54ad64017cac7c80002",
-        "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
-    },
-    {
-        "id": "cliui:7.0.4",
+        "id": "y18n:5.0.8",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
                 "yargs:16.2.0",
-                "mocha:9.1.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
-        "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
-        "md5": "c3a8fba555857874ad0dffba34a2289f",
-        "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
+        "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+        "md5": "6018afaa99207dafc81cb56404a31454",
+        "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
+    },
+    {
+        "id": "p-locate:4.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "pkg-dir:4.2.0",
+                "find-cache-dir:3.3.2",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "locate-path:5.0.0",
+                "find-up:4.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
+        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
+        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
+    },
+    {
+        "id": "is-typedarray:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "typedarray-to-buffer:3.1.5",
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
+        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
+    },
+    {
+        "id": "escape-string-regexp:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "md5": "02440084832abe665260d5db1da1dd9e",
+        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+        "id": "@babel/generator:7.18.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "68337e9ea8044d6ddc690fb29acae39359cca0a5",
+        "md5": "ced102e1a657c80aeac9c54297b0c51a",
+        "sha256": "ecfd6a96062cf06c56236cc2ddbd02e8a978c883b6d1e68d7ec7b7acf833a2ee"
+    },
+    {
+        "id": "is-binary-path:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
+        "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
+        "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
+    },
+    {
+        "id": "imurmurhash:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write-file-atomic:3.0.3",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+        "id": "js-tokens:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
+        "md5": "325b11b965688c69ae45a3cf771fbc5c",
+        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
+    },
+    {
+        "id": "@jridgewell/gen-mapping:0.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9",
+        "md5": "de5b5402b140d1634f9bbf189b298ee3",
+        "sha256": "8176fad9663205ddefe81637fcc24097dded9716ad300a3d8ede3062e4cfc6fd"
+    },
+    {
+        "id": "picocolors:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "update-browserslist-db:1.0.5",
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
+        "md5": "743f01bf24bb6492555959fdeb7e9918",
+        "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
+    },
+    {
+        "id": "uuid:8.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "istanbul-lib-processinfo:2.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+        "md5": "001956ff1c0a16e6bae8bae042ba226b",
+        "sha256": "f630703647a5821c735a542edcf8d26c989724efe9d9912ab6f6836a1e79924a"
+    },
+    {
+        "id": "is-windows:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "md5": "bcc9525ed3558792d281951c90ad366e",
+        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+        "id": "is-stream:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "hasha:5.2.2",
+                "caching-transform:4.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
+        "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
+        "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
+    },
+    {
+        "id": "argparse:1.0.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "js-yaml:3.14.1",
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+        "id": "@jridgewell/sourcemap-codec:1.4.14",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@jridgewell/gen-mapping:0.1.1",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@jridgewell/trace-mapping:0.3.14",
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@jridgewell/gen-mapping:0.3.2",
+                "@babel/generator:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "add4c98d341472a289190b424efbdb096991bb24",
+        "md5": "b462c7a5932255e273725bf451bd36ce",
+        "sha256": "b7430e808b04aeba42441a44b783068c1923b8aa3f6f91fc1d789383b0c53941"
+    },
+    {
+        "id": "@babel/helper-validator-identifier:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/types:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "9c97e30d31b2b8c72a1d08984f2ca9b574d7a076",
+        "md5": "f4d15f6582c54e6a9ad8dfda2c073c6b",
+        "sha256": "110e5d9854308bafa7de7e79e31b4ab34b8720e44cd28adb66ab19b790d57e19"
+    },
+    {
+        "id": "has-flag:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-color:5.5.0",
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "md5": "1fa1fa951639c7058277abcecca86922",
+        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+        "id": "istanbul-lib-report:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "istanbul-reports:3.1.5",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
+        "md5": "87a16f7a36e489fdd042510550872167",
+        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
+    },
+    {
+        "id": "locate-path:6.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "find-up:5.0.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "55321eb309febbc59c4801d931a72452a681d286",
+        "md5": "88dec34f94138c96fd50374b3ff54935",
+        "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
     },
     {
         "id": "strip-bom:4.0.0",
@@ -3901,29 +3768,218 @@
         "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
     },
     {
-        "id": "@babel/helper-split-export-declaration:7.12.13",
+        "id": "@babel/template:7.18.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/helper-module-transforms:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ],
             [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
+                "@babel/helpers:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "@babel/helper-function-name:7.18.9",
+                "@babel/traverse:7.18.9",
+                "@babel/core:7.18.9",
                 "istanbul-lib-instrument:4.0.3",
                 "nyc:15.1.0",
                 "jfrogtest"
             ]
         ],
-        "sha1": "e9430be00baf3e88b0e13e6f9d4eaf2136372b05",
-        "md5": "8db09a6f5e6d9084dbf2df40154de08f",
-        "sha256": "c62fe860b48645cb4e2bdbe1089cc97a369f5dcc1970b42c6b9782f8da1ca818"
+        "sha1": "1283f4993e00b929d6e2d3c72fdc9168a2977a31",
+        "md5": "bc579b67a5099d381f57dc938f2c132d",
+        "sha256": "aef8c9facb86709c1cb53264cdeca13b86bb3eeeb53d86294f05fbfd54562e25"
+    },
+    {
+        "id": "spawn-wrap:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
+        "md5": "300df23ba641ba293cd9907ddf1b7552",
+        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
+    },
+    {
+        "id": "require-main-filename:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
+        "md5": "8b45166659a670e83387649f79c641ad",
+        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
+    },
+    {
+        "id": "nanoid:3.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "6347a18cac88af88f58af0b3594b723d5e99bb35",
+        "md5": "1a27cf077cc40c51811677adab047a31",
+        "sha256": "ad5542a3de899dbd0c2728a94b844ebb00794bb7762d3c1676de14de83f6135e"
+    },
+    {
+        "id": "path-is-absolute:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.0",
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "md5": "18bfccb10294ae19e7eb616ed1c05176",
+        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+        "id": "yargs:16.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "mocha:9.2.2",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+        "md5": "23787ef1801c6394b3bdee59580dd6c8",
+        "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
+    },
+    {
+        "id": "camelcase:5.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@istanbuljs/load-nyc-config:1.1.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "yargs-parser:18.1.3",
+                "yargs:15.4.1",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
+        "md5": "efcf73180d9b7001c92f574d4ae7f908",
+        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
+    },
+    {
+        "id": "foreground-child:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nyc:15.1.0",
+                "jfrogtest"
+            ],
+            [
+                "spawn-wrap:2.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
+        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
+        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
+    },
+    {
+        "id": "@jridgewell/gen-mapping:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@ampproject/remapping:2.2.0",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e5d2e450306a9491e3bd77e323e38d7aff315996",
+        "md5": "0f933b56a27f4640e86c5c9662516c5a",
+        "sha256": "2d2055c259b61a7537644eb25c548d0c1d388caaca9c26766c0df91976b94ab6"
+    },
+    {
+        "id": "@babel/highlight:7.18.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "81158601e93e2563795adcbfbdf5d64be3f2ecdf",
+        "md5": "6be4064f31d9e3fdd17994bd177ef426",
+        "sha256": "f54e6c10da061b163dd744a9ee2f0f3560d26d5cb1d4e81c9bc9ff6bcdcba664"
+    },
+    {
+        "id": "supports-color:5.5.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "@babel/highlight:7.18.6",
+                "@babel/code-frame:7.18.6",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+        "md5": "17b1003344e0e0d2719205be85946698",
+        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
     },
     {
         "id": "is-number:7.0.0",
@@ -3935,13 +3991,49 @@
                 "to-regex-range:5.0.1",
                 "fill-range:7.0.1",
                 "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
+                "chokidar:3.5.3",
+                "mocha:9.2.2",
                 "jfrogtest"
             ]
         ],
         "sha1": "7535345b896734d5f80c4d06c50955527a14f12b",
         "md5": "6c6e00114e00c2815fc0aeae3da1af23",
         "sha256": "7b75c1057198cf97696909a9bee176c9c5e9bcb5b03bf3ecef2f484defadd51e"
+    },
+    {
+        "id": "clean-stack:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "aggregate-error:3.1.0",
+                "p-map:3.0.0",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
+        "md5": "98495454e4106c25e5ed97ae9a6b1148",
+        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
+    },
+    {
+        "id": "node-releases:2.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "browserslist:4.21.2",
+                "@babel/helper-compilation-targets:7.18.9",
+                "@babel/core:7.18.9",
+                "istanbul-lib-instrument:4.0.3",
+                "nyc:15.1.0",
+                "jfrogtest"
+            ]
+        ],
+        "sha1": "8a7088c63a55e493845683ebf3c828d8c51c5503",
+        "md5": "86970ccb7f3cf344f56b70be69b316cf",
+        "sha256": "8b34c017dbfac06f45d6c9de2e32d2d5335cafdffaa9c2ba5aa756c854617eff"
     }
 ]

--- a/build/testdata/npm/project2/npmv8/macos/package-lock.json
+++ b/build/testdata/npm/project2/npmv8/macos/package-lock.json
@@ -17,175 +17,249 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.12.13"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
     "node_modules/@babel/generator": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -195,6 +269,9 @@
       "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
@@ -206,6 +283,9 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
@@ -220,20 +300,26 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
@@ -242,51 +328,69 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
-      "dev": true
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -300,6 +404,9 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
@@ -311,12 +418,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -325,6 +426,9 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
@@ -335,6 +439,9 @@
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -344,6 +451,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
@@ -353,6 +463,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
@@ -362,18 +478,71 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@types/mocha": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -390,19 +559,28 @@
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -411,6 +589,12 @@
       "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -421,6 +605,9 @@
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/append-transform": {
@@ -430,12 +617,15 @@
       "dev": true,
       "dependencies": {
         "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -445,16 +635,19 @@
       "dev": true
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -473,6 +666,9 @@
       "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browser-stdout": {
@@ -480,6 +676,34 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -491,13 +715,35 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/camelcase": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
-      "dev": true
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -507,6 +753,12 @@
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/supports-color": {
@@ -516,13 +768,22 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -532,6 +793,9 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
@@ -540,7 +804,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -560,6 +827,9 @@
       "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
@@ -571,29 +841,23 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -604,22 +868,42 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -628,12 +912,24 @@
       "dev": true,
       "dependencies": {
         "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -652,19 +948,35 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -673,17 +985,26 @@
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -694,13 +1015,22 @@
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
@@ -710,18 +1040,35 @@
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -729,25 +1076,41 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "optional": true
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -761,6 +1124,12 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -770,31 +1139,55 @@
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -804,13 +1197,22 @@
       "dependencies": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -821,19 +1223,25 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -853,19 +1261,28 @@
       "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
@@ -874,55 +1291,82 @@
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/istanbul-lib-hook": {
       "version": "3.0.0",
@@ -931,6 +1375,9 @@
       "dev": true,
       "dependencies": {
         "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-instrument": {
@@ -943,28 +1390,27 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
@@ -975,6 +1421,9 @@
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^3.0.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -984,33 +1433,36 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {
@@ -1026,21 +1478,33 @@
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/locate-path": {
@@ -1050,18 +1514,18 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -1072,6 +1536,12 @@
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -1081,101 +1551,86 @@
       "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-      "dev": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -1184,13 +1639,25 @@
       "dev": true,
       "dependencies": {
         "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -1225,17 +1692,13 @@
         "spawn-wrap": "^2.0.0",
         "test-exclude": "^6.0.0",
         "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=8.9"
       }
-    },
-    "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true
-    },
-    "node_modules/nyc/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
     },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
@@ -1248,12 +1711,6 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/nyc/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
     "node_modules/nyc/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1262,13 +1719,10 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/nyc/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
     },
     "node_modules/nyc/node_modules/locate-path": {
       "version": "5.0.0",
@@ -1277,6 +1731,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/p-limit": {
@@ -1286,6 +1743,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nyc/node_modules/p-locate": {
@@ -1295,26 +1758,9 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
-      }
-    },
-    "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -1326,12 +1772,15 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "node_modules/nyc/node_modules/yargs": {
@@ -1351,6 +1800,9 @@
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
         "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/yargs-parser": {
@@ -1361,12 +1813,15 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -1379,6 +1834,12 @@
       "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -1388,6 +1849,12 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -1397,13 +1864,19 @@
       "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/package-hash": {
       "version": "4.0.0",
@@ -1415,31 +1888,55 @@
         "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -1448,6 +1945,9 @@
       "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/find-up": {
@@ -1458,6 +1958,9 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
@@ -1467,6 +1970,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
@@ -1476,6 +1982,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
@@ -1485,6 +1997,9 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/process-on-spawn": {
@@ -1494,6 +2009,9 @@
       "dev": true,
       "dependencies": {
         "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/randombytes": {
@@ -1512,22 +2030,31 @@
       "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
@@ -1539,7 +2066,10 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -1548,19 +2078,28 @@
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -1574,7 +2113,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -1584,25 +2123,34 @@
       "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
@@ -1616,12 +2164,15 @@
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/string-width": {
@@ -1633,6 +2184,9 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -1642,19 +2196,31 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -1663,6 +2229,12 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/test-exclude": {
@@ -1674,13 +2246,31 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1689,13 +2279,19 @@
       "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -1706,6 +2302,41 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1713,18 +2344,24 @@
       "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -1736,12 +2373,18 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write-file-atomic": {
@@ -1760,7 +2403,10 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -1775,13 +2421,19 @@
         "string-width": "^4.2.0",
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
@@ -1793,185 +2445,231 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2008,19 +2706,19 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -2035,47 +2733,47 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2100,12 +2798,6 @@
           "requires": {
             "sprintf-js": "~1.0.2"
           }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
@@ -2162,10 +2854,48 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@types/mocha": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -2227,7 +2957,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "argparse": {
@@ -2237,9 +2967,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "binary-extensions": {
@@ -2273,6 +3003,18 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -2286,9 +3028,15 @@
       }
     },
     "camelcase": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "chalk": {
@@ -2313,9 +3061,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -2363,30 +3111,22 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "cross-spawn": {
@@ -2401,18 +3141,26 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "default-require-extensions": {
@@ -2428,6 +3176,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "emoji-regex": {
@@ -2470,9 +3224,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2515,7 +3269,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -2555,6 +3309,17 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -2573,9 +3338,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "growl": {
@@ -2615,7 +3380,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -2627,7 +3392,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -2652,7 +3417,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -2683,15 +3448,15 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -2709,13 +3474,13 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -2740,26 +3505,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
+        "uuid": "^8.3.2"
       }
     },
     "istanbul-lib-report": {
@@ -2785,28 +3541,20 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -2835,13 +3583,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -2852,16 +3597,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "log-symbols": {
@@ -2884,101 +3623,56 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "node-preload": {
@@ -2989,6 +3683,12 @@
       "requires": {
         "process-on-spawn": "^1.0.0"
       }
+    },
+    "node-releases": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -3031,16 +3731,6 @@
         "yargs": "^15.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3052,12 +3742,6 @@
             "wrap-ansi": "^6.2.0"
           }
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3067,12 +3751,6 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -3101,26 +3779,6 @@
             "p-limit": "^2.2.0"
           }
         },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3133,9 +3791,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
@@ -3172,7 +3830,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -3232,7 +3890,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -3241,10 +3899,16 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pkg-dir": {
@@ -3325,7 +3989,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -3334,7 +3998,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {
@@ -3359,9 +4023,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "semver": {
@@ -3382,7 +4046,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shebang-command": {
@@ -3401,15 +4065,15 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "spawn-wrap": {
@@ -3429,7 +4093,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string-width": {
@@ -3482,12 +4146,23 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -3514,6 +4189,22 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3526,13 +4217,13 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "wrap-ansi": {
@@ -3549,7 +4240,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {
@@ -3601,6 +4292,20 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
       }
     },
     "yocto-queue": {

--- a/build/testdata/npm/project2/npmv8/windows/excpected_dependencies_list.json
+++ b/build/testdata/npm/project2/npmv8/windows/excpected_dependencies_list.json
@@ -1,3947 +1,4023 @@
 [
     {
-        "id": "p-map:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
-        "md5": "3b38970091b03645f6f4d6680ada671d",
-        "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
-    },
-    {
-        "id": "istanbul-lib-report:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-reports:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
-        "md5": "87a16f7a36e489fdd042510550872167",
-        "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "is-plain-obj:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
-        "md5": "23b716d73535a85a95b57d53d7ac5df6",
-        "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
-    },
-    {
-        "id": "escalade:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
-        "md5": "61feaad8ca2ae37eff46aa4818a7b045",
-        "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
-    },
-    {
-        "id": "spawn-wrap:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
-        "md5": "300df23ba641ba293cd9907ddf1b7552",
-        "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
-    },
-    {
-        "id": "test-exclude:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
-        "md5": "c9d2be086d4d740f9999b77971777008",
-        "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
-    },
-    {
-        "id": "color-convert:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
-        "md5": "0248ebc952524207e296a622372faa1f",
-        "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
-    },
-    {
-        "id": "serialize-javascript:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
-        "md5": "900d6fc6f653ed171f0e54507edb0e43",
-        "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
-    },
-    {
-        "id": "@babel/parser:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cc31257419d2c3189d394081635703f549fc1ed4",
-        "md5": "f573e5455fa39afadc1bb30f724622dd",
-        "sha256": "33a407b6bf6c30fdeda12d1373fb192b49be135a0c48bc58040d9dfcebefd210"
-    },
-    {
-        "id": "gensync:1.0.0-beta.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
-        "md5": "3d1e68bdacb4e8046ccabff0019e916b",
-        "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
-    },
-    {
-        "id": "semver:5.7.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "p-locate:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
-        "md5": "f179aa668706b232c29cb580eea96619",
-        "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
-    },
-    {
-        "id": "strip-json-comments:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
-        "md5": "58e65c07bc47365a2acc9129b810130c",
-        "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
-    },
-    {
-        "id": "find-up:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
-        "md5": "aa0b377135f4af38d106db8b84606924",
-        "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
-    },
-    {
-        "id": "@istanbuljs/schema:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
-        "md5": "868e08ce450f7d9d5cd29997f0865f17",
-        "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
-    },
-    {
-        "id": "write-file-atomic:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
-        "md5": "53e54080c22253705daa1c3115c02220",
-        "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "@babel/helper-module-transforms:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "01afb052dcad2044289b7b20beb3fa8bd0265bea",
-        "md5": "35ed5d6f6c5aca458691c5729eb86c20",
-        "sha256": "224d45efb03f780a2b7fb9cf0b300c2e12e1901cc61dfe8dfc1943aa3b3b2542"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:2.2.0",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "ansi-styles:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
-        "md5": "0534616a9bab55e3e2d350f9ab77ea22",
-        "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
-    },
-    {
-        "id": "color-name:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:2.0.1",
-                "ansi-styles:4.3.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
-        "md5": "a8d4412852471526b8027af2532d0d2b",
-        "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
-    },
-    {
-        "id": "caching-transform:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
-        "md5": "82a03704703e883379f146caa805b457",
-        "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
-    },
-    {
-        "id": "@babel/helper-validator-identifier:7.12.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c9a1f021917dcb5ccf0d4e453e399022981fc9ed",
-        "md5": "7a8722e18203cfdb8c195ad276589390",
-        "sha256": "be0aac74011d70fcf9b20951c875572c0ed8f4738d3f00999f15393e7628f40a"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "jsesc:2.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
-        "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
-        "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
-    },
-    {
-        "id": "uuid:3.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b23e4358afa8a202fe7a100af1f5f883f02007ee",
-        "md5": "2fa27207bb65f4e05c6f10bc0448f662",
-        "sha256": "ba77c9306dbc34c7ae503e9eb142e284f98ea9ab609f416052c2fbbefb6df4dd"
-    },
-    {
-        "id": "aggregate-error:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "92670ff50f5359bdb7a3e0d40d0ec30c5737687a",
-        "md5": "16dd9122f632da20697f8ed47c7bbcc1",
-        "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
-    },
-    {
-        "id": "ansi-colors:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cbb9ae256bf750af1eab344f229aa27fe94ba348",
-        "md5": "ce72bb5360d8326616cae64d8ae9bdfe",
-        "sha256": "24d803210289f2afc6448276aa9d5a9608e86e584698307d2365d93195cf1f44"
-    },
-    {
-        "id": "which-module:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "md5": "ce028f30082fbbea9861a40437d17bd3",
-        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
-    },
-    {
-        "id": "hasha:5.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
-        "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
-        "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "@babel/helper-optimise-call-expression:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "5c02d171b4c8615b1e7163f888c1c81c30a2aaea",
-        "md5": "b06d494852b8183bbceff5cedb7b35d4",
-        "sha256": "bf99da6d67ff090a4b3d417a8c6724a2f6f9315d6dfc7da7b64d4eba76e588f4"
-    },
-    {
-        "id": "@istanbuljs/load-nyc-config:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
-        "md5": "d46010939e33d1d4e7dfce54fc60d89a",
-        "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
-    },
-    {
-        "id": "binary-extensions:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:2.1.0",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
-        "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
-        "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
-    },
-    {
-        "id": "p-limit:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:5.0.0",
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e1daccbe78d0d1388ca18c64fea38e3e57e3706b",
-        "md5": "1362f362e00b9e967f1f922cf1a0a872",
-        "sha256": "36e6519736cafaa158dc1bca8137683f5bf1bc1c476d40519028b3f3a96bc9e0"
-    },
-    {
-        "id": "minimatch:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "5166e286457f03306064be5497e8dbb0c3d32083",
-        "md5": "6a2c6f3ffed6ed50faaff89ef8eab0a0",
-        "sha256": "426a24d79bb6f0d3bb133e62cec69021836d254b39d931c104ddd7c464adea71"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "make-dir:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
-        "md5": "e47d13370c2b27671a13f28ebc27585f",
-        "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
-    },
-    {
-        "id": "shebang-regex:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shebang-command:2.0.0",
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
-        "md5": "800d00b53670160a44fa6116b1cbb6e5",
-        "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
-    },
-    {
-        "id": "default-require-extensions:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
-        "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
-        "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
-    },
-    {
-        "id": "is-glob:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-parent:5.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
-    },
-    {
-        "id": "@babel/helper-member-expression-to-functions:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "41e0916b99f8d5f43da4f05d85f4930fa3d62b22",
-        "md5": "619982af14ec79e31231427db61fc8dd",
-        "sha256": "cbfff31d7b38d87e1511a3762aac2a797f77d353806228ad10edda9808050641"
-    },
-    {
-        "id": "globals:11.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
-        "md5": "712d15395573404a3ddb37ce395d948b",
-        "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
-    },
-    {
-        "id": "indent-string:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
-        "md5": "ad188c269f2d9181da4321f8803a4cde",
-        "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "chalk:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
-        "md5": "cf76e256de1debce9c7a21cd18df954d",
-        "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
-    },
-    {
-        "id": "strip-ansi:6.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
-        "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
-        "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
-    },
-    {
-        "id": "signal-exit:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a1410c2edd8f077b08b4e253c8eacfcaf057461c",
-        "md5": "ae863f6e95a6a6050bc0e70c9ddb0688",
-        "sha256": "15efc9bad612c82f7bea7037c0ae575d015452ae383df94424d489b0f67101c7"
-    },
-    {
-        "id": "@babel/template:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "530265be8a2589dbb37523844c5bcb55947fb327",
-        "md5": "0326d436b3127e3419765111a116a58b",
-        "sha256": "36d2d87b053e91827083d0d94364c7f673536aa963add7a3c10129d816a2ef71"
-    },
-    {
-        "id": "@babel/helpers:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3c75e993632e4dadc0274eae219c73eb7645ba47",
-        "md5": "580610ed8e4e8c7a416fa66bf972b22c",
-        "sha256": "146b595a980720a5e0e98c7e04fdab2b72c41843a3c0189978b2bd5489439364"
-    },
-    {
-        "id": "yargs:15.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
-        "md5": "091d0cc9d7347925d73455bd991e6639",
-        "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
-    },
-    {
-        "id": "diff:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
-        "md5": "a6db67e2eeb11fd4cf5135da638e2157",
-        "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
-    },
-    {
-        "id": "y18n:5.0.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
-        "md5": "6018afaa99207dafc81cb56404a31454",
-        "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
-    },
-    {
-        "id": "p-try:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-limit:2.3.0",
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
-        "md5": "49994562e1f3cbe260710598cbb3edf7",
-        "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
-    },
-    {
-        "id": "append-transform:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
-        "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
-        "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
-    },
-    {
-        "id": "archy:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
-        "md5": "b2a24c65e2212f53168f984b5a693dbd",
-        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
-    },
-    {
-        "id": "fsevents:2.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a526f78b8fdf4623b709e0b975c52c24c02fd1a",
-        "md5": "3cf04486705de7ad22df4b2e51ec4893",
-        "sha256": "e17ade950c193fe09adfc7915fe29ac26166c8782d00e7c3879e7e9de02c5428"
-    },
-    {
-        "id": "is-unicode-supported:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
-        "md5": "5fa12001af4a22129166b9c7262d5fb2",
-        "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
-    },
-    {
-        "id": "camelcase:6.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "250fd350cfd555d0d2160b1d51510eaf8326e86e",
-        "md5": "d14a653ec4c2bdbc4a054b0dbce79d87",
-        "sha256": "07b3b755b39bbc93fed6f67753d4ed3f1a606ebeedc860678162bd9fe30b45c1"
-    },
-    {
-        "id": "camelcase:5.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
-        "md5": "efcf73180d9b7001c92f574d4ae7f908",
-        "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
-    },
-    {
-        "id": "decamelize:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs-parser:18.1.3",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
-        "md5": "330932e4de0e60c36114facb6d3dfafa",
-        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
-    },
-    {
-        "id": "foreground-child:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
-        "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
-        "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "@babel/helper-get-function-arity:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bc63451d403a3b3082b97e1d8b3fe5bd4091e583",
-        "md5": "7a40ffef4058eead9c8b98d56d03ccc4",
-        "sha256": "516342bff750abb2e2200520e63156dbf7b58cd3764cf5a26517a0c45ec32b9f"
-    },
-    {
-        "id": "js-yaml:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
-        "md5": "fba4491839b7fa47c38f639ac243b22d",
-        "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
-    },
-    {
-        "id": "istanbul-lib-source-maps:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9",
-        "md5": "fc78a9f50db7d57da55a839bac0e65da",
-        "sha256": "001db60e8967172df66953d5377a521fa02f167d8bdf3c25a748d8eb896f7fd8"
-    },
-    {
-        "id": "rimraf:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
-        "md5": "c794495fee118854a7cbd585a19a0fa8",
-        "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
-    },
-    {
-        "id": "is-binary-path:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
-        "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
-        "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
-    },
-    {
-        "id": "is-stream:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bde9c32680d6fae04129d6ac9d921ce7815f78e3",
-        "md5": "d4612a02df79da69a9743e26e8a37da6",
-        "sha256": "d6412611e731caafb1796ca17f9aa3104e8ae72517d122c2b313bcf2bb43de54"
-    },
-    {
-        "id": "process-on-spawn:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-preload:0.2.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
-        "md5": "acaca9f6065528d5b79d3d3501b5a745",
-        "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
-    },
-    {
-        "id": "ansi-regex:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:6.0.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "388539f55179bf39339c81af30a654d69f87cb75",
-        "md5": "69fd1c7bc68c850139d20aefed955a71",
-        "sha256": "6ee1bda34e578b6da23ca5ffda9dc971748c3c542f5fa999f818df5dc0323b99"
-    },
-    {
-        "id": "@types/mocha:9.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3205bcd15ada9bc681ac20bef64e9e6df88fd297",
-        "md5": "bf15e99c50d65300ef0110e5742ea07b",
-        "sha256": "077e99cc0d2957b15ce5620565b49e790cf4bda0243883af048d72e90cedc05b"
-    },
-    {
-        "id": "path-exists:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
-        "md5": "d3652d47b80b1aa623e820d7d276b27b",
-        "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
-    },
-    {
-        "id": "workerpool:6.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0f7cf076b6215fd7e1da903ff6f22ddd1886b581",
-        "md5": "d94ad5a124d3e57d0a4d9367ab982088",
-        "sha256": "dbe03b6ff8657ea015656292577c97fbc8d628fe24794799f751a66d753a70aa"
-    },
-    {
-        "id": "is-fullwidth-code-point:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
-        "md5": "87c5848714e5ed8e25abbdc13cfe3995",
-        "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
-    },
-    {
-        "id": "p-limit:2.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "p-locate:4.1.0",
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
-        "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
-        "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
-    },
-    {
-        "id": "debug:4.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
-        "md5": "690937c36f84e02c3d67193c2b867b76",
-        "sha256": "34ccfe056d27979867bc08e7449f3a2b1170e9d16591532d4202fb08eb39a38c"
-    },
-    {
-        "id": "json5:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "2dfefe720c6ba525d9ebd909950f0515316c89a3",
-        "md5": "e4711e39d31c4887d0c727ee258c7b40",
-        "sha256": "37875a2bd12417df58f547acc8b909db3a2cb437511f44516a6871e344c0b1fe"
-    },
-    {
-        "id": "to-regex-range:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:7.0.1",
-                "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
-        "md5": "5ef0a1bd28f353c14bf940103a879257",
-        "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "which:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
-        "md5": "9556a736013ff5223cc9731d9f32b55f",
-        "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
-    },
-    {
-        "id": "p-locate:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "locate-path:5.0.0",
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
-        "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
-        "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "escape-string-regexp:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
-        "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
-        "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
-    },
-    {
-        "id": "supports-color:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
-        "md5": "da58ae58b985905e1445bc447625dc1b",
-        "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
-    },
-    {
-        "id": "package-hash:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
-        "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
-        "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
-    },
-    {
-        "id": "is-typedarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "typedarray-to-buffer:3.1.5",
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
-        "md5": "d5efec2afc8b29ff367a2127cd1890b2",
-        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
-    },
-    {
-        "id": "cross-spawn:7.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
-        "md5": "e8b91e2f179097df541bc96ebb11b8bf",
-        "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
-    },
-    {
-        "id": "he:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
-        "md5": "59dd519e72954845f5a01d23c2695903",
-        "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
-    },
-    {
-        "id": "picomatch:2.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "readdirp:3.6.0",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f1f061de8f6a4bf022892e2d128234fb98302972",
-        "md5": "21b93be8448e9e1f9167e305ad1b4c79",
-        "sha256": "ec81cbb36546358b4369be6521148b129569dc0a51fd0154af618326f89a3596"
-    },
-    {
-        "id": "has-flag:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:7.2.0",
-                "chalk:4.1.2",
-                "log-symbols:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:8.1.1",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "supports-color:7.2.0",
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
-        "md5": "d48b4e68ca6cd00a3f95a43f88625684",
-        "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
-    },
-    {
-        "id": "yargs-unparser:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f131f9226911ae5d9ad38c432fe809366c2325eb",
-        "md5": "f9482cf08bacd4b85c2f4aa27215e73b",
-        "sha256": "c9224d53839022b885216ed18127198abc15e38a242ced14d74b11fafc0ba97c"
-    },
-    {
-        "id": "wrap-ansi:7.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
-        "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
-        "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
-    },
-    {
-        "id": "graceful-fs:4.2.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ff040b2b0853b23c3d31027523706f1885d76bee",
-        "md5": "daa4c01f4d01fa7976a43c17cf2f9454",
-        "sha256": "25334251eddf26a85b59b6c7c994b954cbae4831640881fba46bef3f26cbe537"
-    },
-    {
-        "id": "shebang-command:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
-        "md5": "aa7675df57afd8404d9aaa55e659f7a8",
-        "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "normalize-path:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:3.1.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
-        "md5": "2821b760c1df5dcc38328f154a6ea3cb",
-        "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
-    },
-    {
-        "id": "lodash:4.17.21",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
-        "md5": "25247d3dd7029d08a6ac99adab09086b",
-        "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
-    },
-    {
-        "id": "@babel/helper-module-imports:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ec67e4404f41750463e455cc3203f6a32e93fcb0",
-        "md5": "e2c6246894aa90be1363b5a444fe4f2a",
-        "sha256": "68b836938f51fac48c1bd8d6d70ed65e76ee52d31798b57ef728d1530c8746c8"
-    },
-    {
-        "id": "ansi-regex:5.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:6.0.1",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
-        "md5": "7a0bb891f3a7cd9b174af62beb4de186",
-        "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
-    },
-    {
-        "id": "require-main-filename:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
-        "md5": "8b45166659a670e83387649f79c641ad",
-        "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
-    },
-    {
-        "id": "y18n:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8db2b83c31c5d75099bb890b23f3094891e247d4",
-        "md5": "cb26f5963c1a3702dbb487448bd1f052",
-        "sha256": "cd11c323020c227a1dbebbae09c435d255a12a62586789129e5f178694f49fd8"
-    },
-    {
-        "id": "glob-parent:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
-        "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
-        "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
-    },
-    {
-        "id": "yargs-parser:20.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b42890f14566796f85ae8e3a25290d205f154a54",
-        "md5": "dded5e7456c94ffc7f4ffddddcac0681",
-        "sha256": "4fe61652a7e5375530ef19f941238fec925f34c7cad78f45bc73afad66bd0121"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "convert-source-map:1.7.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "rimraf:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "test-exclude:6.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "randombytes:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "serialize-javascript:6.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
-        "md5": "efb164d8addf215512a3bb6dd19a1496",
-        "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
-    },
-    {
-        "id": "es6-error:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "release-zalgo:1.0.0",
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
-        "md5": "9aeb9c257e683268999655a2071219f2",
-        "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
-    },
-    {
-        "id": "find-cache-dir:3.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "89b33fad4a4670daa94f855f7fbe31d6d84fe880",
-        "md5": "d3957f330dbccdcb14916e19c68ad692",
-        "sha256": "c78bf4bf2e8a6d55e7d41cd5f3ead9ef1d0b03e47cfa60ceb0b2cf7f8be1da0e"
-    },
-    {
-        "id": "commondir:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
-        "md5": "329b8682e83ec34dfe1c58ae90b84988",
-        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
-    },
-    {
-        "id": "@babel/traverse:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "689f0e4b4c08587ad26622832632735fb8c4e0c0",
-        "md5": "cba92dc1fa690a08b0973ce36cb0b3af",
-        "sha256": "b4fcdc925b833ad532b6e68a276c6f1b9b5d26d07c63464c8f00dddc82f06be7"
-    },
-    {
-        "id": "to-fast-properties:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/types:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
-        "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
-        "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
-    },
-    {
-        "id": "source-map:0.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
-        "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
-        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
-    },
-    {
-        "id": "argparse:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:4.1.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
-        "md5": "864f41f5cacfed3315deeba37ba7954b",
-        "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
-    },
-    {
-        "id": "cliui:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
-        "md5": "9065a0615794d52f19cffa078701d382",
-        "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
-    },
-    {
-        "id": "lodash.flattendeep:4.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
-        "md5": "17ca06c4643969cb10e948854434eba0",
-        "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
-    },
-    {
-        "id": "@babel/generator:7.12.15",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4617b5d0b25cc572474cc1aafee1edeaf9b5368f",
-        "md5": "76f9f743c12a36ed324ac0957e3194ff",
-        "sha256": "c0c80724343fde3d974a40d37dc1362473fa078f85eccdda032190e827146a16"
-    },
-    {
-        "id": "@babel/helper-simple-access:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4",
-        "md5": "e84bc3d78539d7dfdf173b23509b9110",
-        "sha256": "2e4854abdaebdb65d6fde6d39cf8606245a8e8f89c922eab28166433d6cd2105"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "growl:1.10.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
-        "md5": "47fb3a576f5916564687b683b1bcea68",
-        "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "typedarray-to-buffer:3.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write-file-atomic:3.0.3",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
-        "md5": "d693220f5eabe1359169bb992abaa064",
-        "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
-    },
-    {
-        "id": "@babel/highlight:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8ab538393e00370b26271b01fa08f7f27f2e795c",
-        "md5": "55ef0df1b744cf4957c1ac4c8283ad13",
-        "sha256": "0b7c3a161e990fc34f22549b01436e8116c2d0038e47b6aaecb27be602ea852d"
-    },
-    {
-        "id": "html-escaper:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-reports:3.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
-        "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
-        "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "spawn-wrap:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "debug:4.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f0a49c18ac8779e31d4a0c6029dfb76873c7428b",
-        "md5": "e6cb523b95d83bb1d087255046eb4d0b",
-        "sha256": "06b5b98471dc02410003e8bf34cf9e96afbadc30a83b19f5c9376faa817fa7bb"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "safe-buffer:5.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randombytes:2.1.0",
-                "serialize-javascript:6.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
-        "md5": "ea7cf66fcf04485e195b1bd3a3551fc9",
-        "sha256": "5d181804516c4a693a384272a7bd0e42d17e0d4b301ccfbe408669ccafdcb3e8"
-    },
-    {
-        "id": "emoji-regex:8.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:4.2.3",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
-        "md5": "598b731d8d33cfff04377ad55da187b0",
-        "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
-    },
-    {
-        "id": "nyc:15.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
-        "md5": "28c5baf103508c15fc352a367910f0c4",
-        "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
-    },
-    {
-        "id": "istanbul-lib-instrument:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "873c6fff897450118222774696a3f28902d77c1d",
-        "md5": "ee314a8a3153abd9396916f9e141d374",
-        "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
-    },
-    {
-        "id": "@babel/code-frame:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dcfc826beef65e75c50e21d3837d7d95798dd658",
-        "md5": "6727735f1d373c0716142eb14e7260e3",
-        "sha256": "b5faeba1c9a62366179479a572b09a898a78e5d4dd07e06c98318a48dac0236f"
-    },
-    {
-        "id": "@babel/helper-function-name:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a",
-        "md5": "e71e30bb9170aca538674078c5cf4188",
-        "sha256": "f8fe08fb616ea9442dbf6ef6fff18970188705d2f41a2e120e8c6472c49608cb"
-    },
-    {
-        "id": "chokidar:3.5.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dba3976fcadb016f66fd365021d91600d01c1e75",
-        "md5": "99944b98cf9fc62c83010c80c2c12e7b",
-        "sha256": "5e3a0ebe621c47dc9348991eaed90e59221d40edd555556df15e46b3b36888da"
-    },
-    {
-        "id": "node-preload:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
-        "md5": "120f936cf9cfb9aaf63819850ee25dab",
-        "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "clean-stack:2.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "aggregate-error:3.1.0",
-                "p-map:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
-        "md5": "98495454e4106c25e5ed97ae9a6b1148",
-        "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
-    },
-    {
-        "id": "flat:5.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
-        "md5": "c215e59da15d7b8eccb1db3e47366cb5",
-        "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
-    },
-    {
-        "id": "yocto-queue:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:3.1.0",
-                "p-locate:5.0.0",
-                "locate-path:6.0.0",
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
-        "md5": "69e27040e38c5b03127488546dc282ea",
-        "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
-    },
-    {
-        "id": "yargs:16.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
-        "md5": "23787ef1801c6394b3bdee59580dd6c8",
-        "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
-    },
-    {
-        "id": "type-fest:0.8.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "hasha:5.2.2",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
-        "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
-        "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
-    },
-    {
-        "id": "release-zalgo:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "package-hash:4.0.0",
-                "caching-transform:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
-        "md5": "2e431e2016bfc667a21974c2c818d769",
-        "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
-    },
-    {
-        "id": "istanbul-lib-hook:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
-        "md5": "5602d9c25a554fbcca017c4df471866e",
-        "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
-    },
-    {
-        "id": "js-tokens:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
-        "md5": "325b11b965688c69ae45a3cf771fbc5c",
-        "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
-    },
-    {
-        "id": "@babel/types:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/generator:7.12.15",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-imports:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-member-expression-to-functions:7.12.16",
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-optimise-call-expression:7.12.13",
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-replace-supers:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-simple-access:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-split-export-declaration:7.12.13",
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helpers:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/template:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-get-function-arity:7.12.13",
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/helper-function-name:7.12.13",
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8be1aa8f2c876da11a9cf650c0ecf656913ad611",
-        "md5": "3ce6b4a1e29cf8b4ef61d92e899b05a0",
-        "sha256": "2843deaf5baef5bacee86f17b2814c64668a42fba87c8e0a14f7e224022458d5"
-    },
-    {
-        "id": "readdirp:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
-        "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
-        "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
-    },
-    {
-        "id": "locate-path:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:4.1.0",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "pkg-dir:4.2.0",
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "find-up:4.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
-        "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
-        "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
-    },
-    {
-        "id": "@babel/core:7.12.16",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8c6ba456b23b680a6493ddcfcd9d3c3ad51cab7c",
-        "md5": "fc251c62b2de391930fd421ca5debd1b",
-        "sha256": "407b393b5e00eecf5f597665815fd196395479958f18be218a932374aa339d12"
-    },
-    {
-        "id": "log-symbols:4.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
-        "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
-        "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
-    },
-    {
-        "id": "get-package-type:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
-        "md5": "53c447a09cbf8afb25d97e78bf4a1397",
-        "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
-    },
-    {
-        "id": "pkg-dir:4.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-cache-dir:3.3.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
-        "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
-        "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "@babel/highlight:7.12.13",
-                "@babel/code-frame:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "@babel/helper-replace-supers:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "00ec4fb6862546bd3d0aff9aac56074277173121",
-        "md5": "1b61afebfcef69d7e33415f68fce3913",
-        "sha256": "774bb7c311010fc27d82dd8546b22e3fa7c5af922928ca86a9377807e57dda54"
-    },
-    {
-        "id": "string-width:4.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:7.0.0",
-                "cliui:7.0.4",
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
-        "md5": "41b9a8984f249b332c0ae05f8b4688a9",
-        "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
-    },
-    {
-        "id": "ms:2.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "nanoid:3.1.25",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "09ca32747c0e543f0e1814b7d3793477f9c8e152",
-        "md5": "cf82465d90a5f488901aa5b70eeed864",
-        "sha256": "1835a342a119a6ad8bcff0c9290ff73d87c8f6f760a16a32de6adec2f3e04a2d"
-    },
-    {
-        "id": "get-caller-file:2.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
-        "md5": "1b9de5ead51b8886be998f58fdb96476",
-        "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
-    },
-    {
-        "id": "sprintf-js:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
-    },
-    {
-        "id": "fromentries:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "process-on-spawn:1.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
-        "md5": "f13c076f7541b0f2993f537b46768314",
-        "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
-    },
-    {
-        "id": "yargs-parser:18.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
-        "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
-        "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
-    },
-    {
-        "id": "braces:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
-        "md5": "3ed11e666a13cb0da288c6f445b2601f",
-        "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
-    },
-    {
-        "id": "browser-stdout:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
-        "md5": "82ebb0cdcee39bc8953381ac71cad549",
-        "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
-    },
-    {
-        "id": "anymatch:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
-        "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
-        "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
-    },
-    {
-        "id": "ms:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:4.3.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "debug:4.3.1",
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
-        "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
-        "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
-    },
-    {
-        "id": "locate-path:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:5.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "55321eb309febbc59c4801d931a72452a681d286",
-        "md5": "88dec34f94138c96fd50374b3ff54935",
-        "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "glob:7.2.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "convert-source-map:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "17a2cb882d7f77d3490585e2ce6c524424a3a442",
-        "md5": "0e5204f1f071e85179a46cb16f500ac1",
-        "sha256": "2c691638758a2d21562c31b10f2784d8be585158da080877ea7b6da0d82503d9"
-    },
-    {
-        "id": "wrap-ansi:6.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
-        "md5": "f8917d0c5de3cfd4ab98a235260b3951",
-        "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
-    },
-    {
-        "id": "mocha:9.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "8a623be6b323810493d8c8f6f7667440fa469fdb",
-        "md5": "6d0631780adf286526d8e07e316cfe2c",
-        "sha256": "5c2b78c19bb5508986be1cbb3a0eda7e291b804fbda9307669505d2767a59953"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:2.0.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "string-width:4.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "952182c46cc7b2c313d1596e623992bd163b72b5",
-        "md5": "d7e1202535d01c2d692f15b4259d6130",
-        "sha256": "b6b0c19edc66b57cea414591d74a0ea206b4baa1deebbf4b06193759f6233e3e"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.1.7",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "supports-color:8.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
-        "md5": "16e8e38709a4675f8ea1482806cb050c",
-        "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
-    },
-    {
-        "id": "path-key:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cross-spawn:7.0.3",
-                "foreground-child:2.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
-        "md5": "4f4b9beb2d53481341e16133a8570dc5",
-        "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
-    },
-    {
-        "id": "istanbul-lib-coverage:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-processinfo:2.0.2",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-report:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "istanbul-lib-source-maps:4.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "f5944a37c70b550b02a78a5c3b2055b280cec8ec",
-        "md5": "08af9082d6a9899699db1c8742ba1aa6",
-        "sha256": "0e39da48fc4d638d67545543b0d0ed604a41b9e977cc74e96bcd1010ff8db0af"
-    },
-    {
-        "id": "semver:6.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "make-dir:3.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
-        "md5": "e0836faadf4b192c3987c5117d62fff6",
-        "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
-    },
-    {
-        "id": "istanbul-reports:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "d593210e5000683750cb09fc0644e4b6e27fd53b",
-        "md5": "1a146a208081fca710ec9ac5686ff870",
-        "sha256": "ac20ddc4f84e2135f064d94014e190d9a2d4f4b73e2f6b4513b896409d1bc1db"
-    },
-    {
-        "id": "fill-range:7.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
-        "md5": "279e60751b8b0e89226a9e9bd5b8f275",
-        "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
-    },
-    {
-        "id": "balanced-match:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.0.4",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "89b4d199ab2bee49de164ea02b89ce462d71b767",
-        "md5": "83d3f9f047e9700f6c4ac4028c4c5c53",
-        "sha256": "2896602c12d3cef566bfbed7ccdef79232f4f1e00622fc5c9b40737465baffad"
-    },
-    {
-        "id": "resolve-from:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@istanbuljs/load-nyc-config:1.1.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
-        "md5": "23cff3fc62d9dd916e67da9c9505603f",
-        "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
-    },
-    {
-        "id": "istanbul-lib-processinfo:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e1426514662244b2f25df728e8fd1ba35fe53b9c",
-        "md5": "93131ca838a58e819813b733c606bd8d",
-        "sha256": "7e529f7767219df1b357ae5b65949760f40516c6fd3743218c6b05b7ca86dd81"
-    },
-    {
-        "id": "strip-ansi:6.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "wrap-ansi:6.2.0",
-                "cliui:6.0.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "string-width:4.2.0",
-                "yargs:15.4.1",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
-        "md5": "767c76e38fb2bb82a3da65412b4610ad",
-        "sha256": "26bc5904a8e6afdf4d2d05d69fa91fec48879917582aa892029695506a0b5653"
-    },
-    {
-        "id": "@ungap/promise-all-settled:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
-        "md5": "b2752b39b9322878e731606f6ec568a1",
-        "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
-    },
-    {
-        "id": "is-extglob:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-glob:4.0.3",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "find-up:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
-        "md5": "f30df2388d75158c7361f549edfe9bef",
-        "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
-    },
-    {
-        "id": "glob:7.1.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "3b193e9233f01d42d0b3f78294bbeeb418f94a90",
-        "md5": "b76e2faffe41be9df3f1ff4605ee1a63",
-        "sha256": "0504b3ddde68d1a93b4b9ef150cdff61e033df5f17cf7858c0d9fe1b412e9bee"
-    },
-    {
-        "id": "decamelize:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs-unparser:2.0.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
-        "md5": "17113f86fb93e54ad64017cac7c80002",
-        "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
-    },
-    {
-        "id": "cliui:7.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:16.2.0",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
-        "md5": "c3a8fba555857874ad0dffba34a2289f",
-        "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
-    },
-    {
-        "id": "strip-bom:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "default-require-extensions:3.0.0",
-                "append-transform:2.0.0",
-                "istanbul-lib-hook:3.0.0",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
-        "md5": "ba5ded28e859d1030ed2f1369e379f67",
-        "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
-    },
-    {
-        "id": "@babel/helper-split-export-declaration:7.12.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "@babel/helper-module-transforms:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ],
-            [
-                "@babel/traverse:7.12.13",
-                "@babel/core:7.12.16",
-                "istanbul-lib-instrument:4.0.3",
-                "nyc:15.1.0",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "e9430be00baf3e88b0e13e6f9d4eaf2136372b05",
-        "md5": "8db09a6f5e6d9084dbf2df40154de08f",
-        "sha256": "c62fe860b48645cb4e2bdbe1089cc97a369f5dcc1970b42c6b9782f8da1ca818"
-    },
-    {
-        "id": "is-number:7.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "to-regex-range:5.0.1",
-                "fill-range:7.0.1",
-                "braces:3.0.2",
-                "chokidar:3.5.2",
-                "mocha:9.1.3",
-                "jfrogtest"
-            ]
-        ],
-        "sha1": "7535345b896734d5f80c4d06c50955527a14f12b",
-        "md5": "6c6e00114e00c2815fc0aeae3da1af23",
-        "sha256": "7b75c1057198cf97696909a9bee176c9c5e9bcb5b03bf3ecef2f484defadd51e"
+    "id": "chalk:4.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aac4e2b7734a740867aeb16bf02aad556a1e7a01",
+    "md5": "cf76e256de1debce9c7a21cd18df954d",
+    "sha256": "e84c643aa53e87ace6c3d368b3cddda24a2d1434a06b6dfbdb628ad2107df90a"
+    },
+    {
+    "id": "es6-error:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "release-zalgo:1.0.0",
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9e3af407459deed47e9a91f9b885a84eb05c561d",
+    "md5": "9aeb9c257e683268999655a2071219f2",
+    "sha256": "e10aaeb70548afb2f3e50eb92d4411bdf4a73b2b366b75b32d7c7fdf9985997a"
+    },
+    {
+    "id": "write-file-atomic:3.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
+    "md5": "53e54080c22253705daa1c3115c02220",
+    "sha256": "e960a6846f713b6b0d16b6a7d98d47f6fc29610f6e59eb5587fd9d48d455fa66"
+    },
+    {
+    "id": "is-typedarray:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "typedarray-to-buffer:3.1.5",
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+    "md5": "d5efec2afc8b29ff367a2127cd1890b2",
+    "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845"
+    },
+    {
+    "id": "istanbul-lib-hook:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6",
+    "md5": "5602d9c25a554fbcca017c4df471866e",
+    "sha256": "b1409b73f51457d3cb29de5a6d5568c3bf19d1654cc1584bb3f0269398b3539c"
+    },
+    {
+    "id": "yargs:15.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
+    "md5": "091d0cc9d7347925d73455bd991e6639",
+    "sha256": "41abfec6a74cfb4fa330af2a33b867dfa06a9b2b439bb01244c4f47c585de535"
+    },
+    {
+    "id": "p-limit:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:5.0.0",
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e1daccbe78d0d1388ca18c64fea38e3e57e3706b",
+    "md5": "1362f362e00b9e967f1f922cf1a0a872",
+    "sha256": "36e6519736cafaa158dc1bca8137683f5bf1bc1c476d40519028b3f3a96bc9e0"
+    },
+    {
+    "id": "has-flag:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:7.2.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "supports-color:8.1.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "supports-color:7.2.0",
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "944771fd9c81c81265c4d6941860da06bb59479b",
+    "md5": "d48b4e68ca6cd00a3f95a43f88625684",
+    "sha256": "77a7eb1411d927bb8a5ca7069dbe168886d63c88f446f0b81500a2cf23ddb5b1"
+    },
+    {
+    "id": "is-unicode-supported:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3f26c76a809593b52bfa2ecb5710ed2779b522a7",
+    "md5": "5fa12001af4a22129166b9c7262d5fb2",
+    "sha256": "7c15fefe222c2ec445ebf1d1b7c9ceb6e9513ce6195b002b7b8c3280ca9ecabe"
+    },
+    {
+    "id": "p-limit:2.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3dd33c647a214fdfffd835933eb086da0dc21db1",
+    "md5": "002eb5aeebd77c4c6a6570c7be31c0e9",
+    "sha256": "384b452409cfeb5c6fa82dc68ebfa498b24717b74fb8d3fe6eb2bb89908db295"
+    },
+    {
+    "id": "to-regex-range:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:7.0.1",
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1648c44aae7c8d988a326018ed72f5b4dd0392e4",
+    "md5": "5ef0a1bd28f353c14bf940103a879257",
+    "sha256": "a63a255ec20a935c3a3334a6645f9245db36e2319ddf1eb6bc0eab2bfe5b42d7"
+    },
+    {
+    "id": "concat-map:0.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+    "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+    "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+    "id": "shebang-command:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ccd0af4f8835fbdc265b82461aaf0c36663f34ea",
+    "md5": "aa7675df57afd8404d9aaa55e659f7a8",
+    "sha256": "9acba5bd18a51e9cdf5898380e4df63f803e1844def64ae1a46f88cff86d556e"
+    },
+    {
+    "id": "@ampproject/remapping:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "56c133824780de3174aed5ab6834f3026790154d",
+    "md5": "f89dd9045903be2cc7c10b3c31e75626",
+    "sha256": "2f2dacc9e8ed33330e4ad095403b9efb51736e06f9c57baf0ca73058406bb890"
+    },
+    {
+    "id": "jsesc:2.5.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "80564d2e483dacf6e8ef209650a67df3f0c283a4",
+    "md5": "73267fc7ff79ed59ec4c02cfb29d8a8b",
+    "sha256": "ae5a2bdb55e44862273f1e08c3692f8da70ced96f0a4bb8294aa488ca58c258b"
+    },
+    {
+    "id": "@babel/compat-data:7.18.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "2483f565faca607b8535590e84e7de323f27764d",
+    "md5": "7088ff85d6c89dea757ce152c9150565",
+    "sha256": "5756345fc4fe02547f9355988f4f923a0ca9ad868cca748a8cd94b9fdd202a5e"
+    },
+    {
+    "id": "json5:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "655d50ed1e6f95ad1a3caababd2b0efda10b395c",
+    "md5": "e7d2fc3e0299d8005b5f7f46161cc227",
+    "sha256": "1d044eb7a06ddb2429366e0630dd884d1e57f116e3704b293631fa4dde045a59"
+    },
+    {
+    "id": "indent-string:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "aggregate-error:3.1.0",
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "624f8f4497d619b2d9768531d58f4122854d7251",
+    "md5": "ad188c269f2d9181da4321f8803a4cde",
+    "sha256": "bc6b74d3d74eb341c8b590c697c7fcd259c6fd1223c4b44dbfb11887ce9842a0"
+    },
+    {
+    "id": "fs.realpath:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+    "md5": "9f790d7180667e1d8d1110f2cf321b62",
+    "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+    "id": "spawn-wrap:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "103685b8b8f9b79771318827aa78650a610d457e",
+    "md5": "300df23ba641ba293cd9907ddf1b7552",
+    "sha256": "839a710cd6d6ca7bcd2788208e51436b27558548015c073ff278ce546d0b5748"
+    },
+    {
+    "id": "growl:1.10.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f2735dc2283674fa67478b10181059355c369e5e",
+    "md5": "47fb3a576f5916564687b683b1bcea68",
+    "sha256": "ba0cc1c69259c6097c62ab156401d00308c129f5776869d365f779f12e6dd912"
+    },
+    {
+    "id": "yargs-unparser:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f131f9226911ae5d9ad38c432fe809366c2325eb",
+    "md5": "f9482cf08bacd4b85c2f4aa27215e73b",
+    "sha256": "c9224d53839022b885216ed18127198abc15e38a242ced14d74b11fafc0ba97c"
+    },
+    {
+    "id": "strip-ansi:6.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9e26c63d30f53443e9489495b2105d37b67a85d9",
+    "md5": "85cbf58500e3b9a7d62e1f7f580c8a45",
+    "sha256": "9bdb75d0bff49f156dd8c3bcb0e06b3fa96c3d88ddd4c342a4345866a40c08ca"
+    },
+    {
+    "id": "ansi-regex:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "strip-ansi:6.0.1",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "082cb2c89c9fe8659a311a53bd6a4dc5301db304",
+    "md5": "7a0bb891f3a7cd9b174af62beb4de186",
+    "sha256": "0e0eadcdaada805db5d85b53ad5cdca0760b996ee199ec9658e7b34aa6c8e0d9"
+    },
+    {
+    "id": "@babel/helper-module-imports:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1e3ebdbbd08aad1437b428c50204db13c5a3ca6e",
+    "md5": "3549438c2b0b59c539a58c4cb733f4a0",
+    "sha256": "9b450e94445d86395e12d74981be606bb90d4e92e99ae358093d1318d78c6568"
+    },
+    {
+    "id": "rimraf:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a",
+    "md5": "c794495fee118854a7cbd585a19a0fa8",
+    "sha256": "5876c20fd84707b7056ec61ccee1a71e80fec1657650010bd4dac828bb977f52"
+    },
+    {
+    "id": "fromentries:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "process-on-spawn:1.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e4bca6808816bf8f93b52750f1127f5a6fd86e3a",
+    "md5": "f13c076f7541b0f2993f537b46768314",
+    "sha256": "88e46e565906b37d81da80cd8785c057f71ca7da9d1eb1272c09c07725f270d2"
+    },
+    {
+    "id": "readdirp:3.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "74a370bd857116e245b29cc97340cd431a02a6c7",
+    "md5": "ebf6617dc3578eb7d4560f0baa3c8273",
+    "sha256": "f1d3b6f146a9f11a0f07827b9bbfa3017d7fb1a420d37acd321ef56ba77099ca"
+    },
+    {
+    "id": "inflight:1.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+    "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+    "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+    "id": "js-yaml:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c1fb65f8f5017901cdd2c951864ba18458a10602",
+    "md5": "fba4491839b7fa47c38f639ac243b22d",
+    "sha256": "0dae332559cf22b21c26ea70e732afd8303ff99412f9c3d9d209faa8882cf2ca"
+    },
+    {
+    "id": "log-symbols:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3fbdbb95b4683ac9fc785111e792e558d4abd503",
+    "md5": "6b7e77c65213bd66f0e775dd1a501ef1",
+    "sha256": "32e706aac11b2ba4c0e9647a3a6738bcd9eb6615bf8ad9f157282e8ed9701323"
+    },
+    {
+    "id": "source-map:0.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+    "md5": "79c3ddee196e8b414e8b5c3b9caa8581",
+    "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86"
+    },
+    {
+    "id": "html-escaper:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-reports:3.1.5",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dfd60027da36a36dfcbe236262c00a5822681453",
+    "md5": "81b8d8f735c3d68acd4c6a5cf0b8e5de",
+    "sha256": "8ab75514cf8515cf43f7b69fef645b952c6577026554eb306cc4c17b37c6fad7"
+    },
+    {
+    "id": "aggregate-error:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "92670ff50f5359bdb7a3e0d40d0ec30c5737687a",
+    "md5": "16dd9122f632da20697f8ed47c7bbcc1",
+    "sha256": "03360cb8b5aba425c69ede72e465bbd7847104209048c95200b6b432c98b205b"
+    },
+    {
+    "id": "is-binary-path:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ea1f7f3b80f064236e83470f86c09c254fb45b09",
+    "md5": "bd33f08c47fb70bb6d1b11ae6c760437",
+    "sha256": "a076b203c5bd01082c17de903fd872d282d223aca47830047183228010c64def"
+    },
+    {
+    "id": "p-locate:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "83c8315c6785005e3bd021839411c9e110e6d834",
+    "md5": "f179aa668706b232c29cb580eea96619",
+    "sha256": "2ec11480a90965a753b141be5432d24f4ca98860b844fd1b10cab0a1023423fc"
+    },
+    {
+    "id": "sprintf-js:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "argparse:1.0.10",
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+    "md5": "8e6b31a052754055683e4a35a317feab",
+    "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+    "id": "hasha:5.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a48477989b3b327aea3c04f53096d816d97522a1",
+    "md5": "e115dd4df0b0ac30070f0d3e7a99bd10",
+    "sha256": "71ab42b150104fff441f2317540af19dd5b08fd0a23f0a4fbad5bcc700d0b82d"
+    },
+    {
+    "id": "release-zalgo:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "09700b7e5074329739330e535c5a90fb67851730",
+    "md5": "2e431e2016bfc667a21974c2c818d769",
+    "sha256": "3f586b2c471263a7b7f304267b550de0c3f0236336dd8c509c9e8585928234a3"
+    },
+    {
+    "id": "foreground-child:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "71b32800c9f15aa8f2f83f4a6bd9bff35d861a53",
+    "md5": "a40037cbec5e1d0f5428d9c99a9e91cf",
+    "sha256": "142a7ad241b5dbd9cc55a3194b217953cc08d2cbeb5bfe8ad9f8127b9a724e3c"
+    },
+    {
+    "id": "@babel/core:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "805461f967c77ff46c74ca0460ccf4fe933ddd59",
+    "md5": "414e3ac6524d22ef6fe284e456051fb9",
+    "sha256": "9a1831b17a6a6b8524ffd957c70deb5b12f2ec90869c0b3b0bacd201bfbc338b"
+    },
+    {
+    "id": "@babel/code-frame:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3b25d38c89600baa2dcc219edfa88a74eb2c427a",
+    "md5": "06bf74bedad2a91ac5c5950ee0d527a4",
+    "sha256": "069544665ad7c8eb0fd72fd2ebf2c651454fce88768e3a8d203041865e729977"
+    },
+    {
+    "id": "find-up:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4c92819ecb7083561e4f4a240a86be5198f536fc",
+    "md5": "f30df2388d75158c7361f549edfe9bef",
+    "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
+    },
+    {
+    "id": "@babel/helper-hoist-variables:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d4d2c8fb4baeaa5c68b99cc8245c56554f926678",
+    "md5": "f10ece88fdea253c1678a09bdfa85160",
+    "sha256": "cd91a6aef86fb2089e6798c395dffa5d59ca2801e348ef6259f78882082707ec"
+    },
+    {
+    "id": "@babel/traverse:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "deeff3e8f1bad9786874cb2feda7a2d77a904f98",
+    "md5": "4e01105ee87a3406c4a9c3617ebdba42",
+    "sha256": "a9d2fd8aa3dccf55f8057d42d02d620960875c5d283a7fc0f941afbd5680ac2d"
+    },
+    {
+    "id": "strip-json-comments:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "31f1281b3832630434831c310c01cccda8cbe006",
+    "md5": "58e65c07bc47365a2acc9129b810130c",
+    "sha256": "0213fe6b1c1c470cf5c60ffca0d362142117c8e303ffbcabbd9a4c4700b6ceed"
+    },
+    {
+    "id": "camelcase:6.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "5685b95eb209ac9c0c177467778c9c84df58ba9a",
+    "md5": "cde9397a5c3cbfcdb6a5e559f5c00cd4",
+    "sha256": "2851fe487cf5607b5196895b13d6db4620200b225eec753897a9759f8912adb6"
+    },
+    {
+    "id": "require-directory:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+    "md5": "f3a9010155b6a46066afbe2d07f624bd",
+    "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+    "id": "is-fullwidth-code-point:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f116f8064fe90b3f7844a38997c0b75051269f1d",
+    "md5": "87c5848714e5ed8e25abbdc13cfe3995",
+    "sha256": "6f415dae5dc6070f1b42daee6165eab941a97101982305facc8bafdaf300bc4a"
+    },
+    {
+    "id": "@jridgewell/gen-mapping:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e5d2e450306a9491e3bd77e323e38d7aff315996",
+    "md5": "0f933b56a27f4640e86c5c9662516c5a",
+    "sha256": "2d2055c259b61a7537644eb25c548d0c1d388caaca9c26766c0df91976b94ab6"
+    },
+    {
+    "id": "@babel/helper-split-export-declaration:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7367949bc75b20c6d5a5d4a97bba2824ae8ef075",
+    "md5": "d7c42328ad1e542ae3f255320630d31c",
+    "sha256": "a985fbbc087d43887197fbe6ee6ecab05a2bf71daa6e99929d4fd09f176f58f5"
+    },
+    {
+    "id": "diff:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7ed6ad76d859d030787ec35855f5b1daf31d852b",
+    "md5": "a6db67e2eeb11fd4cf5135da638e2157",
+    "sha256": "f8911521b249c1171e3be1e728e6490e761c032f89d5c9f2e418dc0bdaba8b33"
+    },
+    {
+    "id": "@babel/helper-validator-option:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8",
+    "md5": "d22673cb3b1ea3e3127bb12d507a036c",
+    "sha256": "3efdfe87e7e6830c5091ee369a27368e263d9dab8cfc7f0f41e7f9b9c5aec9cf"
+    },
+    {
+    "id": "ms:2.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:4.3.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d09d1f357b443f493382a8eb3ccd183872ae6009",
+    "md5": "5a8310f20fd4b97c7f8eeaf65f896a7a",
+    "sha256": "1157a6e30d3ffe1b9fcaf3a39caf159f8dc981199a3380c78ddd89f73bcefb48"
+    },
+    {
+    "id": "browser-stdout:1.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "baa559ee14ced73452229bad7326467c61fabd60",
+    "md5": "82ebb0cdcee39bc8953381ac71cad549",
+    "sha256": "bf7534c1382579f4e8856acc39b3e34c49a1ce94171ad1eaabfab320369bb111"
+    },
+    {
+    "id": "binary-extensions:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-binary-path:2.1.0",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
+    "md5": "bb73db2f62b2dbe0cd6f73eef702c994",
+    "sha256": "0f81fa2208e48444f1314a44320e6a50e5786ffe35bf5e377854120204c7d623"
+    },
+    {
+    "id": "locate-path:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "55321eb309febbc59c4801d931a72452a681d286",
+    "md5": "88dec34f94138c96fd50374b3ff54935",
+    "sha256": "71d20b2743581b997191a760edc54df51dcea7c53b12c613cabc360f636d832a"
+    },
+    {
+    "id": "find-up:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
+    "md5": "aa0b377135f4af38d106db8b84606924",
+    "sha256": "33a9b0535306d2e05e0a27088b68344b52ac767d576ef60b7ab173aa0d5a26eb"
+    },
+    {
+    "id": "js-tokens:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "19203fb59991df98e3a287050d4647cdeaf32499",
+    "md5": "325b11b965688c69ae45a3cf771fbc5c",
+    "sha256": "d884c7a2d8adb5568c1272d92b4f9c62707f4226cf9e7b22e7b957c7361e3c53"
+    },
+    {
+    "id": "@babel/helper-environment-visitor:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0c0cee9b35d2ca190478756865bb3528422f51be",
+    "md5": "62eaa04ce85291b537bd92b4cba422a3",
+    "sha256": "00aa1c2f172719e15df07a13833cd9632c51ec20ce87c68bfa10deff44545af3"
+    },
+    {
+    "id": "@babel/parser:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f2dde0c682ccc264a9a8595efd030a5cc8fd2539",
+    "md5": "374150ff1ab6268dd1248d12950e392d",
+    "sha256": "a4fba8f4f3542a6b44e848fa989ba96e4ad4ee2c1020139c3dc0093260ba2ecc"
+    },
+    {
+    "id": "mocha:9.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d70db46bdb93ca57402c809333e5a84977a88fb9",
+    "md5": "efdae5243a066904827b3adfc3393733",
+    "sha256": "829065fecd9d6eb25c755a05d5ca748da3ad775e6d30d24abba5791039218492"
+    },
+    {
+    "id": "test-exclude:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04a8698661d805ea6fa293b6cb9e63ac044ef15e",
+    "md5": "c9d2be086d4d740f9999b77971777008",
+    "sha256": "e77c50f9beeebe95b599dff7f94c539dad4ab2326ee4048e1f22105e4c15c66e"
+    },
+    {
+    "id": "get-caller-file:2.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+    "md5": "1b9de5ead51b8886be998f58fdb96476",
+    "sha256": "7b13e1c81949ff4c1baae4ac4e34990492d5e8a86dab7e3b90027b1f5126935f"
+    },
+    {
+    "id": "resolve-from:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c35225843df8f776df21c57557bc087e9dfdfc69",
+    "md5": "23cff3fc62d9dd916e67da9c9505603f",
+    "sha256": "fdf7cffeccad13cf433fe9399b291c5437de4b43c83ea0d535294e1b3d4f25e3"
+    },
+    {
+    "id": "lodash.flattendeep:4.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
+    "md5": "17ca06c4643969cb10e948854434eba0",
+    "sha256": "02cd21eeeb3f2713b129c76333e861657ed74a6a83f3c4dc0e5dacebcd9b21c8"
+    },
+    {
+    "id": "commondir:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+    "md5": "329b8682e83ec34dfe1c58ae90b84988",
+    "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0"
+    },
+    {
+    "id": "escape-string-regexp:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+    "md5": "02440084832abe665260d5db1da1dd9e",
+    "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+    "id": "supports-color:5.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+    "md5": "17b1003344e0e0d2719205be85946698",
+    "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
+    },
+    {
+    "id": "istanbul-reports:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cc9a6ab25cb25659810e4785ed9d9fb742578bae",
+    "md5": "37a18bd3f4140ff1690f1048aef18171",
+    "sha256": "a118d2013c68c83b81acabbfa2df3e2838e1e2f5a53d3045c208689540c48d85"
+    },
+    {
+    "id": "yargs:16.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+    "md5": "23787ef1801c6394b3bdee59580dd6c8",
+    "sha256": "461dfd148ca865daeaaac4922e6b8ffd999f802589d0cd373a32bb4ddc76abf5"
+    },
+    {
+    "id": "clean-stack:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "aggregate-error:3.1.0",
+    "p-map:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ee8472dbb129e727b31e8a10a427dee9dfe4008b",
+    "md5": "98495454e4106c25e5ed97ae9a6b1148",
+    "sha256": "056c37660ab8c6ff60e5b25b883241c335478fee9c1ab1ec4c15bf891cf55655"
+    },
+    {
+    "id": "nanoid:3.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "6347a18cac88af88f58af0b3594b723d5e99bb35",
+    "md5": "1a27cf077cc40c51811677adab047a31",
+    "sha256": "ad5542a3de899dbd0c2728a94b844ebb00794bb7762d3c1676de14de83f6135e"
+    },
+    {
+    "id": "isexe:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which:2.0.2",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+    "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+    "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+    "id": "workerpool:6.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "827d93c9ba23ee2019c3ffaff5c27fccea289e8b",
+    "md5": "a1e0bfe26fa42fcc8898777d366b3457",
+    "sha256": "5cbec29ff60e6176083cdfe869eaf15b32a2410746730b3ce424dc84e9f8472b"
+    },
+    {
+    "id": "make-dir:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "415e967046b3a7f1d185277d84aa58203726a13f",
+    "md5": "e47d13370c2b27671a13f28ebc27585f",
+    "sha256": "ec54ab8aa54b1161fd346e870e587be6595d9c8ea90f5485b7367df7575674dc"
+    },
+    {
+    "id": "globals:11.12.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ab8795338868a0babd8525758018c2a7eb95c42e",
+    "md5": "712d15395573404a3ddb37ce395d948b",
+    "sha256": "38a58c45c2857fdca4db807682e46ad9da6b59ed2080c308b84bcfbdf7eb5af6"
+    },
+    {
+    "id": "brace-expansion:1.1.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "minimatch:3.1.2",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "minimatch:3.1.2",
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+    "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+    "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+    "id": "cliui:7.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a0265ee655476fc807aea9df3df8df7783808b4f",
+    "md5": "c3a8fba555857874ad0dffba34a2289f",
+    "sha256": "a7f4835b8683e8826a4313c1022ee78f1fd94f77806995be5e5e6daaca5403bb"
+    },
+    {
+    "id": "node-releases:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8a7088c63a55e493845683ebf3c828d8c51c5503",
+    "md5": "86970ccb7f3cf344f56b70be69b316cf",
+    "sha256": "8b34c017dbfac06f45d6c9de2e32d2d5335cafdffaa9c2ba5aa756c854617eff"
+    },
+    {
+    "id": "@babel/helpers:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "4bef3b893f253a1eced04516824ede94dcfe7ff9",
+    "md5": "029dea1cf8f08d6602536f2650d9f25c",
+    "sha256": "912bfc1b1aaea6ffb32155c8f7c783ccf48d80a04b9ad9853080b4a10206d8d4"
+    },
+    {
+    "id": "chokidar:3.5.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1cf37c8707b932bd1af1ae22c0432e2acd1903bd",
+    "md5": "058cc35293e3dfdf9cf4f122206e9ed6",
+    "sha256": "2ecbd23217998661de76f061e65e01263882c5a88bffb28f362323b185935c1a"
+    },
+    {
+    "id": "graceful-fs:4.2.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "package-hash:4.0.0",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+    "md5": "094ac6976c4cec6cced67915d6c726c0",
+    "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+    "id": "decamelize:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs-parser:18.1.3",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+    "md5": "330932e4de0e60c36114facb6d3dfafa",
+    "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
+    },
+    {
+    "id": "append-transform:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "99d9d29c7b38391e6f428d28ce136551f0b77e12",
+    "md5": "3fdaa8ee7fab3c1ab71b4ef98a55a239",
+    "sha256": "4d56be51c38f3dff577e6160df3dd080d710b58eaa62de66534f504d11da9e43"
+    },
+    {
+    "id": "default-require-extensions:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "append-transform:2.0.0",
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96",
+    "md5": "7f046d603b546f69f7ab4d7ef2b41b28",
+    "sha256": "ea5eeead2e3b0bd77faad8b6d9bfa30bd65cc6943e1779be958c872065fb62ba"
+    },
+    {
+    "id": "@babel/helper-validator-identifier:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/types:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9c97e30d31b2b8c72a1d08984f2ca9b574d7a076",
+    "md5": "f4d15f6582c54e6a9ad8dfda2c073c6b",
+    "sha256": "110e5d9854308bafa7de7e79e31b4ab34b8720e44cd28adb66ab19b790d57e19"
+    },
+    {
+    "id": "picocolors:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
+    "md5": "743f01bf24bb6492555959fdeb7e9918",
+    "sha256": "6062ec2ba406ea15e5f91a4da300f07eef6505b0e77af3ae92dd471cd915f383"
+    },
+    {
+    "id": "@babel/helper-simple-access:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d6d8f51f4ac2978068df934b569f08f29788c7ea",
+    "md5": "d0e1a86f6785eb7548411ed182da8374",
+    "sha256": "7b37715bb3decd3b3a2144244d321aafb3b9b9ef034f53a22cd1e828a101c040"
+    },
+    {
+    "id": "@ungap/promise-all-settled:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aa58042711d6e3275dd37dc597e5d31e8c290a44",
+    "md5": "b2752b39b9322878e731606f6ec568a1",
+    "sha256": "1ecc2fc041eb44df4cc2d9c574ad862ac02b050c8e49b5590aed9058ae3671d4"
+    },
+    {
+    "id": "color-convert:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:4.3.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+    "md5": "0248ebc952524207e296a622372faa1f",
+    "sha256": "920fa43538c019a085dbbf04cb6f72cc337624e5f5217519f0e7b2ef784e7ce1"
+    },
+    {
+    "id": "escalade:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+    "md5": "61feaad8ca2ae37eff46aa4818a7b045",
+    "sha256": "60f830428beb9022a2da1a31a41eef5aee4b27013f88d16535322b9a238ba79d"
+    },
+    {
+    "id": "locate-path:5.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
+    "md5": "13cc8f708d7f9f5ad9cda1a3c5ff3344",
+    "sha256": "ae3d1b9360a435840a81a8c7da29f59630dd793c3f39a08f15f73fd3894053b7"
+    },
+    {
+    "id": "p-try:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "p-limit:2.3.0",
+    "p-locate:4.1.0",
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cb2868540e313d61de58fafbe35ce9004d5540e6",
+    "md5": "49994562e1f3cbe260710598cbb3edf7",
+    "sha256": "a390b2b89899df950afc0304eaba7cd1f5e3746b2e370758a9b50f177e713790"
+    },
+    {
+    "id": "imurmurhash:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+    "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+    "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+    "id": "yocto-queue:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:3.1.0",
+    "p-locate:5.0.0",
+    "locate-path:6.0.0",
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b",
+    "md5": "69e27040e38c5b03127488546dc282ea",
+    "sha256": "c772bceca58f20f0ea08ac6121ba385f55db715cd3c2c46b2b38d06d3c6129f1"
+    },
+    {
+    "id": "path-exists:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:5.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
+    "md5": "d3652d47b80b1aa623e820d7d276b27b",
+    "sha256": "dbb535c9302ce9b3f777ece3ff055cc8d88890a1e1deddc045340aef76fb775c"
+    },
+    {
+    "id": "inherits:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+    "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+    "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+    "id": "p-locate:4.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "pkg-dir:4.2.0",
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "locate-path:5.0.0",
+    "find-up:4.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a3428bb7088b3a60292f66919278b7c297ad4f07",
+    "md5": "ef4841bc32d15f49592f42a89d3f8cfd",
+    "sha256": "d95a6ae462e3d967deb0c250bda1c3bbebfe86a58832d27b204c7b74a76fa5f0"
+    },
+    {
+    "id": "get-package-type:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8de2d803cff44df3bc6c456e6668b36c3926e11a",
+    "md5": "53c447a09cbf8afb25d97e78bf4a1397",
+    "sha256": "f1c3619acfbbbb090e054336310cf1cdb7761a0a843733e77b1d5b877f72b210"
+    },
+    {
+    "id": "@jridgewell/gen-mapping:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9",
+    "md5": "de5b5402b140d1634f9bbf189b298ee3",
+    "sha256": "8176fad9663205ddefe81637fcc24097dded9716ad300a3d8ede3062e4cfc6fd"
+    },
+    {
+    "id": "p-map:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d704d9af8a2ba684e2600d9a215983d4141a979d",
+    "md5": "3b38970091b03645f6f4d6680ada671d",
+    "sha256": "79f172094ebdfe97403e3f80ed8cc1bb10e533213a6fbe458ef79004c5aab296"
+    },
+    {
+    "id": "cliui:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "511d702c0c4e41ca156d7d0e96021f23e13225b1",
+    "md5": "9065a0615794d52f19cffa078701d382",
+    "sha256": "538bfc9753338f8eb816c46e7e541b3bbada18446cf8b5149cfaaafff01acbd8"
+    },
+    {
+    "id": "@types/mocha:9.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4",
+    "md5": "af8133831578083c75040f5ab0981fff",
+    "sha256": "6587cb469be76e37c4be6cf9d70b002c78b37025c599ef6ffe5c132d93a88d9d"
+    },
+    {
+    "id": "cross-spawn:7.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f73a85b9d5d41d045551c177e2882d4ac85728a6",
+    "md5": "e8b91e2f179097df541bc96ebb11b8bf",
+    "sha256": "11c58814090217e3effa2b4c28e0398683da87d6cb35441d846c2a38cf4a7205"
+    },
+    {
+    "id": "path-key:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "581f6ade658cbba65a0d3380de7753295054f375",
+    "md5": "4f4b9beb2d53481341e16133a8570dc5",
+    "sha256": "4b8999acb914830edcd3c5b8fec632b32c6bc759ac3edc86336f5a9e08ba7b92"
+    },
+    {
+    "id": "caniuse-lite:1.0.30001368",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c5c06381c6051cd863c45021475434e81936f713",
+    "md5": "1762454bac8432336003f3f2740b008b",
+    "sha256": "174dceca41249223bdf0923ef3065692bb095161607d0ca5376ab63305b76e92"
+    },
+    {
+    "id": "require-main-filename:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d0b329ecc7cc0f61649f62215be69af54aa8989b",
+    "md5": "8b45166659a670e83387649f79c641ad",
+    "sha256": "c5bb566318fb6091c7c2ac7c0aba6eeb7b332ffcfafad2268a2dc12a4d428e00"
+    },
+    {
+    "id": "js-yaml:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+    "md5": "2a522c3e23f7999abd8f852c012c20dd",
+    "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+    "id": "minimatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+    "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+    "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+    "id": "color-name:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:2.0.1",
+    "ansi-styles:4.3.0",
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c2a09a87acbde69543de6f63fa3995c826c536a2",
+    "md5": "a8d4412852471526b8027af2532d0d2b",
+    "sha256": "507b7c4461e8eb941355af9a59e9a7e02cd0e7c6176b48d1809766344f3f1708"
+    },
+    {
+    "id": "decamelize:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "aa472d7bf660eb15f3494efd531cab7f2a709837",
+    "md5": "17113f86fb93e54ad64017cac7c80002",
+    "sha256": "e4533ffad5fe578500b72f12bea96e226251ed6034162af1fb99bff93416f59f"
+    },
+    {
+    "id": "@jridgewell/resolve-uri:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/trace-mapping:0.3.14",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "2203b118c157721addfe69d47b70465463066d78",
+    "md5": "bdc32c6b7d0a978faf304b94ba607f93",
+    "sha256": "fe4cb2ab38b4813b27926d9e08852ad81d8c14d0034cfa4a23555ec134ee16b0"
+    },
+    {
+    "id": "node-preload:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c03043bb327f417a18fee7ab7ee57b408a144301",
+    "md5": "120f936cf9cfb9aaf63819850ee25dab",
+    "sha256": "a8fb3ae5af7dda060ad407826c101393134b25d040996e6586b9a77722563cb6"
+    },
+    {
+    "id": "braces:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3454e1a462ee8d599e236df336cd9ea4f8afe107",
+    "md5": "3ed11e666a13cb0da288c6f445b2601f",
+    "sha256": "735881928fd4cf6e0c469c7ec6f66f49133563b840ef2f6c6098943a4250eace"
+    },
+    {
+    "id": "randombytes:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "serialize-javascript:6.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "df6f84372f0270dc65cdf6291349ab7a473d4f2a",
+    "md5": "efb164d8addf215512a3bb6dd19a1496",
+    "sha256": "b8a6d3e6532817912ad3dacbb0e64be75026941a5167549aa1d7fecbafd1bcaa"
+    },
+    {
+    "id": "string-width:4.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "269c7117d27b05ad2e536830a8ec895ef9c6d010",
+    "md5": "41b9a8984f249b332c0ae05f8b4688a9",
+    "sha256": "adbb4fb1b26e8069af99adff0079369c93f17cf887b91086691d671ddbd52934"
+    },
+    {
+    "id": "caching-transform:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "00d297a4206d71e2163c39eaffa8157ac0651f0f",
+    "md5": "82a03704703e883379f146caa805b457",
+    "sha256": "9734acc0e8f17d4261eb9bd13f3edd6cc7941e3ddfa15626a5259786dc478d44"
+    },
+    {
+    "id": "browserslist:4.21.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "update-browserslist-db:1.0.5",
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "59a400757465535954946a400b841ed37e2b4ecf",
+    "md5": "b7595f1787cc1f79d334efbfd10c7b0e",
+    "sha256": "cf0524be457eb24273a426cdf6651af11a8df6817bcb284366b0889591473f65"
+    },
+    {
+    "id": "update-browserslist-db:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "be06a5eedd62f107b7c19eb5bcefb194411abf38",
+    "md5": "2a4f39c3cad79d0f127387a479d7348c",
+    "sha256": "44ce49ceb80c9b30c8860ae914df75cc88b8a0a65a2aa471f87659af97777a15"
+    },
+    {
+    "id": "@babel/helper-function-name:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "940e6084a55dee867d33b4e487da2676365e86b0",
+    "md5": "5a360d6490679bc8050ae8342bce1d68",
+    "sha256": "089fc866e1349e85fe331ddf5388afae1d42271fe105a3951024fe6b55f88e0b"
+    },
+    {
+    "id": "normalize-path:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:3.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "0dcd69ff23a1c9b11fd0978316644a0388216a65",
+    "md5": "2821b760c1df5dcc38328f154a6ea3cb",
+    "sha256": "0b983cca55c555cdc0e919ed5ecd0e4648f6e303f9dffeb449f1ad760d4f84fe"
+    },
+    {
+    "id": "supports-color:7.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1b7dcdcb32b8138801b3e478ba6a51caa89648da",
+    "md5": "da58ae58b985905e1445bc447625dc1b",
+    "sha256": "f16acafd1634624e60c24a5538004c4e168c82607f10dbe28395e9df3e7d5e4a"
+    },
+    {
+    "id": "@istanbuljs/load-nyc-config:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fd3db1d59ecf7cf121e80650bb86712f9b55eced",
+    "md5": "d46010939e33d1d4e7dfce54fc60d89a",
+    "sha256": "4ad534a19208b4f8ae1b7e659635c2a74933f1ee0061de7adf100c6e1128b39e"
+    },
+    {
+    "id": "esprima:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+    "md5": "c9d44a818c324d707a81b08dd36cd079",
+    "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+    "id": "istanbul-lib-coverage:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-report:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "189e7909d0a39fa5a3dfad5b03f71947770191d3",
+    "md5": "799503e96989c6a2906f2c58bc51f0d6",
+    "sha256": "fc2238bf728adc2795114f3d681d45c5f0dc7a7ee640a4af642743797c2b4fef"
+    },
+    {
+    "id": "color-name:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:1.9.3",
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+    "md5": "b45186c4fe76a2450ec484149ade0066",
+    "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+    "id": "has-flag:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:5.5.0",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+    "md5": "1fa1fa951639c7058277abcecca86922",
+    "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+    "id": "argparse:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
+    "md5": "864f41f5cacfed3315deeba37ba7954b",
+    "sha256": "27903847fc8215e6fc5a33e81490f7baba66403f8aade33771b988cca097728c"
+    },
+    {
+    "id": "path-is-absolute:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+    "md5": "18bfccb10294ae19e7eb616ed1c05176",
+    "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+    "id": "balanced-match:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:4.2.1",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+    "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+    "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+    "id": "type-fest:0.8.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "hasha:5.2.2",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "09e249ebde851d3b1e48d27c105444667f17b83d",
+    "md5": "4bcceb8c6c02dfd452ce9f2564eed691",
+    "sha256": "9f196f4105285775fc89dc50afe583e8576cf2043e111430159c4c3dc8b2f5c7"
+    },
+    {
+    "id": "@babel/highlight:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "81158601e93e2563795adcbfbdf5d64be3f2ecdf",
+    "md5": "6be4064f31d9e3fdd17994bd177ef426",
+    "sha256": "f54e6c10da061b163dd744a9ee2f0f3560d26d5cb1d4e81c9bc9ff6bcdcba664"
+    },
+    {
+    "id": "istanbul-lib-report:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-reports:3.1.5",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
+    "md5": "87a16f7a36e489fdd042510550872167",
+    "sha256": "0c3149f3222df87e1980647ec9904bb4452b996772e62b3827d4399b831cae3a"
+    },
+    {
+    "id": "glob:7.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "rimraf:3.0.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
+    "md5": "05f5ea4a12aecafd90fe04c32385ce80",
+    "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
+    },
+    {
+    "id": "is-glob:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob-parent:5.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+    "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+    "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+    "id": "wrap-ansi:7.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "67e145cff510a6a6984bdf1152911d69d2eb9e43",
+    "md5": "85a965a6e2a0944eafcbca7e5ab07ed5",
+    "sha256": "0795b3510bd2e938f6a415396de3d4f58fd76ef1f8249a07196444eaf85ca42f"
+    },
+    {
+    "id": "is-stream:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "hasha:5.2.2",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
+    "md5": "c3a1ab9ba58463f1dead35dc9d5aba9a",
+    "sha256": "3501ff72a20b78f1a2170a4982d82d9a71d16b99a935bec9787f1c486d61b6d7"
+    },
+    {
+    "id": "ansi-styles:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+    "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+    "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+    "id": "@babel/helper-compilation-targets:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf",
+    "md5": "e4bb285eb8cfaafeb0964e277713e836",
+    "sha256": "b1045536c086bdc82da52399401e7fabeacf8c52f38c653f04e921d3def4b74f"
+    },
+    {
+    "id": "yargs-parser:18.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "be68c4975c6b2abf469236b0c870362fab09a7b0",
+    "md5": "4d5c278a0e6c1d7a11f1ae5079f57602",
+    "sha256": "0c9135ee2330fd9cdc19fed11b8d9a7b292f5dd8ddf40c13b051340693ebbe58"
+    },
+    {
+    "id": "anymatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "c0557c096af32f106198f4f4e2a383537e378716",
+    "md5": "b71f406c504180e27c3c7fa72d0e6a8f",
+    "sha256": "ca680b3cae7eef97d0c5b95156587a30cd082941e9ce43d2bdf264573eea5b14"
+    },
+    {
+    "id": "which:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7c6a8dd0a636a0327e10b59c9286eee93f3f51b1",
+    "md5": "9556a736013ff5223cc9731d9f32b55f",
+    "sha256": "a13adf5fddeb769655edce551e81fbb11904b9c9be76d95e41da8c4c499d4edc"
+    },
+    {
+    "id": "@jridgewell/sourcemap-codec:1.4.14",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/gen-mapping:0.1.1",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/trace-mapping:0.3.14",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "add4c98d341472a289190b424efbdb096991bb24",
+    "md5": "b462c7a5932255e273725bf451bd36ce",
+    "sha256": "b7430e808b04aeba42441a44b783068c1923b8aa3f6f91fc1d789383b0c53941"
+    },
+    {
+    "id": "chalk:2.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+    "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+    "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+    "id": "archy:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+    "md5": "b2a24c65e2212f53168f984b5a693dbd",
+    "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26"
+    },
+    {
+    "id": "istanbul-lib-source-maps:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "895f3a709fcfba34c6de5a42939022f3e4358551",
+    "md5": "2b0cd1493c52493181871afc3c5a93be",
+    "sha256": "104845ef8ef44acfe9c3c2f716288fb6b5798c03b3997b32c7d89e6406f47c93"
+    },
+    {
+    "id": "debug:4.3.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-source-maps:4.0.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "04266e0b70a98d4462e6e288e38259213332b664",
+    "md5": "e0e3067fdf8e98f4d817683191280e8e",
+    "sha256": "5fa9d542c65bca3df3a7445581b62a7c61b25dd11fe6f79a1b9b29236cafcced"
+    },
+    {
+    "id": "is-extglob:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-glob:4.0.3",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+    "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+    "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+    "id": "y18n:5.0.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+    "md5": "6018afaa99207dafc81cb56404a31454",
+    "sha256": "d43743bad3a7cb3af5d3b6bf70fd32fe3923ea86e4148109c6dd0126deada769"
+    },
+    {
+    "id": "fill-range:7.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1919a6a7c75fe38b2c7c77e5198535da9acdda40",
+    "md5": "279e60751b8b0e89226a9e9bd5b8f275",
+    "sha256": "28cdfdbcf2b2d92ef67ed76097017c5220b0dee95898184d6c8dfde7781de972"
+    },
+    {
+    "id": "once:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+    "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+    "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+    "id": "safe-buffer:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randombytes:2.1.0",
+    "serialize-javascript:6.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "convert-source-map:1.8.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+    "md5": "dc7142b470e0957c5c34098b6fced0ab",
+    "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+    "id": "@istanbuljs/schema:0.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "test-exclude:6.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e45e384e4b8ec16bce2fd903af78450f6bf7ec98",
+    "md5": "868e08ce450f7d9d5cd29997f0865f17",
+    "sha256": "1d7cba774f9a37f770cb5e5f56727342c98ab5ee517b6862d56aa2df82b6e5e0"
+    },
+    {
+    "id": "@babel/generator:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "68337e9ea8044d6ddc690fb29acae39359cca0a5",
+    "md5": "ced102e1a657c80aeac9c54297b0c51a",
+    "sha256": "ecfd6a96062cf06c56236cc2ddbd02e8a978c883b6d1e68d7ec7b7acf833a2ee"
+    },
+    {
+    "id": "uuid:8.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "istanbul-lib-processinfo:2.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+    "md5": "001956ff1c0a16e6bae8bae042ba226b",
+    "sha256": "f630703647a5821c735a542edcf8d26c989724efe9d9912ab6f6836a1e79924a"
+    },
+    {
+    "id": "set-blocking:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+    "md5": "ff057cf430b35ecb25780f94cd051ab3",
+    "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+    "id": "escape-string-regexp:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "14ba83a5d373e3d311e5afca29cf5bfad965bf34",
+    "md5": "6c4ea446a9f85d76c9b3e599a9ea25b5",
+    "sha256": "4b44a14da6987a3c0585c2ff16b3800425732ff35cad710c65e72d7f8e33b11b"
+    },
+    {
+    "id": "@babel/helper-module-transforms:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "5a1079c005135ed627442df31a42887e80fcb712",
+    "md5": "19160955f01c62275ff14f0daa5706f6",
+    "sha256": "c6f2dbdfa8850bdbe650a350f419535e8cbb95339a0b15ab028e6a1b78ef2afc"
+    },
+    {
+    "id": "is-windows:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+    "md5": "bcc9525ed3558792d281951c90ad366e",
+    "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+    "id": "camelcase:5.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "yargs-parser:18.1.3",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e3c9b31569e106811df242f715725a1f4c494320",
+    "md5": "efcf73180d9b7001c92f574d4ae7f908",
+    "sha256": "c609324ab889515f2f7354ddcc319b6080c9b76f2ac1441c03da031c85458696"
+    },
+    {
+    "id": "package-hash:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3537f654665ec3cc38827387fc904c163c54f506",
+    "md5": "0f9f3fd2b83a4aaf53ca7436bcc76845",
+    "sha256": "35f3408c1370c166c2b8197656437bce5f47e505074fcf288e492919694a15e6"
+    },
+    {
+    "id": "electron-to-chromium:1.4.196",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "browserslist:4.21.2",
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e18cdc5c1c2c2ebf78da237d0c374cc3b244d4cb",
+    "md5": "e65dea46a634f06ef01bd9d9d84da73a",
+    "sha256": "fde9ab86721e9199b2a0b3ac946e4103ae1799a6813db0a4ef8881d0558750aa"
+    },
+    {
+    "id": "process-on-spawn:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-preload:0.2.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "95b05a23073d30a17acfdc92a440efd2baefdc93",
+    "md5": "acaca9f6065528d5b79d3d3501b5a745",
+    "sha256": "d3ce9515289d5350cdfa10cff7bb163650d4713ea72ad99cffe0a99b075bea03"
+    },
+    {
+    "id": "is-number:7.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "to-regex-range:5.0.1",
+    "fill-range:7.0.1",
+    "braces:3.0.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7535345b896734d5f80c4d06c50955527a14f12b",
+    "md5": "6c6e00114e00c2815fc0aeae3da1af23",
+    "sha256": "7b75c1057198cf97696909a9bee176c9c5e9bcb5b03bf3ecef2f484defadd51e"
+    },
+    {
+    "id": "supports-color:8.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cd6fc17e28500cff56c1b86c0a7fd4a54a73005c",
+    "md5": "16e8e38709a4675f8ea1482806cb050c",
+    "sha256": "ea69d9b5801e109932f9f12b5499c06de3fde936119a21c5941b2759d4364fb0"
+    },
+    {
+    "id": "emoji-regex:8.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:4.2.3",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e818fd69ce5ccfcb404594f842963bf53164cc37",
+    "md5": "598b731d8d33cfff04377ad55da187b0",
+    "sha256": "b5ccd9fbfb08098eefbeb6b6b4b40db6db3acf9243e327e039925aa8661cb107"
+    },
+    {
+    "id": "convert-source-map:1.8.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f3373c32d21b4d780dd8004514684fb791ca4369",
+    "md5": "d1c553aaaffba79be7073471b2619511",
+    "sha256": "8ff5f30e96cd04fe8e5a99b85526ce0746b34f2b7e314df40dc643742aecfaaa"
+    },
+    {
+    "id": "pkg-dir:4.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-cache-dir:3.3.2",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "f099133df7ede422e81d1d8448270eeb3e4261f3",
+    "md5": "5e6cbcda90ee1b6006cbf5a5945048eb",
+    "sha256": "a7f4456094d571d70d29f32aa5fa1c738cb8c7087034661078b8678f0153224d"
+    },
+    {
+    "id": "shebang-regex:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shebang-command:2.0.0",
+    "cross-spawn:7.0.3",
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ae16f1644d873ecad843b0307b143362d4c42172",
+    "md5": "800d00b53670160a44fa6116b1cbb6e5",
+    "sha256": "fedbabaa6db26c6be0183f82777dfa852d59a62f8885de93bd32ebc28758958f"
+    },
+    {
+    "id": "istanbul-lib-processinfo:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "366d454cd0dcb7eb6e0e419378e60072c8626169",
+    "md5": "6053742aadc8e3ef55d8808d24ef2b59",
+    "sha256": "4df1e5e9927bb39e18ed3a2d2d567c8e66ce54ded31704e36d34d1d70697f99c"
+    },
+    {
+    "id": "picomatch:2.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:3.1.2",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "readdirp:3.6.0",
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "3ba3833733646d9d3e4995946c1365a67fb07a42",
+    "md5": "fa0a8505a751a04b4cff2285257ddf73",
+    "sha256": "1b14ee9ec867c090d7b52c77193d83e77910553b3d18b2f86dd2b7b55e82c11f"
+    },
+    {
+    "id": "@jridgewell/trace-mapping:0.3.14",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b231a081d8f66796e475ad588a1ef473112701ed",
+    "md5": "55173b301ee67c9e20d5b60835018a67",
+    "sha256": "7f5c917fa0abdcc4cbd99f49fe1dcccdac40151c0ec18d8163325c643c64a993"
+    },
+    {
+    "id": "to-fast-properties:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/types:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
+    "md5": "ac0b1f7eef6a645d444e9ad835d1950a",
+    "sha256": "c713fe48bc243fb0505dfc66f0c9fda8aec9c98c152b80cf44d459345f4e0983"
+    },
+    {
+    "id": "ansi-styles:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:4.1.2",
+    "log-symbols:4.1.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:7.0.0",
+    "cliui:7.0.4",
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "wrap-ansi:6.2.0",
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "edd803628ae71c04c85ae7a0906edad34b648937",
+    "md5": "0534616a9bab55e3e2d350f9ab77ea22",
+    "sha256": "2c539a46d85ab6033183997434d2d9a5ca2ceefc12b4db9022f564784cd7987f"
+    },
+    {
+    "id": "typedarray-to-buffer:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
+    "md5": "d693220f5eabe1359169bb992abaa064",
+    "sha256": "2b264d84a680cb57b9ee9e6f0bf8a365c79465408509116a2c52461dcc1ff936"
+    },
+    {
+    "id": "find-cache-dir:3.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
+    "md5": "52bbc85bfe0ddab6259eb6618900ab61",
+    "sha256": "4be0abb89e1a007faecb5129fdb160d77aaf589fe1d82200c749840eb71ce204"
+    },
+    {
+    "id": "istanbul-lib-instrument:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "873c6fff897450118222774696a3f28902d77c1d",
+    "md5": "ee314a8a3153abd9396916f9e141d374",
+    "sha256": "d9840e3cd2576110a2ef1a3984fabc9450229bc2fc4950153e49c84bd83e465a"
+    },
+    {
+    "id": "color-convert:1.9.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "@babel/highlight:7.18.6",
+    "@babel/code-frame:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+    "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+    "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+    "id": "ansi-colors:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "cbb9ae256bf750af1eab344f229aa27fe94ba348",
+    "md5": "ce72bb5360d8326616cae64d8ae9bdfe",
+    "sha256": "24d803210289f2afc6448276aa9d5a9608e86e584698307d2365d93195cf1f44"
+    },
+    {
+    "id": "is-plain-obj:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "45e42e37fccf1f40da8e5f76ee21515840c09287",
+    "md5": "23b716d73535a85a95b57d53d7ac5df6",
+    "sha256": "6b6423e1b1aa7427594b9d5a69d430ab309d47ed71a31cfc0306f2b47e070fb5"
+    },
+    {
+    "id": "argparse:1.0.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "@istanbuljs/load-nyc-config:1.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+    "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+    "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+    "id": "@babel/types:7.18.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-imports:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-simple-access:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-split-export-declaration:7.18.6",
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/template:7.18.6",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-function-name:7.18.9",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-hoist-variables:7.18.6",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7148d64ba133d8d73a41b3172ac4b83a1452205f",
+    "md5": "a9bbb05787a9f2f0310fba1d42f84320",
+    "sha256": "1b309d075c4970b84308ab5055b56335e117969d4c9fbb34140adf3e6e4ac63a"
+    },
+    {
+    "id": "which-module:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+    "md5": "ce028f30082fbbea9861a40437d17bd3",
+    "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea"
+    },
+    {
+    "id": "he:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "84ae65fa7eafb165fddb61566ae14baf05664f0f",
+    "md5": "59dd519e72954845f5a01d23c2695903",
+    "sha256": "777a7c030c1b6c0bbe8638136dcc5cedbb36b1082f821b06648de5d7d11c1b68"
+    },
+    {
+    "id": "strip-bom:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "default-require-extensions:3.0.0",
+    "append-transform:2.0.0",
+    "istanbul-lib-hook:3.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "9c3505c1db45bcedca3d9cf7a16f5c5aa3901878",
+    "md5": "ba5ded28e859d1030ed2f1369e379f67",
+    "sha256": "8880c5faaa4073b8236a50470b966eecf11ee63d5026299e4bb21e5147e3dcab"
+    },
+    {
+    "id": "@jridgewell/set-array:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@jridgewell/gen-mapping:0.1.1",
+    "@ampproject/remapping:2.2.0",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@jridgewell/gen-mapping:0.3.2",
+    "@babel/generator:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "7c6cf998d6d20b914c0a55a91ae928ff25965e72",
+    "md5": "b48ee5bc088b403daf0f66546312ef9a",
+    "sha256": "7585773292098c500f5e8a993357c0b91512696ad6a6f79bd10f2beb84e607ff"
+    },
+    {
+    "id": "gensync:1.0.0-beta.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
+    "md5": "3d1e68bdacb4e8046ccabff0019e916b",
+    "sha256": "df9f92ef26a35d4f92cb8a73415dfea8dadaf294a03e60e4d176df82f38d17c9"
+    },
+    {
+    "id": "y18n:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5f259c82cd6e336921efd7bfd8bf560de9eeedf",
+    "md5": "182c1f29baf6577adccaf23ac94d5ed1",
+    "sha256": "bc4970449801429ba77228a26f03e05ba7e9a5e98111edb44d6a0fc7b6660ecf"
+    },
+    {
+    "id": "wrappy:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "once:1.4.0",
+    "glob:7.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+    "md5": "567b1699cfae49cb20f598571a6c90c7",
+    "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
+    },
+    {
+    "id": "minimatch:4.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "40d9d511a46bdc4e563c22c3080cde9c0d8299b4",
+    "md5": "145e5c35d2aa8d7ade9fcfd6cac624b2",
+    "sha256": "2afcebdaa72e6a049a8b37600f996b86a27e8c755bdb442d8eccd2f2746639b5"
+    },
+    {
+    "id": "ms:2.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+    "md5": "a50e4bf82f754914316bfca3dfbcf352",
+    "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+    "id": "serialize-javascript:6.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
+    "md5": "900d6fc6f653ed171f0e54507edb0e43",
+    "sha256": "284d917617d342241bc32f4d56bf97e32ff08d26e4d5c9704edf8952640e02fc"
+    },
+    {
+    "id": "yargs-parser:20.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "mocha:9.2.2",
+    "jfrogtest"
+    ],
+    [
+    "yargs:16.2.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "b42890f14566796f85ae8e3a25290d205f154a54",
+    "md5": "dded5e7456c94ffc7f4ffddddcac0681",
+    "sha256": "4fe61652a7e5375530ef19f941238fec925f34c7cad78f45bc73afad66bd0121"
+    },
+    {
+    "id": "flat:5.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "yargs-unparser:2.0.0",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "8ca6fe332069ffa9d324c327198c598259ceb241",
+    "md5": "c215e59da15d7b8eccb1db3e47366cb5",
+    "sha256": "d772de42fa0c5e2b3d940c351873743d9149e5d343f11523dcfb6619f8feed42"
+    },
+    {
+    "id": "nyc:15.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1335dae12ddc87b6e249d5a1994ca4bdaea75f02",
+    "md5": "28c5baf103508c15fc352a367910f0c4",
+    "sha256": "b6977f5b5a89c9c7036c09d618d576d30ecdd7773ef39e3075090dc9a60625c8"
+    },
+    {
+    "id": "signal-exit:3.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write-file-atomic:3.0.3",
+    "caching-transform:4.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "foreground-child:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "spawn-wrap:2.0.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "a9a1767f8af84155114eaabd73f99273c8f59ad9",
+    "md5": "05cf0ff414a9fc6e30abb6d20780c762",
+    "sha256": "439623fa6aab91600615ec757eaa137fcab40d3b35dda38df7444c15678f20a8"
+    },
+    {
+    "id": "glob-parent:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:3.5.3",
+    "mocha:9.2.2",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "869832c58034fe68a4093c17dc15e8340d8401c4",
+    "md5": "b10ba1a21ff8ef737fe83ca5f33684a0",
+    "sha256": "9616afebd18b93592a79d48cce6a841604593ae90563f0ec5554a07b6952d6d5"
+    },
+    {
+    "id": "@babel/template:7.18.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-module-transforms:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helpers:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/helper-function-name:7.18.9",
+    "@babel/traverse:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "1283f4993e00b929d6e2d3c72fdc9168a2977a31",
+    "md5": "bc579b67a5099d381f57dc938f2c132d",
+    "sha256": "aef8c9facb86709c1cb53264cdeca13b86bb3eeeb53d86294f05fbfd54562e25"
+    },
+    {
+    "id": "wrap-ansi:6.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cliui:6.0.0",
+    "yargs:15.4.1",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "e9393ba07102e6c91a3b221478f0257cd2856e53",
+    "md5": "f8917d0c5de3cfd4ab98a235260b3951",
+    "sha256": "d46fc412f04d873700a557bc9686d42c0d6c7979e1825cefebf4279ca9d678f8"
+    },
+    {
+    "id": "semver:6.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "@babel/helper-compilation-targets:7.18.9",
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "@babel/core:7.18.9",
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "istanbul-lib-instrument:4.0.3",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ],
+    [
+    "make-dir:3.1.0",
+    "nyc:15.1.0",
+    "jfrogtest"
+    ]
+    ],
+    "sha1": "ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
+    "md5": "e0836faadf4b192c3987c5117d62fff6",
+    "sha256": "6bf14af3333843b62526ced99519918c7f6bf2cfe1c111556d36cf239a4c6745"
     }
-]
+    ]

--- a/build/testdata/npm/project2/npmv8/windows/package-lock.json
+++ b/build/testdata/npm/project2/npmv8/windows/package-lock.json
@@ -17,175 +17,249 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.12.13"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
     "node_modules/@babel/generator": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -195,6 +269,9 @@
       "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
@@ -206,6 +283,9 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
@@ -220,20 +300,26 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
@@ -242,51 +328,69 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
-      "dev": true
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -300,6 +404,9 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
@@ -311,12 +418,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -325,6 +426,9 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
@@ -335,6 +439,9 @@
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -344,6 +451,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
@@ -353,6 +463,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
@@ -362,18 +478,71 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@types/mocha": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -390,19 +559,28 @@
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -411,6 +589,12 @@
       "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -421,6 +605,9 @@
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/append-transform": {
@@ -430,12 +617,15 @@
       "dev": true,
       "dependencies": {
         "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -445,16 +635,19 @@
       "dev": true
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -473,6 +666,9 @@
       "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browser-stdout": {
@@ -480,6 +676,34 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -491,13 +715,35 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/camelcase": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
-      "dev": true
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -507,6 +753,12 @@
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/supports-color": {
@@ -516,13 +768,22 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -532,6 +793,9 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
@@ -540,7 +804,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -560,6 +827,9 @@
       "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
@@ -571,29 +841,23 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -604,22 +868,42 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -628,12 +912,24 @@
       "dev": true,
       "dependencies": {
         "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -652,19 +948,35 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -673,17 +985,26 @@
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -694,13 +1015,22 @@
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
@@ -710,18 +1040,35 @@
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -729,25 +1076,41 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "optional": true
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -761,6 +1124,12 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -770,31 +1139,55 @@
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -804,13 +1197,22 @@
       "dependencies": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -821,19 +1223,25 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -853,19 +1261,28 @@
       "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
@@ -874,55 +1291,82 @@
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/istanbul-lib-hook": {
       "version": "3.0.0",
@@ -931,6 +1375,9 @@
       "dev": true,
       "dependencies": {
         "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-instrument": {
@@ -943,28 +1390,27 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
@@ -975,6 +1421,9 @@
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^3.0.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -984,33 +1433,36 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {
@@ -1026,21 +1478,33 @@
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/locate-path": {
@@ -1050,18 +1514,18 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -1072,6 +1536,12 @@
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -1081,101 +1551,86 @@
       "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-      "dev": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -1184,13 +1639,25 @@
       "dev": true,
       "dependencies": {
         "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -1225,17 +1692,13 @@
         "spawn-wrap": "^2.0.0",
         "test-exclude": "^6.0.0",
         "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=8.9"
       }
-    },
-    "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true
-    },
-    "node_modules/nyc/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
     },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
@@ -1248,12 +1711,6 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/nyc/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
     "node_modules/nyc/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1262,13 +1719,10 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/nyc/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
     },
     "node_modules/nyc/node_modules/locate-path": {
       "version": "5.0.0",
@@ -1277,6 +1731,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/p-limit": {
@@ -1286,6 +1743,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nyc/node_modules/p-locate": {
@@ -1295,26 +1758,9 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
-      }
-    },
-    "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -1326,12 +1772,15 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "node_modules/nyc/node_modules/yargs": {
@@ -1351,6 +1800,9 @@
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
         "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/yargs-parser": {
@@ -1361,12 +1813,15 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -1379,6 +1834,12 @@
       "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -1388,6 +1849,12 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -1397,13 +1864,19 @@
       "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/package-hash": {
       "version": "4.0.0",
@@ -1415,31 +1888,55 @@
         "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -1448,6 +1945,9 @@
       "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/find-up": {
@@ -1458,6 +1958,9 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
@@ -1467,6 +1970,9 @@
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
@@ -1476,6 +1982,12 @@
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
@@ -1485,6 +1997,9 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/process-on-spawn": {
@@ -1494,6 +2009,9 @@
       "dev": true,
       "dependencies": {
         "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/randombytes": {
@@ -1512,22 +2030,31 @@
       "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
@@ -1539,7 +2066,10 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -1548,19 +2078,28 @@
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -1574,7 +2113,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -1584,25 +2123,34 @@
       "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
@@ -1616,12 +2164,15 @@
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/string-width": {
@@ -1633,6 +2184,9 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -1642,19 +2196,31 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -1663,6 +2229,12 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/test-exclude": {
@@ -1674,13 +2246,31 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1689,13 +2279,19 @@
       "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -1706,6 +2302,41 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1713,18 +2344,24 @@
       "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -1736,12 +2373,18 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write-file-atomic": {
@@ -1760,7 +2403,10 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -1775,13 +2421,19 @@
         "string-width": "^4.2.0",
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
@@ -1793,185 +2445,231 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
+      "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.9",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+      "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.18.9",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2008,19 +2706,19 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -2035,47 +2733,47 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+      "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.9",
+        "@babel/types": "^7.18.9",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2100,12 +2798,6 @@
           "requires": {
             "sprintf-js": "~1.0.2"
           }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
@@ -2162,10 +2854,48 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@types/mocha": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -2227,7 +2957,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "argparse": {
@@ -2237,9 +2967,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "binary-extensions": {
@@ -2273,6 +3003,18 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -2286,9 +3028,15 @@
       }
     },
     "camelcase": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "chalk": {
@@ -2313,9 +3061,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -2363,30 +3111,22 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "cross-spawn": {
@@ -2401,18 +3141,26 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "default-require-extensions": {
@@ -2428,6 +3176,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "emoji-regex": {
@@ -2470,9 +3224,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2515,7 +3269,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -2555,6 +3309,17 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -2573,9 +3338,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "growl": {
@@ -2615,7 +3380,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -2627,7 +3392,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -2652,7 +3417,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -2683,15 +3448,15 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -2709,13 +3474,13 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -2740,26 +3505,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
+        "uuid": "^8.3.2"
       }
     },
     "istanbul-lib-report": {
@@ -2785,28 +3541,20 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -2835,13 +3583,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -2852,16 +3597,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "log-symbols": {
@@ -2884,101 +3623,56 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "node-preload": {
@@ -2989,6 +3683,12 @@
       "requires": {
         "process-on-spawn": "^1.0.0"
       }
+    },
+    "node-releases": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -3031,16 +3731,6 @@
         "yargs": "^15.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3052,12 +3742,6 @@
             "wrap-ansi": "^6.2.0"
           }
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3067,12 +3751,6 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -3101,26 +3779,6 @@
             "p-limit": "^2.2.0"
           }
         },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3133,9 +3791,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
@@ -3172,7 +3830,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -3232,7 +3890,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -3241,10 +3899,16 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pkg-dir": {
@@ -3325,7 +3989,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -3334,7 +3998,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {
@@ -3359,9 +4023,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "semver": {
@@ -3382,7 +4046,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shebang-command": {
@@ -3401,15 +4065,15 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "spawn-wrap": {
@@ -3429,7 +4093,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string-width": {
@@ -3482,12 +4146,23 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -3514,6 +4189,22 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3526,13 +4217,13 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "wrap-ansi": {
@@ -3549,7 +4240,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {
@@ -3601,6 +4292,20 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
       }
     },
     "yocto-queue": {

--- a/build/testdata/npm/project3/npmv8/package-lock.json
+++ b/build/testdata/npm/project3/npmv8/package-lock.json
@@ -18,7 +18,7 @@
     "node_modules/json": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
-      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "integrity": "sha512-Nx+4WwMM1xadgqjjteOVEyjoIVq7fGH1hAlRDoxoq2tFzYsBYZDIKwYbyxolkTYwxsSOgAZD2ACLkeGjhFW2Jw==",
       "dev": true,
       "bin": {
         "json": "lib/json.js"
@@ -30,20 +30,20 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     }
   },
   "dependencies": {
     "json": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
-      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "integrity": "sha512-Nx+4WwMM1xadgqjjteOVEyjoIVq7fGH1hAlRDoxoq2tFzYsBYZDIKwYbyxolkTYwxsSOgAZD2ACLkeGjhFW2Jw==",
       "dev": true
     },
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     }
   }
 }

--- a/build/testdata/npm/project4/npmv8/linux/excpected_dependencies_list.json
+++ b/build/testdata/npm/project4/npmv8/linux/excpected_dependencies_list.json
@@ -1,12115 +1,12341 @@
 [
     {
-        "id": "fast-levenshtein:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
-        "md5": "443a739d106c51a33470c9f018d82e85",
-        "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
-    },
-    {
-        "id": "chalk:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.8.0",
-                "babel-traverse:6.8.0",
-                "babel-plugin-transform-es2015-block-scoping:6.8.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-code-frame:6.7.7",
-                "babel-traverse:6.7.6",
-                "babel-eslint:6.0.4",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fancy-log:1.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "run-sequence:1.1.5",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
-        "md5": "d7e0f89d6888d5d9ced994c205926555",
-        "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d"
-    },
-    {
-        "id": "lodash._arrayeach:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
-        "md5": "2500bac4195ee774f346d80500ad77ef",
-        "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "source-map-resolve:0.5.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
-        "md5": "88b0cf532783413eb92e171554ddd28d",
-        "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
-    },
-    {
-        "id": "is-shared-array-buffer:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6",
-        "md5": "262a0c4a277cb35dc227ce4a0f552be1",
-        "sha256": "14b35068e9505161afce57efbd849b33c519d4524f4b2548587d017e51d25897"
-    },
-    {
-        "id": "eslint-plugin-mocha:4.12.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
-        "md5": "3e429cc644ee80c1c60c86478eee616b",
-        "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
-    },
-    {
-        "id": "require-uncached:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
-        "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
-        "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
-    },
-    {
-        "id": "figures:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
-        "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
-        "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
-    },
-    {
-        "id": "cliui:3.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "120601537a916d29940f934da3b48d585a39213d",
-        "md5": "3a83794ba283c15042e429b11802766d",
-        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
-    },
-    {
-        "id": "is-plain-object:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-extendable:1.0.1",
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
-        "md5": "335972afae19ad1eccb8eee9aad94747",
-        "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
-    },
-    {
-        "id": "is-callable:1.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "47301d58dd0259407865547853df6d61fe471945",
-        "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
-        "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
-    },
-    {
-        "id": "chokidar:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
-        "md5": "3b76ca6e8ebf196645910f2985f77385",
-        "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
-    },
-    {
-        "id": "cache-base:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
-        "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
-        "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
-    },
-    {
-        "id": "core-js:2.6.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-runtime:6.26.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
-        "md5": "a1881352eef45832b331dc025db1b72c",
-        "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
-    },
-    {
-        "id": "use:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
-        "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
-        "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
-    },
-    {
-        "id": "path-exists:2.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
-        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
-    },
-    {
-        "id": "string.prototype.trimend:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e75ae90c2942c63504686c18b287b4a0b1a45f80",
-        "md5": "88b629f9cb3e49990b0fbd7c2c06a4f9",
-        "sha256": "984cce7dab0d22dfe19301aeedfca180c9243c97d16cdd7c0f31c7be744e6710"
-    },
-    {
-        "id": "slice-ansi:0.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
-        "md5": "c6a421b62848c96d57d4394964a89162",
-        "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:1.3.1",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "type:2.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ext:1.6.0",
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
-        "md5": "b06b1e937cd3671d147ef4f040fa297d",
-        "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
-    },
-    {
-        "id": "babylon:6.18.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
-        "md5": "c0f769098a62e7881847657d146d9cbe",
-        "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
-    },
-    {
-        "id": "colors:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-table:0.3.11",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
-        "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
-        "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
-    },
-    {
-        "id": "eslint-config-canonical:1.15.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
-        "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
-        "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
-    },
-    {
-        "id": "require-main-filename:1.0.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
-        "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
-        "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
-    },
-    {
-        "id": "parse-glob:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
-        "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
-        "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
-    },
-    {
-        "id": "to-regex:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
-        "md5": "8a6359bf8c570483aad2a767191e87bb",
-        "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
-    },
-    {
-        "id": "decode-uri-component:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
-        "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
-        "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
-    },
-    {
-        "id": "which:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
-        "md5": "3077f0c321098e78b78ddd6b4b2789e5",
-        "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
-    },
-    {
-        "id": "is-boolean-object:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
-        "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
-        "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
-    },
-    {
-        "id": "ansi-escapes:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
-        "md5": "7431226bb3f179e8cd7eddf297b904ec",
-        "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
-    },
-    {
-        "id": "object-assign:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
-        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
-        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
-    },
-    {
-        "id": "is-posix-bracket:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:0.1.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
-        "md5": "cd1bc456317e6cf7357683e79b8354c5",
-        "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
-    },
-    {
-        "id": "has-values:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
-        "md5": "b22e4bd0ee56cd167cb12437533618b1",
-        "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
-    },
-    {
-        "id": "es6-set:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
-        "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
-        "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
-    },
-    {
-        "id": "table:3.8.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
-        "md5": "caa5899fd31138fdbe11b2944fdf16e4",
-        "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
-    },
-    {
-        "id": "path-type:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "md5": "e14c138690b623db36532ff609b81b08",
-        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
-    },
-    {
-        "id": "supports-color:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
-        "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
-        "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "redeyed:2.1.1",
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "word-wrap:1.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
-        "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
-        "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
-    },
-    {
-        "id": "source-map-url:0.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
-        "md5": "db54d6dc84c3bfa7f420da51c493023c",
-        "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
-    },
-    {
-        "id": "ajv:4.11.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv-keywords:1.5.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
-        "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
-        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
-    },
-    {
-        "id": "braces:2.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
-        "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
-        "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
-    },
-    {
-        "id": "map-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
-        "md5": "1911d8539476d5e5b03c42e63a87b49a",
-        "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
-    },
-    {
-        "id": "ansi-regex:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "has-ansi:2.0.0",
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-ansi:3.0.1",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
-        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
-        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
-    },
-    {
-        "id": "invert-kv:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
-        "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
-        "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
-    },
-    {
-        "id": "os-locale:1.4.0",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "md5": "fdb77de7d9374b72e7f466c27908a730",
-        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
-    },
-    {
-        "id": "is-number:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
-        "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
-        "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
-    },
-    {
-        "id": "isobject:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-plain-object:2.0.4",
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.pick:1.3.0",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-visit:1.0.1",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
-        "md5": "9e7647515c0885e809f9aeb22de293f3",
-        "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
-    },
-    {
-        "id": "regenerator-runtime:0.11.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-runtime:6.26.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
-        "md5": "728ac808fb5276bf420fab33620d0c39",
-        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
-    },
-    {
-        "id": "cli-width:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
-        "md5": "c9cf40c64a983c42f8fd91a97542f25e",
-        "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
-    },
-    {
-        "id": "cardinal:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
-        "md5": "876b0338412efe635c487c4bf31a55b1",
-        "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "snapdragon:0.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
-        "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
-        "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
-    },
-    {
-        "id": "is-get-set-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
-        "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
-        "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
-    },
-    {
-        "id": "string-width:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
-        "md5": "b8aa95585646db49430dbaf185daec5d",
-        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
-    },
-    {
-        "id": "is-extendable:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
-        "md5": "61392549d95a063512f916897d7069b7",
-        "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
-    },
-    {
-        "id": "static-extend:0.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
-        "md5": "685c7b45bd48268f9eeffbccecb2d313",
-        "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
-    },
-    {
-        "id": "babel-messages:6.23.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
-        "md5": "f7a22e78d59c180af1175172a3abee40",
-        "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
-    },
-    {
-        "id": "tsconfig-paths:3.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19769aca6ee8f6a1a341e38c8fa45dd9fb18899b",
-        "md5": "864704be71309d70ae4a2045ce17e2e0",
-        "sha256": "99c2bb5ac67ade10dc163b295eabb1b2a827e7857cdfeeccf5c9f8e496af3f81"
-    },
-    {
-        "id": "es6-iterator:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
-        "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
-        "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
-    },
-    {
-        "id": "is-accessor-descriptor:0.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
-        "md5": "988cec0d99237747735bc5d84953a207",
-        "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
-    },
-    {
-        "id": "ignore:3.3.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
-        "md5": "623073ae841f6a00f1d93c50f97065ad",
-        "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
-    },
-    {
-        "id": "micromatch:2.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
-        "md5": "0c6949145be8bb09e5aa63fdebea9c24",
-        "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
-    },
-    {
-        "id": "through:2.3.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
-        "md5": "615296782d4936bd53ebe4e5baa57db7",
-        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
-    },
-    {
-        "id": "debug:3.2.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
-        "md5": "0f887df93ceeaa5784063eb8733a6778",
-        "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "component-emitter:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
-        "md5": "6b8517f3d7ad46e95c97b6d453f82189",
-        "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "lodash._arraycopy:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
-        "md5": "6de9a4e0d113c056078d1db4e75c748b",
-        "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
-    },
-    {
-        "id": "object-inspect:1.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6e2c120e868fd1fd18cb4f18c31741d0d6e776f0",
-        "md5": "3b663a84af220988fe04b4a283676fb0",
-        "sha256": "c172809067d5c1e1a9d02dbef2abbe8e602676c3b78dbe7effd3274dee7d7646"
-    },
-    {
-        "id": "generate-object-property:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
-        "md5": "275dde8134c99f03d9ff31a8fa861f19",
-        "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
-    },
-    {
-        "id": "is-fullwidth-code-point:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
-        "md5": "edbd4281a6ac4fb8d1082592c411f250",
-        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
-    },
-    {
-        "id": "es5-ext:0.10.53",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.1",
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "event-emitter:0.3.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "93c5a3acfdbef275220ad72644ad02ee18368de1",
-        "md5": "fae9645d4e605a9cda5974baa7dc1733",
-        "sha256": "03e3c58089f1bcc66467ee24b4625d39b3279fccf2d937121289f3145e7b6ec2"
-    },
-    {
-        "id": "ms:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:2.6.9",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
-        "md5": "9615634070dd7751f127b2a0fb362484",
-        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
-    },
-    {
-        "id": "es6-weak-map:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
-        "md5": "edb82ccad9f34520dc736bfbc67dc4be",
-        "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
-    },
-    {
-        "id": "lodash._baseclone:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.clonedeep:3.0.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "303519bf6393fe7e42f34d8b630ef7794e3542b7",
-        "md5": "553b734a6902f3363cf41de744286bab",
-        "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549"
-    },
-    {
-        "id": "parse-json:2.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "md5": "9b98b48019fa25c226348737831cf130",
-        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
-    },
-    {
-        "id": "map-cache:0.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fragment-cache:0.2.1",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
-        "md5": "7ed5e46ed67d87ec937cedc485559cb6",
-        "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
-    },
-    {
-        "id": "nanomatch:1.2.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
-        "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
-        "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
-    },
-    {
-        "id": "function-bind:1.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has:1.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
-        "md5": "ee976e75439af2b82e707f3a64c69684",
-        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
-    },
-    {
-        "id": "is-data-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
-        "md5": "d4fe7614279e3f4718d383035209c33e",
-        "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
-    },
-    {
-        "id": "is-glob:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "write:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
-        "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
-        "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
-    },
-    {
-        "id": "ansi-regex:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:4.0.0",
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
-        "md5": "1cc176457cc56d720f68eaf26b2afe8b",
-        "sha256": "bdadb0d036d35d54a71c47d94b2abfedb595775f41b8137bec044dc5efe43d35"
-    },
-    {
-        "id": "micromatch:3.1.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
-        "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
-        "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
-    },
-    {
-        "id": "es6-symbol:3.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
-        "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
-        "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "kind-of:6.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
-        "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
-        "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
-    },
-    {
-        "id": "eslint:3.19.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-babel:3.3.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-flowtype:2.50.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-lodash:2.7.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
-        "md5": "2b28bed1fe16d31f22178145baa90d7a",
-        "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
-    },
-    {
-        "id": "shellwords:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
-        "md5": "406c4d51a834f3ddddfaf96b9303af36",
-        "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
-    },
-    {
-        "id": "find-up:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
-        "md5": "cb9da6343737d03323119847685addf1",
-        "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
-    },
-    {
-        "id": "mute-stream:0.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
-        "md5": "597b34af22c4237293f5c05cd5f74214",
-        "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
-    },
-    {
-        "id": "supports-hyperlinks:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
-        "md5": "ac43da5665ec45c28303793339d60e5f",
-        "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
-    },
-    {
-        "id": "assign-symbols:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
-        "md5": "e9bb66200b728da39a79c2f235780331",
-        "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
-    },
-    {
-        "id": "is-data-descriptor:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
-        "md5": "f8d653ce6e504d83c985de8d182f1ae5",
-        "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
-    },
-    {
-        "id": "ramda:0.25.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
-        "md5": "f86f2a632aa11bb7af129304fbe22a67",
-        "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
-    },
-    {
-        "id": "is-extglob:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:0.3.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-glob:2.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
-        "md5": "2abcdb854a7d2b4446afc7b636916db7",
-        "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
-    },
-    {
-        "id": "lowercase-keys:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
-        "md5": "de9b080b5e473d21200e69b8bfc7c204",
-        "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "run-async:0.1.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "babel-eslint:7.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
-        "md5": "85d7580cf18c64e2b1cd165832032bbc",
-        "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
-    },
-    {
-        "id": "esquery:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
-        "md5": "67c3703f159c91ae9bd06b896a863b19",
-        "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
-    },
-    {
-        "id": "array-unique:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
-        "md5": "7b3ac4760380d655957c68e59748f438",
-        "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
-    },
-    {
-        "id": "readdirp:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
-        "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
-        "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
-    },
-    {
-        "id": "lodash.clonedeep:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
-        "md5": "dfef3b8bee7adea034e7224d909d92f5",
-        "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
-    },
-    {
-        "id": "globals:9.18.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
-        "md5": "746bb222029d9fd52336a7503c6e110b",
-        "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
-    },
-    {
-        "id": "buffer-from:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
-        "md5": "5fe5f473dc3263473041a56654581058",
-        "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
-    },
-    {
-        "id": "event-emitter:0.3.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
-        "md5": "5e969bf0d73326a36ab0eede156d48e3",
-        "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
-    },
-    {
-        "id": "is-buffer:1.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "kind-of:3.2.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:4.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
-        "md5": "374af5d9a1a7e4d3e686419412fa6b72",
-        "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
-    },
-    {
-        "id": "user-home:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
-        "md5": "221f00361d182f5dfd195a7d867307c7",
-        "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
-    },
-    {
-        "id": "binary-extensions:1.13.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:1.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
-        "md5": "013fed37056567a27186a86285f28efd",
-        "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
-    },
-    {
-        "id": "cli-cursor:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
-        "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
-        "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
-    },
-    {
-        "id": "type:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
-        "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
-        "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
-    },
-    {
-        "id": "string_decoder:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
-        "md5": "7b93eea8153258fea64c3192922effaa",
-        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "unbox-primitive:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "085e215625ec3162574dc8859abee78a59b14471",
-        "md5": "23d12db3c5ca7db2738571b3e610d09d",
-        "sha256": "dccea4f58520131a5e103a44a7f45e734a0161d7ef7490ba93008afe707eed3e"
-    },
-    {
-        "id": "glob-base:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
-        "md5": "ea2fd4074a1f129431de415f1c5387aa",
-        "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
-    },
-    {
-        "id": "urix:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "source-map-resolve:0.3.1",
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
-        "md5": "dd3921f317a15657fad465fd215fe38d",
-        "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
-    },
-    {
-        "id": "y18n:3.2.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
-        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
-        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
-    },
-    {
-        "id": "pragmatist:3.0.24",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
-        "md5": "282125ff6b702db1e05de93b7b866982",
-        "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
-    },
-    {
-        "id": "co:4.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv:4.11.8",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
-        "md5": "b6f068b290c84d37007997c45148ad18",
-        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
-    },
-    {
-        "id": "math-random:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5dd6943c938548267016d4e34f057583080c514c",
-        "md5": "029796aed5b40e10d30518bc21ad436a",
-        "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
-    },
-    {
-        "id": "is-descriptor:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-property:1.0.0",
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:1.0.0",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:1.0.0",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3b159746a66604b04f8c81524ba365c5f14d86ec",
-        "md5": "7cd33adcb4ca927942b08b261badd3ed",
-        "sha256": "fe5ee7a359c2ae4ec7c12a075d903150c23365bf55c0c471b8d34fade96c6ead"
-    },
-    {
-        "id": "get-intrinsic:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "15f59f376f855c446963948f0d24cd3637b4abc6",
-        "md5": "dcf91ab5448081811d382dfabad32bb6",
-        "sha256": "5a1b968faf5a6c2c3833e40321641651cbee32e41296e573d84b88ed2fe07b1b"
-    },
-    {
-        "id": "is-arrayish:0.2.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.2",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
-        "md5": "4bbbacda455ab73d86f5eda908989f24",
-        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
-    },
-    {
-        "id": "ansicolors:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979",
-        "md5": "9a8ff703d6072578025a1a324c9005d1",
-        "sha256": "b8e260ab45c01049f6a58029b723935bcef0cb28e62888e412f217bfd4e228ef"
-    },
-    {
-        "id": "arr-diff:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
-        "md5": "42ec151186ae4bd9980a212083d98bbe",
-        "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
-    },
-    {
-        "id": "kind-of:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20813df3d712928b207378691a45066fae72dd57",
-        "md5": "e24d0d555965b239fb2b6435b0724853",
-        "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
-    },
-    {
-        "id": "text-table:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
-        "md5": "4e595139988957453229d6ccd229f626",
-        "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
-    },
-    {
-        "id": "lodash._bindcallback:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.clonedeep:3.0.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createassigner:3.1.1",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
-        "md5": "20bfe15e77fe081ff95fa92c73f0699e",
-        "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
-    },
-    {
-        "id": "ajv-keywords:1.5.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
-        "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
-        "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
-    },
-    {
-        "id": "for-in:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "for-own:0.1.5",
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
-        "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
-        "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
-    },
-    {
-        "id": "eslint-import-resolver-node:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
-        "md5": "bf0a201e44f3e437813f10b97923f452",
-        "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
-    },
-    {
-        "id": "lodash._basefor:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.isplainobject:3.2.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._pickbycallback:3.0.0",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
-        "md5": "e0118d593252e3902b3769f0ff775d04",
-        "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
-    },
-    {
-        "id": "supports-preserve-symlinks-flag:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
-        "md5": "2ecf7c03c814ab155c5278d61f65583f",
-        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
-    },
-    {
-        "id": "fill-range:2.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
-        "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
-        "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
-    },
-    {
-        "id": "jsx-ast-utils:1.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
-        "md5": "704aebceee728c9e0120486622b35790",
-        "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
-    },
-    {
-        "id": "onetime:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
-        "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
-        "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
-    },
-    {
-        "id": "proto-props:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
-        "md5": "43c4cc31101ee8f37df9b66ff8353003",
-        "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
-    },
-    {
-        "id": "arr-diff:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
-        "md5": "5aa32e7c03b612d64d433306ecfcd392",
-        "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
-    },
-    {
-        "id": "is-equal-shallow:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
-        "md5": "79abafbc68151c75a7242adf69c9b7c5",
-        "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
-    },
-    {
-        "id": "mixin-deep:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
-        "md5": "53fb379c1187b97eecfcf06399958566",
-        "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
-    },
-    {
-        "id": "pify:2.3.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
-        "md5": "475310192b9d153240ac82eb66b827e8",
-        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
-    },
-    {
-        "id": "xtend:4.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
-        "md5": "183e6eef1df0529fd39bd932447ba547",
-        "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
-    },
-    {
-        "id": "is-binary-path:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
-        "md5": "a989667cf8d696127090b72fe8a674b3",
-        "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
-    },
-    {
-        "id": "fill-range:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
-        "md5": "35483acae8b070dad60c41a99afe6b4d",
-        "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
-    },
-    {
-        "id": "comment-parser:0.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
-        "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
-        "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
-    },
-    {
-        "id": "normalize-path:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
-        "md5": "b2f3932160dc03a5604dbac60ef59c34",
-        "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
-    },
-    {
-        "id": "exit-hook:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
-        "md5": "d6ad3b683bee91b5a117990d68a097dd",
-        "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
-    },
-    {
-        "id": "number-is-nan:1.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "is-fullwidth-code-point:1.0.0",
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "097b602b53422a522c1afb8790318336941a011d",
-        "md5": "1c192095065e6b72a7e20a747b110469",
-        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
-    },
-    {
-        "id": "strip-bom:2.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
-        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
-    },
-    {
-        "id": "deep-is:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
-        "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
-        "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
-    },
-    {
-        "id": "is-date-object:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
-        "md5": "3b3393d413d848d50129f3f80d37e86a",
-        "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
-    },
-    {
-        "id": "resolve:1.22.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "rechoir:0.6.2",
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5e0b8c67c15df57a89bdbabe603a002f21731198",
-        "md5": "aaf15861cf0f8af2222bd383a475bc28",
-        "sha256": "06536fa0cbfbf8d6b2d5e6971437f4eb02110c84961b698d1b8ba5c6ae8f760d"
-    },
-    {
-        "id": "extglob:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
-        "md5": "c8be79678101bbc03ea2018b80a8ac0a",
-        "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
-    },
-    {
-        "id": "arr-union:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
-        "md5": "f3cf2ebd1f4051917051f0c2b9287954",
-        "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
-    },
-    {
-        "id": "cli-table:0.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
-        "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
-        "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
-    },
-    {
-        "id": "ansi-escapes:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
-        "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
-        "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
-    },
-    {
-        "id": "prelude-ls:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "levn:0.2.5",
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "type-check:0.3.2",
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "type-check:0.3.2",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
-        "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
-        "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
-    },
-    {
-        "id": "get-value:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
-        "md5": "b45bf08107e22e624dade29284abd265",
-        "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
-    },
-    {
-        "id": "eslint-plugin-lodash:2.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
-        "md5": "7673c712d2af4c5fdc07ae78775670d6",
-        "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
-    },
-    {
-        "id": "has-value:0.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
-        "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
-        "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
-    },
-    {
-        "id": "os-homedir:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "user-home:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
-        "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
-        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
-    },
-    {
-        "id": "read-pkg:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
-        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
-    },
-    {
-        "id": "cli-usage:0.1.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
-        "md5": "9f20b9678f9a13b909660a21fee052a4",
-        "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
-    },
-    {
-        "id": "canonical:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
-        "md5": "a92c480423bdf2a2773e91c283b74ad8",
-        "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
-    },
-    {
-        "id": "lodash.keys:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
-        "md5": "d2aa104b88db88e2c0f1ed627031ed03",
-        "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
-    },
-    {
-        "id": "has-flag:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
-        "md5": "7ba03f6b47769f2acdc743ac0b23e339",
-        "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
-    },
-    {
-        "id": "caller-path:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
-        "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
-        "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
-    },
-    {
-        "id": "circular-json:0.3.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
-        "md5": "5569f191dea3cd5f952867196e41e050",
-        "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
-    },
-    {
-        "id": "is-regex:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
-        "md5": "13a02d0abc63ff0093ca592e999f713c",
-        "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
-    },
-    {
-        "id": "error-ex:1.3.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
-        "md5": "5d2c673565060037f9e04d7975d04feb",
-        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
-    },
-    {
-        "id": "es-abstract:1.19.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d4885796876916959de78edaa0df456627115ec3",
-        "md5": "11444142629b2eb1c6cc47907ca74f1f",
-        "sha256": "10fd94f8d892b32a91429bb7be44e1256d891c69467ae522e79bd6400f8946bc"
-    },
-    {
-        "id": "extend-shallow:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "split-string:3.1.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
-        "md5": "194095206e18756d832f5e0ad3d71cb8",
-        "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
-    },
-    {
-        "id": "internal-slot:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
-        "md5": "01f7b7499f71622547496b12f902bec8",
-        "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
-    },
-    {
-        "id": "doctrine:1.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
-        "md5": "8628b3ac690236d809939b9c3ec2531c",
-        "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "path-is-inside:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "365417dede44430d1c11af61027facf074bdfc53",
-        "md5": "8f27701be0f4d4da9534227663ae61ed",
-        "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "define-properties:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
-        "md5": "d06819a7b947f1b335da2f41519994ac",
-        "sha256": "5524f4db15bb95af92c791ba208e2fc774bd8ae17eb347865492d444f95a70a5"
-    },
-    {
-        "id": "restore-cursor:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34661f46886327fed2991479152252df92daa541",
-        "md5": "99b769f599ac64ecf9027f8717f01bb0",
-        "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
-    },
-    {
-        "id": "file-entry-cache:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
-        "md5": "329f8f032842d7a2c711bd18423e5226",
-        "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
-    },
-    {
-        "id": "kind-of:3.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-number:2.1.0",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon-util:3.0.1",
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-object-path:0.3.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
-        "md5": "c46cdfc40c94b44938f30b7254194d92",
-        "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47"
-    },
-    {
-        "id": "p-locate:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20a0103b222a70c8fd39cc2e580680f3dde5ec43",
-        "md5": "1dd1c9d3ebad6ad80815da62a0d3cf43",
-        "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46"
-    },
-    {
-        "id": "natural-compare:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
-        "md5": "210787ea3f1a715dd963317ebfc5193f",
-        "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
-    },
-    {
-        "id": "escope:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
-        "md5": "9390f529580d458bc659af81607d7114",
-        "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
-    },
-    {
-        "id": "run-async:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
-        "md5": "05b4c27dcef5296aff906af32f377494",
-        "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
-    },
-    {
-        "id": "class-utils:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
-        "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
-        "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
-    },
-    {
-        "id": "has-ansi:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
-        "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
-        "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
-    },
-    {
-        "id": "loose-envify:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "invariant:2.2.4",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
-        "md5": "5e78d5f6b1ad3ecce9605936059d087e",
-        "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
-    },
-    {
-        "id": "levn:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
-        "md5": "824680de0ed2dabe2745e88737723963",
-        "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
-    },
-    {
-        "id": "babel-types:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
-        "md5": "d12869e767169377af311247a2d247e9",
-        "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
-    },
-    {
-        "id": "define-property:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
-        "md5": "2751868d9fa31ebbbe851fdcb729115d",
-        "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
-    },
-    {
-        "id": "object.assign:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
-        "md5": "87b8da296ced17d6e062b791d48ed38b",
-        "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
-    },
-    {
-        "id": "acorn:5.7.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
-        "md5": "861b7e390cd4b067b90229f4b9eec0c9",
-        "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
-    },
-    {
-        "id": "mkdirp:0.5.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write:0.2.1",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d91cefd62d1436ca0f41620e251288d420099def",
-        "md5": "7e445b65cc532ae036e685117d5fe44d",
-        "sha256": "4e5ab01a61e329dd14d4020ce846e3abd93ee79b0f788f22fd5d5b4a61b1bb0a"
-    },
-    {
-        "id": "safe-regex:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
-        "md5": "6729d2a26cdabb856b9506e567bd8a57",
-        "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
-    },
-    {
-        "id": "lodash._baseassign:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
-        "md5": "2438792bc711256968416ae0164b5dd9",
-        "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
-    },
-    {
-        "id": "fragment-cache:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
-        "md5": "14306688d4947a100f6cce5b00d07afd",
-        "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
-    },
-    {
-        "id": "has:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-core-module:2.8.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
-        "md5": "b765203b0d733534ee6a58d84767223a",
-        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
-    },
-    {
-        "id": "glob-parent:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
-        "md5": "7dc0b2d10ed856934e289df5e1f12c59",
-        "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
-    },
-    {
-        "id": "hosted-git-info:2.8.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
-        "md5": "e50583bc39341b531466e5de5b6aef94",
-        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
-    },
-    {
-        "id": "invariant:2.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
-        "md5": "445e70b75ab7215bc0da1fbaa36113cd",
-        "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
-    },
-    {
-        "id": "code-point-at:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
-        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
-        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
-    },
-    {
-        "id": "split-string:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
-        "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
-        "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
-    },
-    {
-        "id": "lodash.assign:4.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
-        "md5": "5a92447d4e8669abba120d5164892902",
-        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
-    },
-    {
-        "id": "is-number-object:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a7aaf838c7f0686a50b4553f7e54a96494e89f0",
-        "md5": "b9541523302c3dcfc0ed3f819496057c",
-        "sha256": "0d6833a8c4f62895368ccb95fbd08ba8a6ff9124974aba410a58ad9104cc6683"
-    },
-    {
-        "id": "randomatic:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
-        "md5": "da226719644d2e64d1127424e028f827",
-        "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
-    },
-    {
-        "id": "ansi-styles:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
-        "md5": "deb5e5008ca69027719588d723cf9f91",
-        "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
-    },
-    {
-        "id": "lodash.isarray:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.isplainobject:3.2.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.toplainobject:3.0.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseflatten:3.1.4",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash._pickbycallback:3.0.0",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
-        "md5": "ac707272f6b31e82622b1d581110aec2",
-        "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd"
-    },
-    {
-        "id": "string.prototype.trimstart:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b36399af4ab2999b4c9c648bd7a3fb2bb26feeed",
-        "md5": "ad7c83cedfcdcafa713e957c027893c6",
-        "sha256": "8f5bffcc06a218d0106e9aba6216621e4f7e12667470e9b25d1ae3d4b13be75a"
-    },
-    {
-        "id": "generate-function:2.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f069617690c10c868e73b8465746764f97c3479f",
-        "md5": "b4fd862f79a3a0a097ea8818a5858d22",
-        "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
-    },
-    {
-        "id": "callsites:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
-        "md5": "b6e9bfb992503522ddaee4e965423faa",
-        "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
-    },
-    {
-        "id": "find-up:1.1.2",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
-        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
-    },
-    {
-        "id": "node-emoji:1.11.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
-        "md5": "40310f4209362a8df02af58dac079c7d",
-        "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
-    },
-    {
-        "id": "decamelize:1.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:3.10.0",
-                "uglify-js:2.6.2",
-                "handlebars:4.0.5",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "meow:3.7.0",
-                "dateformat:1.0.12",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
-        "md5": "330932e4de0e60c36114facb6d3dfafa",
-        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "supports-color:5.5.0",
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "lodash.isarguments:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
-        "md5": "5aee2d8dc451d10cdc97666d9964074d",
-        "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
-    },
-    {
-        "id": "is-primitive:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-equal-shallow:0.1.3",
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "207bab91638499c07b2adf240a41a87210034575",
-        "md5": "73402009e3936aeaa7b5c473d090b017",
-        "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
-    },
-    {
-        "id": "is-string:1.0.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
-        "md5": "a7cc7f159a13b20e5fa93015d6124705",
-        "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
-    },
-    {
-        "id": "object-keys:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-properties:1.1.3",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
-        "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
-        "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
-    },
-    {
-        "id": "pinkie:2.0.4",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pinkie-promise:2.0.1",
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
-        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
-        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
-    },
-    {
-        "id": "has-symbols:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-symbol:1.0.4",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-tostringtag:1.0.0",
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "165d3070c00309752a1236a479331e3ac56f1423",
-        "md5": "6fa03a33b382263eedbbdc38c48cd24b",
-        "sha256": "005c4ea47993c807c8a535827b56db30dde39400e918c424fc3de1cc3eb165dd"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "for-own:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
-        "md5": "6b95dc29fcffc91036164869c724d05b",
-        "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
-    },
-    {
-        "id": "snapdragon-node:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
-        "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
-        "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
-    },
-    {
-        "id": "set-value:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
-        "md5": "b1e945fff7d8430e86066db678ca6390",
-        "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
-    },
-    {
-        "id": "rechoir:0.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "liftoff:2.2.1",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
-        "md5": "9a0aa4db2a887a452ef08921160c7eb4",
-        "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "typedarray:0.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
-        "md5": "54a18bcd7fd55c812993e9ce90a0709d",
-        "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
-    },
-    {
-        "id": "resolve-url:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "source-map-resolve:0.3.1",
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
-        "md5": "b515d6d96cd554cb0cda158563e82e00",
-        "sha256": "88e9cb578b6373125c416cacb9f42c4896fe3e072e4b94ba6948cba70e551824"
-    },
-    {
-        "id": "@types/json5:0.0.29",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
-        "md5": "b2b856287e2f65c5298b7747332bb633",
-        "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
-    },
-    {
-        "id": "esutils:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:2.1.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
-        "md5": "fbea0e3ececd72f8135013e599bb44b3",
-        "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
-    },
-    {
-        "id": "optionator:0.8.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
-        "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
-        "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
-    },
-    {
-        "id": "eslint-plugin-import:2.25.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "322f3f916a4e9e991ac7af32032c25ce313209f1",
-        "md5": "441bc6892fc8ba6a5b335b241d27954b",
-        "sha256": "96d40d97f89261c792a276dc515c20fafbbc4c2e24d6e51d34a53b700957021d"
-    },
-    {
-        "id": "is-number:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
-        "md5": "16a0b10f0dab47199d6536d319c0c6d5",
-        "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
-    },
-    {
-        "id": "eslint-plugin-promise:3.8.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
-        "md5": "ba6f09078795c4b8612de3a95a483603",
-        "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
-    },
-    {
-        "id": "load-json-file:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
-        "md5": "939784db9c3c72c26262cebef2f9b631",
-        "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
-    },
-    {
-        "id": "core-util-is:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
-        "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
-        "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
-    },
-    {
-        "id": "json-stable-stringify:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "ajv:4.11.8",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
-        "md5": "7712931a8d538cad6e4beaccd491cbb2",
-        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
-    },
-    {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "graceful-fs:4.2.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "041b05df45755e587a24942279b9d113146e1c96",
-        "md5": "e387a6dfac11fd5d79bd2718100e08b6",
-        "sha256": "16677911bf936576c5c73447657a30b4c535ddf8dc2fa0c8109ae93fa9319f0a"
-    },
-    {
-        "id": "is-glob:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-parent:2.0.0",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
-        "md5": "094686a7618e52db5f126af328da6aff",
-        "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
-    },
-    {
-        "id": "normalize-package-data:2.5.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
-        "md5": "b46c083aa373a30b8d2421e9f269d543",
-        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
-    },
-    {
-        "id": "rx-lite:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
-        "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
-        "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
-    },
-    {
-        "id": "has-tostringtag:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-date-object:1.0.5",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number-object:1.0.6",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
-        "md5": "25e5a30ea25da9a3e5cf67924512233a",
-        "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
-    },
-    {
-        "id": "string-width:1.0.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
-        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
-        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
-    },
-    {
-        "id": "isobject:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
-        "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
-        "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
-    },
-    {
-        "id": "get-caller-file:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
-        "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
-        "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
-    },
-    {
-        "id": "side-channel:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
-        "md5": "abcc258cdccfd0db4007c7be3888d7df",
-        "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
-    },
-    {
-        "id": "which-boxed-primitive:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13757bc89b209b049fe5d86430e21cf40a89a8e6",
-        "md5": "2d84f8bed229309416dffff93d5028cd",
-        "sha256": "4a4017ba9103fed80bc3ec67c529ed43b38066a626dd9595d91a57cf0c5e089d"
-    },
-    {
-        "id": "util-deprecate:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
-        "md5": "280e304a953ba3a89f52cc6ad616b284",
-        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
-    },
-    {
-        "id": "braces:1.8.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
-        "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
-        "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
-    },
-    {
-        "id": "lodash._getnative:3.9.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createcache:3.1.2",
-                "lodash._basedifference:3.0.3",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
-        "md5": "a311ce03b077bd8a3b4bfe46776f9035",
-        "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
-    },
-    {
-        "id": "eslint-module-utils:2.7.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
-        "md5": "b209efc416d3e5b3f9b15c9177a19fec",
-        "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
-    },
-    {
-        "id": "spdx-expression-parse:3.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
-        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
-        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "rimraf:2.6.3",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
-    },
-    {
-        "id": "get-set-props:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
-        "md5": "ae71d26ef14801348a804a1b2e987ed9",
-        "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
-    },
-    {
-        "id": "is-proto-prop:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
-        "md5": "78443d3b543426fda71dfcb27111473b",
-        "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "extglob:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
-        "md5": "5e368678ebf35fe8dbaa173517e7adc1",
-        "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
-    },
-    {
-        "id": "to-object-path:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
-        "md5": "ed213d48acc6db7b01883673013ba398",
-        "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
-    },
-    {
-        "id": "spdx-correct:3.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
-        "md5": "bd668e9b71960e76e867c11ec3ec2982",
-        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
-    },
-    {
-        "id": "is-js-type:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
-        "md5": "89c1378f5a53fec687827f000e40d29b",
-        "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
-    },
-    {
-        "id": "eslint-plugin-babel:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
-        "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
-        "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
-    },
-    {
-        "id": "d:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.1",
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "event-emitter:0.3.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8698095372d58dbee346ffd0c7093f99f8f9eb5a",
-        "md5": "34f0b6b6c919df899c7c240deb36deed",
-        "sha256": "e7fb647f7a114c2f5bc547454b043c29dd13de095dc6f476b883b266993918a9"
-    },
-    {
-        "id": "to-regex-range:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
-        "md5": "5ad83eab061e092ad457387b4317ed45",
-        "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
-    },
-    {
-        "id": "expand-brackets:2.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
-        "md5": "a49099d108479157c6efcc4b739a00b2",
-        "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
-    },
-    {
-        "id": "posix-character-classes:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
-        "md5": "1fc17a88bddf7099b36179e8acbb68e9",
-        "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
-    },
-    {
-        "id": "is-core-module:2.8.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f59fdfca701d5879d0a6b100a40aa1560ce27211",
-        "md5": "b7203baea21d3312e5c49f374855b4b3",
-        "sha256": "a5476c788ef83b7ff627631136a2dfefe49e0f3c6ed00bee6ec426223c751e20"
-    },
-    {
-        "id": "readable-stream:2.3.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "comment-parser:0.4.2",
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
-        "md5": "f060c259b513e887f551d073950f12f9",
-        "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
-    },
-    {
-        "id": "is-resolvable:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
-        "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
-        "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
-    },
-    {
-        "id": "filename-regex:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
-        "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
-        "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
-    },
-    {
-        "id": "semver:5.7.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
-    },
-    {
-        "id": "is-weakref:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
-        "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
-        "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
-    },
-    {
-        "id": "expand-range:1.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
-        "md5": "b9375c64d875584bb5bf5a4829007f32",
-        "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
-    },
-    {
-        "id": "array.prototype.flat:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07e0975d84bbc7c48cd1879d609e682598d33e13",
-        "md5": "97648174e504c24169cf0eda8f034788",
-        "sha256": "846fec18a5be9e6f972b366954db8b98812ee8b8873592b364a7a3e54dcb19bb"
-    },
-    {
-        "id": "window-size:0.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
-        "md5": "250499d281e44d2783aec6cfc458e96a",
-        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
-    },
-    {
-        "id": "is-number:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
-        "md5": "fb4c6b1ce591089d5da379104d9455b8",
-        "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
-    },
-    {
-        "id": "readline2:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
-        "md5": "4e61bfb7db0673cc96401d5c3eea081c",
-        "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
-    },
-    {
-        "id": "remove-trailing-separator:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "normalize-path:2.1.1",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
-        "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
-        "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
-    },
-    {
-        "id": "async-each:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
-        "md5": "c1130142d7ed405602b1fc38d811e360",
-        "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
-    },
-    {
-        "id": "concat-stream:1.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
-        "md5": "f3d719f26732b5206541e52972316e84",
-        "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
-    },
-    {
-        "id": "snapdragon-util:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
-        "md5": "17c194e41dd12d561800985ef5b4ffdf",
-        "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
-    },
-    {
-        "id": "define-property:0.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
-        "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
-        "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
-    },
-    {
-        "id": "is-negative-zero:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
-        "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
-        "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
-    },
-    {
-        "id": "has-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
-        "md5": "0f5d46e9619fa36d9930f590ef96844b",
-        "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
-    },
-    {
-        "id": "spdx-license-ids:3.0.11",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
-        "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
-        "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
-    },
-    {
-        "id": "anymatch:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
-        "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
-        "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
-    },
-    {
-        "id": "yargs:4.8.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
-        "md5": "964f012a6509b1b431de5f58a11e061a",
-        "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
-    },
-    {
-        "id": "shelljs:0.7.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
-        "md5": "476ea3b109ecf2179be8b78b444245d0",
-        "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
-    },
-    {
-        "id": "doctrine:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
-        "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
-        "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
-    },
-    {
-        "id": "is-extglob:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-glob:4.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "object.values:1.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
-        "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
-        "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
-    },
-    {
-        "id": "path-parse:1.0.7",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
-        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
-        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
-    },
-    {
-        "id": "is-accessor-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
-        "md5": "71d1d01f8028c245544a9a1217fb2bce",
-        "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
-    },
-    {
-        "id": "jsonpointer:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f802669a524ec4805fa7389eadbc9921d5dc8072",
-        "md5": "463322a0a00674acd3366d4c3bfd152f",
-        "sha256": "5d92ea00b9af9a6eadf29006039b37c7612d1c02ca17fcc142b4ceb30be75f4c"
-    },
-    {
-        "id": "interpret:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
-        "md5": "9d7dec2c46613400992e6b9ed13175c1",
-        "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
-    },
-    {
-        "id": "lcid:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "md5": "33e24746875ebbcc37c40c7297388609",
-        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
-    },
-    {
-        "id": "rimraf:2.6.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
-        "md5": "bd58522df35ee7b727430b41720e912d",
-        "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
-    },
-    {
-        "id": "yargs-parser:2.4.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
-        "md5": "3ed28206e170b6c0cf902511c2d0534b",
-        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
-    },
-    {
-        "id": "get-symbol-description:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
-        "md5": "e14a4c666fa15e9f9173046700ead218",
-        "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
-    },
-    {
-        "id": "array.prototype.find:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6abbd0c2573925d8094f7d23112306af8c16d534",
-        "md5": "bd2ad5f97c8a124851aa316833fb8dd7",
-        "sha256": "f35b78cc51239d0c6edcc59872e03487a401d2ea995065a0526386e38a80baea"
-    },
-    {
-        "id": "babel-runtime:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-messages:6.23.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
-        "md5": "f791f7898733e02f7216de5d6d6a1602",
-        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
-    },
-    {
-        "id": "camelcase:3.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
-        "md5": "d9d2d730959290cbbb9ef3900cd6126c",
-        "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
-    },
-    {
-        "id": "es6-map:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
-        "md5": "98c9ef67294b8213745a30395f4a62b5",
-        "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
-    },
-    {
-        "id": "ms:2.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:3.2.7",
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "debug:3.2.7",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "define-property:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
-        "md5": "8a6929a07bffc6c4c16bb506e31834c1",
-        "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
-    },
-    {
-        "id": "expand-brackets:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
-        "md5": "15d774bbd64fa32c2c427854bf58143b",
-        "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
-    },
-    {
-        "id": "type-check:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "levn:0.2.5",
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
-        "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
-        "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
-    },
-    {
-        "id": "spdx-exceptions:2.3.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
-        "md5": "acbb50a4dc418357a51310b852eb2e38",
-        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
-    },
-    {
-        "id": "node-notifier:4.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
-        "md5": "0f04f7a88ceff67961e4277485727ce9",
-        "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
-    },
-    {
-        "id": "js-types:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-js-type:2.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
-        "md5": "60cccf96110592ca167c2c9b98155a45",
-        "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
-    },
-    {
-        "id": "is-my-ip-valid:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7b351b8e8edd4d3995d4d066680e664d94696824",
-        "md5": "933f3e907a361ef18be30c70737b7808",
-        "sha256": "5ffa08e4ea7c36daf2ab805d31f678457823c347262856f9d819b5d99ee53e24"
-    },
-    {
-        "id": "which-module:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
-        "md5": "004cd541632e781023b01a91b2d4b851",
-        "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "debug:2.6.9",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
-        "md5": "cb6cb63ab5843aee3af94d27c60ea476",
-        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
-    },
-    {
-        "id": "is-my-json-valid:2.20.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
-        "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
-        "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
-    },
-    {
-        "id": "to-fast-properties:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
-        "md5": "eb323816b9903f0e6877898c3065da5b",
-        "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
-    },
-    {
-        "id": "is-descriptor:0.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "366d8240dde487ca51823b1ab9f07a10a78251ca",
-        "md5": "8e793e2a6d3bef3145c7bfae02099c0a",
-        "sha256": "b0d542e7aa38610efea55af9bf42c812a73d93ae522b1ceaa106f831900bb06a"
-    },
-    {
-        "id": "has-values:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
-        "md5": "59bfd41b8b69c52c77823af62b7bada7",
-        "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
-    },
-    {
-        "id": "pluralize:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
-        "md5": "10ffc865fc0a65a38893463e1ab77403",
-        "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
-    },
-    {
-        "id": "repeat-element:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
-        "md5": "bf964c7d487f69452bf2196b93908917",
-        "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string_decoder:1.1.1",
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "locate-path:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
-        "md5": "3241773d42e4709beacb91d0e7d92331",
-        "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
-    },
-    {
-        "id": "js-tokens:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "loose-envify:1.4.0",
-                "invariant:2.2.4",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9866df395102130e38f7f996bceb65443209c25b",
-        "md5": "969180644218c18794b6df26d42accd5",
-        "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
-    },
-    {
-        "id": "strip-ansi:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
-        "md5": "f0aa5746513c46c807ea71744ec2bc5c",
-        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
-    },
-    {
-        "id": "is-fullwidth-code-point:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
-        "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
-        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
-    },
-    {
-        "id": "is-utf8:0.2.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:1.0.0",
-                "vinyl-fs:0.3.14",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
-        "md5": "7c483523b33b0640efedcc6561c545e2",
-        "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
-    },
-    {
-        "id": "next-tick:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ca86d1fe8828169b0120208e3dc8424b9db8342c",
-        "md5": "e199ee5dd3885bfecd2d3c8856fcc85f",
-        "sha256": "589acf7512a9bef481eec81eeb8aef056e638f26257e572a0cb3e3baccbc7863"
-    },
-    {
-        "id": "jsonify:0.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json-stable-stringify:1.0.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "json-stable-stringify:1.0.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
-        "md5": "78cc678249f2a175db1cffbd5bb25a14",
-        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
-    },
-    {
-        "id": "array-unique:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
-        "md5": "c7fa44b0117a3ed0d161f876c68633f7",
-        "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.4",
-                "minimatch:2.0.10",
-                "babel-core:6.8.0",
-                "babel-plugin-transform-regenerator:6.8.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.3",
-                "minimatch:3.0.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "strip-json-comments:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
-        "md5": "af7d37e88560f64851d5c27b0abc617e",
-        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
-    },
-    {
-        "id": "balanced-match:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
-        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
-        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
-    },
-    {
-        "id": "ext:1.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
-        "md5": "9cf67c9330abea4cd40a86724154f246",
-        "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
-    },
-    {
-        "id": "p-try:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:1.3.0",
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
-        "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
-        "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
-    },
-    {
-        "id": "minimatch:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "879ad447200773912898b46cd516a7abbb5e50b0",
-        "md5": "22992838af1452c5cccc92cdf6c21025",
-        "sha256": "2b4e6fc003c29d58cb6f21c9b235ffa6ad29c7e94eba24c60d42973113629280"
-    },
-    {
-        "id": "object.pick:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
-        "md5": "40633da6e17a372e353e73ae28beb843",
-        "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
-    },
-    {
-        "id": "atob:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
-        "md5": "45eb23f9eb24b3ff24e18466deeaa887",
-        "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
-    },
-    {
-        "id": "growly:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
-        "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
-        "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
-    },
-    {
-        "id": "babel-traverse:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
-        "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
-        "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
-    },
-    {
-        "id": "p-limit:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
-        "md5": "f674d1283c8ac4d11ec813efc2b5934a",
-        "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
-    },
-    {
-        "id": "union-value:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
-        "md5": "5438ca0bb737dc01e85a61121dcc3626",
-        "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
-    },
-    {
-        "id": "es6-symbol:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
-        "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
-        "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
-    },
-    {
-        "id": "estraverse:5.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "esrecurse:4.3.0",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "esquery:1.4.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
-        "md5": "ac5d5752d7928d448689899477f994b0",
-        "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
-    },
-    {
-        "id": "espree:3.5.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
-        "md5": "84b02c58a8ae5ce3da5886773141518b",
-        "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
-    },
-    {
-        "id": "inquirer:0.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
-        "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
-        "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
-    },
-    {
-        "id": "es-to-primitive:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
-        "md5": "a32f26c478b76efa377601b8d17268a9",
-        "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
-    },
-    {
-        "id": "eslint-plugin-react:6.10.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
-        "md5": "fabc99b1e4722b4e10fe41f348940da3",
-        "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
-    },
-    {
-        "id": "acorn-jsx:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
-        "md5": "4b90c954f940a0891370c7d265ce0fc6",
-        "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "eslint-plugin-jsdoc:2.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
-        "md5": "faf67209cc82f0fc3b0717ea662bbdab",
-        "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:1.0.1",
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mkdirp:0.5.5",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "estraverse:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
-        "md5": "fe475b154e52864c56c3fc8f4b4af81b",
-        "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
-    },
-    {
-        "id": "preserve:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
-        "md5": "bca875c4e8d238ef216dc9d1bcabf976",
-        "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
-    },
-    {
-        "id": "is-extendable:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
-        "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
-        "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
-    },
-    {
-        "id": "babel-code-frame:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
-        "md5": "fdca204ce9b0158bcc65745baa896e4c",
-        "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
-    },
-    {
-        "id": "pinkie-promise:2.0.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
-        "md5": "d6cf74027e88ca54043e91d59629a656",
-        "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
-    },
-    {
-        "id": "pascalcase:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
-        "md5": "0c6e0012f1d98450a08a7b76b55a3296",
-        "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
-    },
-    {
-        "id": "acorn:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "acorn-jsx:3.0.1",
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
-        "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
-        "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
-    },
-    {
-        "id": "arr-flatten:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "arr-diff:2.0.0",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "36048bbff4e7b47e136644316c99669ea5ae91f1",
-        "md5": "1b469d538f9b387d83b3cb7e5994f7a5",
-        "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a"
-    },
-    {
-        "id": "object.omit:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
-        "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
-        "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
-    },
-    {
-        "id": "esrecurse:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
-        "md5": "a39f104614e3543dd4522ac4afdace00",
-        "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
-    },
-    {
-        "id": "is-property:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "generate-function:2.3.1",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
-        "md5": "29d8709ba7392da7846b05c30cb83832",
-        "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
-    },
-    {
-        "id": "copy-descriptor:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
-        "md5": "d6e57e9597c6af638adc414e74c3d516",
-        "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
-    },
-    {
-        "id": "isarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.2.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
-        "md5": "c24471c617803171eed93b3516624c97",
-        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
-    },
-    {
-        "id": "kind-of:5.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
-        "md5": "378018a0079fc3bc94e8ec2812d86fe6",
-        "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
-    },
-    {
-        "id": "lodash._basecopy:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.toplainobject:3.0.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
-        "md5": "34a2be5e888808f5239e85ae528752bf",
-        "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
-    },
-    {
-        "id": "validate-npm-package-license:3.0.4",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
-        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
-        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
-    },
-    {
-        "id": "is-bigint:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
-        "md5": "54f51f1529d609a8762b6f18a9fc5f39",
-        "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
-    },
-    {
-        "id": "call-bind:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-weakref:1.0.2",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
-        "md5": "d244c20a7b3f2c607030df6337a4e68d",
-        "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
-    },
-    {
-        "id": "eslint-plugin-no-use-extend-native:0.3.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
-        "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
-        "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
-    },
-    {
-        "id": "array-includes:3.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5b493162c760f3539631f005ba2bb46acb45ba9",
-        "md5": "9d752dc8689c23a402be29863f5c1079",
-        "sha256": "9cdcf83ee2d54701efc89e0a73785538d154bd0d7db7218bdaab94047801b95c"
-    },
-    {
-        "id": "ret:0.1.15",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "safe-regex:1.1.0",
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
-        "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
-        "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
-    },
-    {
-        "id": "collection-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
-        "md5": "735947ef7cec034327b0f2b0144b8256",
-        "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
-    },
-    {
-        "id": "object-visit:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "map-visit:1.0.0",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
-        "md5": "0c309d8c43bc9546676100500c1db1c4",
-        "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
-    },
-    {
-        "id": "process-nextick-args:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
-        "md5": "09e1b13837638717ed3f2aae7bc700db",
-        "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
-    },
-    {
-        "id": "eslint-plugin-flowtype:2.50.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
-        "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
-        "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
-    },
-    {
-        "id": "strip-ansi:3.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
-        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
-        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
-    },
-    {
-        "id": "unset-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
-        "md5": "d69bb4d1f65e08acd32debce863b513e",
-        "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
-    },
-    {
-        "id": "regex-cache:0.4.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
-        "md5": "c08a04a26436892d55f3d2fb294d8b73",
-        "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
-    },
-    {
-        "id": "regex-not:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
-        "md5": "e54f51e5d23c17edae9f9d199b337531",
-        "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
-    },
-    {
-        "id": "marked-terminal:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
-        "md5": "3fc3251d4faab2d1df0155b08258bd34",
-        "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
-    },
-    {
-        "id": "has-bigints:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-bigint:1.0.4",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64fe6acb020673e3b78db035a5af69aa9d07b113",
-        "md5": "3d1a6fa2571c73144e864272fd5e2e75",
-        "sha256": "7bd053a7d11cfd00367859ca9d06020f643cb6b305a400e424dfd872ebcc223a"
-    },
-    {
-        "id": "lodash:4.17.21",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-flowtype:2.50.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-lodash:2.7.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-emoji:1.11.0",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
-        "md5": "25247d3dd7029d08a6ac99adab09086b",
-        "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
-    },
-    {
-        "id": "is-obj-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
-        "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
-        "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
-    },
-    {
-        "id": "resolve-from:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
-        "md5": "e19abe316d7d524402ff940ff923406c",
-        "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
-    },
-    {
-        "id": "flat-cache:1.3.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
-        "md5": "7f7fe842b74285784727aedf7cf81c4b",
-        "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
-    },
-    {
-        "id": "progress:1.1.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
-        "md5": "06556528b7598e755a84c9c8f75c2622",
-        "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
-    },
-    {
-        "id": "base:0.11.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
-        "md5": "b457a16eb8603bc0d84d252716f5b0d5",
-        "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
-    },
-    {
-        "id": "marked:0.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
-        "md5": "2981b17fa46348526d23658960663d88",
-        "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
-    },
-    {
-        "id": "is-symbol:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
-        "md5": "1d481161785d0b7c5a729e39edb86e9a",
-        "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
-    },
-    {
-        "id": "json5:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
-        "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
-        "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
-    },
-    {
-        "id": "is-dotfile:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
-        "md5": "9c1b18df01884a55636db529eca19fe2",
-        "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
-    },
-    {
-        "id": "object-copy:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
-        "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
-        "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
-    },
-    {
-        "id": "redeyed:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
-        "md5": "b143ff11e6aece5ad2722daebb73c708",
-        "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
-    },
-    {
-        "id": "wrap-ansi:2.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
-        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
-    },
-    {
-        "id": "sprintf-js:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "argparse:1.0.7",
-                "js-yaml:3.6.0",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "extend-shallow:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
-        "md5": "5c9316b33e9363368f4468595c700044",
-        "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
-    },
-    {
-        "id": "strip-bom:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
-        "md5": "a2045f7f89506a0f8301822998d1daf7",
-        "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
-    },
-    {
-        "id": "read-pkg-up:1.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "meow:3.7.0",
-                "dateformat:1.0.12",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
-        "md5": "02cc53c7512931912dcbdcd9c1d55265",
-        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
-    },
-    {
-        "id": "obj-props:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8884ab21c8d8496c4a7f696c78bf82289c51680b",
-        "md5": "ab45790d12ef25b271e0705f15cbdc4e",
-        "sha256": "ca7dad5516740c0db50ebeec237f934b90afcdc2cab6f4faae7774c08c2ca14e"
-    },
-    {
-        "id": "path-exists:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
-        "md5": "7c2676f4502f776524cefe6e0b877136",
-        "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
-    },
-    {
-        "id": "repeat-string:1.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
-        "md5": "ed49a5a26c9110a28411da1cded28e3a",
-        "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+    "id": "estraverse:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+    "md5": "fe475b154e52864c56c3fc8f4b4af81b",
+    "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
+    },
+    {
+    "id": "espree:3.5.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
+    "md5": "84b02c58a8ae5ce3da5886773141518b",
+    "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
+    },
+    {
+    "id": "string.prototype.trimstart:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5466d93ba58cfa2134839f81d7f42437e8c01fef",
+    "md5": "1eb8bb5c0f48eb09d1729982c3b8c843",
+    "sha256": "b427df5466fec97d1dad5d4ef7e2e954ee9ad586ab6357bc9078bf996c95c501"
+    },
+    {
+    "id": "is-js-type:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
+    "md5": "89c1378f5a53fec687827f000e40d29b",
+    "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
+    },
+    {
+    "id": "is-arrayish:0.2.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "error-ex:1.3.0",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "error-ex:1.3.0",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "error-ex:1.3.2",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+    "md5": "4bbbacda455ab73d86f5eda908989f24",
+    "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
+    },
+    {
+    "id": "ms:2.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:3.2.7",
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "debug:3.2.7",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+    "md5": "a50e4bf82f754914316bfca3dfbcf352",
+    "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+    "id": "ajv:4.11.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ajv-keywords:1.5.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
+    "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
+    "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
+    },
+    {
+    "id": "define-properties:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1",
+    "md5": "d2ec48d9ec2ffc96c1cade78993d2fc4",
+    "sha256": "db524cc69a1fb36e417553bcf82df6511685c6b94d4b82eae99759589a686948"
+    },
+    {
+    "id": "to-regex:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+    "md5": "8a6359bf8c570483aad2a767191e87bb",
+    "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
+    },
+    {
+    "id": "unbox-primitive:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "29032021057d5e6cdbd08c5129c226dff8ed6f9e",
+    "md5": "f8a4b8d86554bfb4b6901ac51bf00863",
+    "sha256": "733eb170b51adb49104a823ed62f1a4606b45ee1e886178f12a1a00fb04fca1d"
+    },
+    {
+    "id": "inflight:1.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+    "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+    "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+    "id": "babel-traverse:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
+    "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
+    "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
+    },
+    {
+    "id": "regenerator-runtime:0.11.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-runtime:6.26.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+    "md5": "728ac808fb5276bf420fab33620d0c39",
+    "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
+    },
+    {
+    "id": "once:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "run-async:0.1.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+    "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+    "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+    "id": "window-size:0.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
+    "md5": "250499d281e44d2783aec6cfc458e96a",
+    "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
+    },
+    {
+    "id": "path-type:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
+    "md5": "e14c138690b623db36532ff609b81b08",
+    "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
+    },
+    {
+    "id": "eslint-plugin-react:6.10.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
+    "md5": "fabc99b1e4722b4e10fe41f348940da3",
+    "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
+    },
+    {
+    "id": "is-my-json-valid:2.20.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
+    "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
+    "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
+    },
+    {
+    "id": "supports-color:5.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+    "md5": "17b1003344e0e0d2719205be85946698",
+    "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
+    },
+    {
+    "id": "readline2:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
+    "md5": "4e61bfb7db0673cc96401d5c3eea081c",
+    "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
+    },
+    {
+    "id": "caller-path:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
+    "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
+    "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
+    },
+    {
+    "id": "unset-value:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+    "md5": "d69bb4d1f65e08acd32debce863b513e",
+    "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
+    },
+    {
+    "id": "write:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
+    "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
+    "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
+    },
+    {
+    "id": "path-is-inside:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "365417dede44430d1c11af61027facf074bdfc53",
+    "md5": "8f27701be0f4d4da9534227663ae61ed",
+    "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d"
+    },
+    {
+    "id": "snapdragon-node:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
+    "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
+    "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
+    },
+    {
+    "id": "eslint-plugin-promise:3.8.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
+    "md5": "ba6f09078795c4b8612de3a95a483603",
+    "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
+    },
+    {
+    "id": "has-value:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
+    "md5": "0f5d46e9619fa36d9930f590ef96844b",
+    "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
+    },
+    {
+    "id": "functions-have-names:1.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0404fe4ee2ba2f607f0e0ec3c80bae994133b834",
+    "md5": "89a2b8928f2e27c2087690ab9f5d846a",
+    "sha256": "3be0c99c006f7c53093e3f6a56a1128f1a72fec3b041ec585a4175b809fab1dc"
+    },
+    {
+    "id": "lodash._arrayeach:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
+    "md5": "2500bac4195ee774f346d80500ad77ef",
+    "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
+    },
+    {
+    "id": "object.assign:4.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
+    "md5": "87b8da296ced17d6e062b791d48ed38b",
+    "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
+    },
+    {
+    "id": "eslint-module-utils:2.7.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
+    "md5": "b209efc416d3e5b3f9b15c9177a19fec",
+    "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
+    },
+    {
+    "id": "define-property:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+    "md5": "8a6929a07bffc6c4c16bb506e31834c1",
+    "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
+    },
+    {
+    "id": "event-emitter:0.3.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
+    "md5": "5e969bf0d73326a36ab0eede156d48e3",
+    "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
+    },
+    {
+    "id": "urix:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "source-map-resolve:0.3.1",
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+    "md5": "dd3921f317a15657fad465fd215fe38d",
+    "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
+    },
+    {
+    "id": "cli-usage:0.1.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
+    "md5": "9f20b9678f9a13b909660a21fee052a4",
+    "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
+    },
+    {
+    "id": "spdx-correct:3.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
+    "md5": "bd668e9b71960e76e867c11ec3ec2982",
+    "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
+    },
+    {
+    "id": "js-types:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-js-type:2.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
+    "md5": "60cccf96110592ca167c2c9b98155a45",
+    "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
+    },
+    {
+    "id": "is-descriptor:0.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "366d8240dde487ca51823b1ab9f07a10a78251ca",
+    "md5": "8e793e2a6d3bef3145c7bfae02099c0a",
+    "sha256": "b0d542e7aa38610efea55af9bf42c812a73d93ae522b1ceaa106f831900bb06a"
+    },
+    {
+    "id": "is-fullwidth-code-point:1.0.0",
+    "scopes": [
+    "prod",
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+    "md5": "edbd4281a6ac4fb8d1082592c411f250",
+    "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
+    },
+    {
+    "id": "union-value:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
+    "md5": "5438ca0bb737dc01e85a61121dcc3626",
+    "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
+    },
+    {
+    "id": "onetime:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
+    "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
+    "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
+    },
+    {
+    "id": "node-emoji:1.11.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
+    "md5": "40310f4209362a8df02af58dac079c7d",
+    "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
+    },
+    {
+    "id": "eslint-plugin-flowtype:2.50.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
+    "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
+    "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
+    },
+    {
+    "id": "type:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "d:1.0.1",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
+    "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
+    "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
+    },
+    {
+    "id": "base:0.11.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
+    "md5": "b457a16eb8603bc0d84d252716f5b0d5",
+    "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
+    },
+    {
+    "id": "pragmatist:3.0.24",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
+    "md5": "282125ff6b702db1e05de93b7b866982",
+    "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
+    },
+    {
+    "id": "chalk:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.8.0",
+    "babel-traverse:6.8.0",
+    "babel-plugin-transform-es2015-block-scoping:6.8.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-code-frame:6.7.7",
+    "babel-traverse:6.7.6",
+    "babel-eslint:6.0.4",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fancy-log:1.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "run-sequence:1.1.5",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
+    "md5": "d7e0f89d6888d5d9ced994c205926555",
+    "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d"
+    },
+    {
+    "id": "core-js:2.6.12",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-runtime:6.26.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
+    "md5": "a1881352eef45832b331dc025db1b72c",
+    "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
+    },
+    {
+    "id": "chokidar:1.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
+    "md5": "3b76ca6e8ebf196645910f2985f77385",
+    "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
+    },
+    {
+    "id": "kind-of:3.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-number:2.1.0",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon-util:3.0.1",
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-object-path:0.3.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+    "md5": "c46cdfc40c94b44938f30b7254194d92",
+    "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47"
+    },
+    {
+    "id": "spdx-expression-parse:3.0.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-correct:3.1.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
+    "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
+    "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
+    },
+    {
+    "id": "has-bigints:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-bigint:1.0.4",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0871bd3e3d51626f6ca0966668ba35d5602d6eaa",
+    "md5": "df87410ab4558f7e29b52e8733c1a3e6",
+    "sha256": "207b82f1fa30704c5cd488074a29582f64e20c3ceb29d78f2295d68268570ce3"
+    },
+    {
+    "id": "extglob:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
+    "md5": "c8be79678101bbc03ea2018b80a8ac0a",
+    "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
+    },
+    {
+    "id": "color-convert:1.9.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+    "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+    "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+    "id": "which-module:1.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
+    "md5": "004cd541632e781023b01a91b2d4b851",
+    "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
+    },
+    {
+    "id": "imurmurhash:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+    "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+    "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+    "id": "use:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+    "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
+    "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
+    },
+    {
+    "id": "is-descriptor:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-property:1.0.0",
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:1.0.0",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:1.0.0",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3b159746a66604b04f8c81524ba365c5f14d86ec",
+    "md5": "7cd33adcb4ca927942b08b261badd3ed",
+    "sha256": "fe5ee7a359c2ae4ec7c12a075d903150c23365bf55c0c471b8d34fade96c6ead"
+    },
+    {
+    "id": "anymatch:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
+    "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
+    "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
+    },
+    {
+    "id": "tsconfig-paths:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ba0734599e8ea36c862798e920bcf163277b137a",
+    "md5": "4d77fe4a7d930f1ecb5942b37f359909",
+    "sha256": "9c764c11733958e34f461ca43b430f4c54edc9167cfbbb9088660f3431e9f401"
+    },
+    {
+    "id": "es6-symbol:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
+    "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
+    "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
+    },
+    {
+    "id": "randomatic:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
+    "md5": "da226719644d2e64d1127424e028f827",
+    "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
+    },
+    {
+    "id": "js-tokens:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "loose-envify:1.4.0",
+    "invariant:2.2.4",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9866df395102130e38f7f996bceb65443209c25b",
+    "md5": "969180644218c18794b6df26d42accd5",
+    "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
+    },
+    {
+    "id": "globals:9.18.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
+    "md5": "746bb222029d9fd52336a7503c6e110b",
+    "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
+    },
+    {
+    "id": "array-unique:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
+    "md5": "7b3ac4760380d655957c68e59748f438",
+    "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
+    },
+    {
+    "id": "pluralize:1.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
+    "md5": "10ffc865fc0a65a38893463e1ab77403",
+    "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
+    },
+    {
+    "id": "lodash.isarguments:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
+    "md5": "5aee2d8dc451d10cdc97666d9964074d",
+    "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
+    },
+    {
+    "id": "acorn:5.7.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
+    "md5": "861b7e390cd4b067b90229f4b9eec0c9",
+    "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
+    },
+    {
+    "id": "is-extglob:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:0.3.2",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-glob:2.0.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
+    "md5": "2abcdb854a7d2b4446afc7b636916db7",
+    "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
+    },
+    {
+    "id": "cache-base:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
+    "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
+    "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
+    },
+    {
+    "id": "next-tick:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1836ee30ad56d67ef281b22bd199f709449b35eb",
+    "md5": "faaf65a0216bc6be06b5cf1139315f60",
+    "sha256": "f29d4d707449588c7200d1d4d05286fd3b8c0f63ad2e595f9bcd011c8d0ed755"
+    },
+    {
+    "id": "buffer-from:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
+    "md5": "5fe5f473dc3263473041a56654581058",
+    "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
+    },
+    {
+    "id": "semver:5.7.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
+    "md5": "99453010ab0aad4c49dba769e6193c35",
+    "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
+    },
+    {
+    "id": "camelcase:3.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs-parser:2.4.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
+    "md5": "d9d2d730959290cbbb9ef3900cd6126c",
+    "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
+    },
+    {
+    "id": "escape-string-regexp:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "figures:1.7.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+    "md5": "02440084832abe665260d5db1da1dd9e",
+    "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+    "id": "acorn-jsx:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
+    "md5": "4b90c954f940a0891370c7d265ce0fc6",
+    "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
+    },
+    {
+    "id": "source-map-resolve:0.5.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
+    "md5": "88b0cf532783413eb92e171554ddd28d",
+    "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
+    },
+    {
+    "id": "flat-cache:1.3.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
+    "md5": "7f7fe842b74285784727aedf7cf81c4b",
+    "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
+    },
+    {
+    "id": "path-exists:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+    "md5": "7c2676f4502f776524cefe6e0b877136",
+    "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
+    },
+    {
+    "id": "has-flag:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:5.5.0",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "supports-color:5.5.0",
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+    "md5": "1fa1fa951639c7058277abcecca86922",
+    "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+    "id": "text-table:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
+    "md5": "4e595139988957453229d6ccd229f626",
+    "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
+    },
+    {
+    "id": "is-core-module:2.9.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e1c34429cd51c6dd9e09e0799e396e27b19a9c69",
+    "md5": "9862dd9912e0d8158cdb2b339c0ee148",
+    "sha256": "2ba3f3317b3f4055f45e879068a1c37dafef035b407282e420ccf5fa8c13cc6d"
+    },
+    {
+    "id": "code-point-at:1.1.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+    "md5": "c214d9956b6b675ad837e76eecfc2d4b",
+    "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
+    },
+    {
+    "id": "copy-descriptor:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+    "md5": "d6e57e9597c6af638adc414e74c3d516",
+    "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
+    },
+    {
+    "id": "glob-base:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
+    "md5": "ea2fd4074a1f129431de415f1c5387aa",
+    "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
+    },
+    {
+    "id": "expand-range:1.8.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
+    "md5": "b9375c64d875584bb5bf5a4829007f32",
+    "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
+    },
+    {
+    "id": "generate-object-property:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-my-json-valid:2.13.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
+    "md5": "275dde8134c99f03d9ff31a8fa861f19",
+    "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
+    },
+    {
+    "id": "map-visit:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+    "md5": "1911d8539476d5e5b03c42e63a87b49a",
+    "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
+    },
+    {
+    "id": "internal-slot:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
+    "md5": "01f7b7499f71622547496b12f902bec8",
+    "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
+    },
+    {
+    "id": "resolve-from:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-mocha:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
+    "md5": "e19abe316d7d524402ff940ff923406c",
+    "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
+    },
+    {
+    "id": "object.omit:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
+    "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
+    "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
+    },
+    {
+    "id": "source-map:0.5.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+    "md5": "3773f963d18f1aca320fae40b04aded2",
+    "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
+    },
+    {
+    "id": "lodash.clonedeep:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
+    "md5": "dfef3b8bee7adea034e7224d909d92f5",
+    "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
+    },
+    {
+    "id": "esquery:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
+    "md5": "67c3703f159c91ae9bd06b896a863b19",
+    "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
+    },
+    {
+    "id": "fast-levenshtein:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
+    "md5": "443a739d106c51a33470c9f018d82e85",
+    "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
+    },
+    {
+    "id": "assign-symbols:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+    "md5": "e9bb66200b728da39a79c2f235780331",
+    "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
+    },
+    {
+    "id": "is-buffer:1.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "kind-of:3.2.2",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-number:3.0.0",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-number:3.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:4.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+    "md5": "374af5d9a1a7e4d3e686419412fa6b72",
+    "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
+    },
+    {
+    "id": "array.prototype.find:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "153b8a28ad8965cd86d3117b07e6596af6f2880d",
+    "md5": "ec713f547ad22ceb5cf77b1282059b4c",
+    "sha256": "132f73797a28c9f91511f20662cc43ee6a51473b191b4d7aa5987861c540513d"
+    },
+    {
+    "id": "is-fullwidth-code-point:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
+    "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
+    "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
+    },
+    {
+    "id": "is-glob:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob-base:0.3.0",
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob-parent:2.0.0",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
+    "md5": "094686a7618e52db5f126af328da6aff",
+    "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
+    },
+    {
+    "id": "normalize-path:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+    "md5": "b2f3932160dc03a5604dbac60ef59c34",
+    "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
+    },
+    {
+    "id": "mixin-deep:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
+    "md5": "53fb379c1187b97eecfcf06399958566",
+    "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
+    },
+    {
+    "id": "remove-trailing-separator:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "normalize-path:2.1.1",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+    "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
+    "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
+    },
+    {
+    "id": "fill-range:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
+    "md5": "35483acae8b070dad60c41a99afe6b4d",
+    "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
+    },
+    {
+    "id": "to-object-path:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+    "md5": "ed213d48acc6db7b01883673013ba398",
+    "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
+    },
+    {
+    "id": "is-property:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "generate-function:2.3.1",
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "generate-object-property:1.2.0",
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "generate-object-property:1.2.0",
+    "is-my-json-valid:2.13.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
+    "md5": "29d8709ba7392da7846b05c30cb83832",
+    "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
+    },
+    {
+    "id": "repeat-element:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
+    "md5": "bf964c7d487f69452bf2196b93908917",
+    "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
+    },
+    {
+    "id": "hosted-git-info:2.8.9",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
+    "md5": "e50583bc39341b531466e5de5b6aef94",
+    "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
+    },
+    {
+    "id": "is-posix-bracket:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:0.1.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
+    "md5": "cd1bc456317e6cf7357683e79b8354c5",
+    "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
+    },
+    {
+    "id": "node-notifier:4.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
+    "md5": "0f04f7a88ceff67961e4277485727ce9",
+    "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
+    },
+    {
+    "id": "is-extglob:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-glob:4.0.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+    "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+    "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+    "id": "extglob:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
+    "md5": "5e368678ebf35fe8dbaa173517e7adc1",
+    "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
+    },
+    {
+    "id": "cli-cursor:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
+    "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
+    "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
+    },
+    {
+    "id": "string-width:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+    "md5": "b8aa95585646db49430dbaf185daec5d",
+    "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
+    },
+    {
+    "id": "map-cache:0.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fragment-cache:0.2.1",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+    "md5": "7ed5e46ed67d87ec937cedc485559cb6",
+    "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
+    },
+    {
+    "id": "optionator:0.8.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+    "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
+    "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
+    },
+    {
+    "id": "string_decoder:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+    "md5": "7b93eea8153258fea64c3192922effaa",
+    "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
+    },
+    {
+    "id": "strip-ansi:3.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "wrap-ansi:2.1.0",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+    "md5": "823f58e5d7b03f4e924b2be7157f4f43",
+    "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
+    },
+    {
+    "id": "minimist:1.2.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "json5:1.0.1",
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mkdirp:0.5.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8637a5b759ea0d6e98702cfb3a9283323c93af44",
+    "md5": "0d781b9eda1d585527fb8e1edcfce4c6",
+    "sha256": "49c9124665fc1900e589be610b8dc69d5e61a179e9ed8547c6d61d30a225e726"
+    },
+    {
+    "id": "regex-not:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+    "md5": "e54f51e5d23c17edae9f9d199b337531",
+    "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
+    },
+    {
+    "id": "is-windows:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+    "md5": "bcc9525ed3558792d281951c90ad366e",
+    "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+    "id": "lodash.isarray:3.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.isplainobject:3.2.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.toplainobject:3.0.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseflatten:3.1.4",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash._pickbycallback:3.0.0",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
+    "md5": "ac707272f6b31e82622b1d581110aec2",
+    "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd"
+    },
+    {
+    "id": "number-is-nan:1.0.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "is-fullwidth-code-point:1.0.0",
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "097b602b53422a522c1afb8790318336941a011d",
+    "md5": "1c192095065e6b72a7e20a747b110469",
+    "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
+    },
+    {
+    "id": "esprima:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "redeyed:2.1.1",
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+    "md5": "c9d44a818c324d707a81b08dd36cd079",
+    "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+    "id": "pify:2.3.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "del:2.2.0",
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
+    "md5": "475310192b9d153240ac82eb66b827e8",
+    "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
+    },
+    {
+    "id": "is-utf8:0.2.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "strip-bom:2.0.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:2.0.0",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:1.0.0",
+    "vinyl-fs:0.3.14",
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:2.0.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
+    "md5": "7c483523b33b0640efedcc6561c545e2",
+    "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
+    },
+    {
+    "id": "filename-regex:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
+    "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
+    "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
+    },
+    {
+    "id": "babel-messages:6.23.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
+    "md5": "f7a22e78d59c180af1175172a3abee40",
+    "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
+    },
+    {
+    "id": "get-intrinsic:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "call-bind:1.0.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-property-descriptors:1.0.0",
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-symbol-description:1.0.0",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "336975123e05ad0b7ba41f152ee4aadbea6cf598",
+    "md5": "100e3a1e0c452360575c70b6b6cb03ad",
+    "sha256": "4759e55e01afaed935a624731dd753bd5a4fe73f4557e007bd8e765a2c1c328b"
+    },
+    {
+    "id": "eslint-plugin-jsdoc:2.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
+    "md5": "faf67209cc82f0fc3b0717ea662bbdab",
+    "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
+    },
+    {
+    "id": "micromatch:3.1.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
+    "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
+    "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
+    },
+    {
+    "id": "is-data-descriptor:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
+    "md5": "f8d653ce6e504d83c985de8d182f1ae5",
+    "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
+    },
+    {
+    "id": "typedarray:0.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
+    "md5": "54a18bcd7fd55c812993e9ce90a0709d",
+    "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
+    },
+    {
+    "id": "graceful-fs:4.2.10",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+    "md5": "094ac6976c4cec6cced67915d6c726c0",
+    "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+    "id": "object-inspect:1.12.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c0641f26394532f28ab8d796ab954e43c009a8ea",
+    "md5": "1193ad67b8d504446e7cb98275c5399b",
+    "sha256": "42e71d82a0209bda2995cae7e3d8802f631e5933646cae8cd000192dba74d65a"
+    },
+    {
+    "id": "is-accessor-descriptor:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
+    "md5": "71d1d01f8028c245544a9a1217fb2bce",
+    "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
+    },
+    {
+    "id": "p-locate:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20a0103b222a70c8fd39cc2e580680f3dde5ec43",
+    "md5": "1dd1c9d3ebad6ad80815da62a0d3cf43",
+    "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46"
+    },
+    {
+    "id": "babel-eslint:7.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
+    "md5": "85d7580cf18c64e2b1cd165832032bbc",
+    "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
+    },
+    {
+    "id": "is-callable:1.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "47301d58dd0259407865547853df6d61fe471945",
+    "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
+    "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
+    },
+    {
+    "id": "is-regex:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
+    "md5": "13a02d0abc63ff0093ca592e999f713c",
+    "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
+    },
+    {
+    "id": "parse-glob:3.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
+    "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
+    "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
+    },
+    {
+    "id": "xtend:4.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
+    "md5": "183e6eef1df0529fd39bd932447ba547",
+    "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
+    },
+    {
+    "id": "obj-props:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-obj-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9a9beebb6faf8b287ff7dc1cd133a4247dc85641",
+    "md5": "ace7f0609a71a11dbb9532032b2acab8",
+    "sha256": "41eaa9b49ccc882b9db952d448a180d1c4a5ee17c344634c046ff58ecb4da71a"
+    },
+    {
+    "id": "atob:2.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
+    "md5": "45eb23f9eb24b3ff24e18466deeaa887",
+    "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
+    },
+    {
+    "id": "color-name:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:1.9.3",
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+    "md5": "b45186c4fe76a2450ec484149ade0066",
+    "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+    "id": "sprintf-js:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "argparse:1.0.7",
+    "js-yaml:3.6.0",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "argparse:1.0.10",
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+    "md5": "8e6b31a052754055683e4a35a317feab",
+    "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+    "id": "is-bigint:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
+    "md5": "54f51f1529d609a8762b6f18a9fc5f39",
+    "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
+    },
+    {
+    "id": "fragment-cache:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+    "md5": "14306688d4947a100f6cce5b00d07afd",
+    "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
+    },
+    {
+    "id": "js-yaml:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+    "md5": "2a522c3e23f7999abd8f852c012c20dd",
+    "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+    "id": "strip-json-comments:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
+    "md5": "af7d37e88560f64851d5c27b0abc617e",
+    "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
+    },
+    {
+    "id": "arr-flatten:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "arr-diff:2.0.0",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "36048bbff4e7b47e136644316c99669ea5ae91f1",
+    "md5": "1b469d538f9b387d83b3cb7e5994f7a5",
+    "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a"
+    },
+    {
+    "id": "object-keys:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
+    "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
+    "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
+    },
+    {
+    "id": "require-uncached:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
+    "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
+    "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
+    },
+    {
+    "id": "eslint-plugin-import:2.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f812dc47be4f2b72b478a021605a59fc6fe8b88b",
+    "md5": "9f46ab62fb92c3f10d14890b32b7d0bb",
+    "sha256": "bddeb1bd17cefa19c56b5e9cc861f667e0c82dcc35ee49aad27b1781f616753e"
+    },
+    {
+    "id": "is-dotfile:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
+    "md5": "9c1b18df01884a55636db529eca19fe2",
+    "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
+    },
+    {
+    "id": "safe-regex:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+    "md5": "6729d2a26cdabb856b9506e567bd8a57",
+    "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
+    },
+    {
+    "id": "ansi-escapes:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
+    "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
+    "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
+    },
+    {
+    "id": "ms:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:2.6.9",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
+    "md5": "9615634070dd7751f127b2a0fb362484",
+    "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
+    },
+    {
+    "id": "comment-parser:0.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
+    "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
+    "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
+    },
+    {
+    "id": "restore-cursor:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "34661f46886327fed2991479152252df92daa541",
+    "md5": "99b769f599ac64ecf9027f8717f01bb0",
+    "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
+    },
+    {
+    "id": "lodash.assign:4.2.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs-parser:2.4.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
+    "md5": "5a92447d4e8669abba120d5164892902",
+    "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
+    },
+    {
+    "id": "eslint-plugin-babel:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
+    "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
+    "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
+    },
+    {
+    "id": "es-to-primitive:1.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
+    "md5": "a32f26c478b76efa377601b8d17268a9",
+    "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
+    },
+    {
+    "id": "wrappy:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "once:1.4.0",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+    "md5": "567b1699cfae49cb20f598571a6c90c7",
+    "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
+    },
+    {
+    "id": "is-data-descriptor:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
+    "md5": "d4fe7614279e3f4718d383035209c33e",
+    "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
+    },
+    {
+    "id": "deep-is:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
+    "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
+    "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
+    },
+    {
+    "id": "read-pkg:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+    "md5": "c35de6ee14fc66999d84a2e20bdd478b",
+    "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
+    },
+    {
+    "id": "regex-cache:0.4.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
+    "md5": "c08a04a26436892d55f3d2fb294d8b73",
+    "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
+    },
+    {
+    "id": "has:1.0.3",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-shim-unscopables:1.0.0",
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-core-module:2.9.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+    "md5": "b765203b0d733534ee6a58d84767223a",
+    "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
+    },
+    {
+    "id": "proto-props:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-proto-prop:1.0.1",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
+    "md5": "43c4cc31101ee8f37df9b66ff8353003",
+    "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
+    },
+    {
+    "id": "estraverse:5.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "esrecurse:4.3.0",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "esquery:1.4.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
+    "md5": "ac5d5752d7928d448689899477f994b0",
+    "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
+    },
+    {
+    "id": "static-extend:0.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+    "md5": "685c7b45bd48268f9eeffbccecb2d313",
+    "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
+    },
+    {
+    "id": "wrap-ansi:2.1.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+    "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
+    "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
+    },
+    {
+    "id": "lodash._baseassign:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
+    "md5": "2438792bc711256968416ae0164b5dd9",
+    "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
+    },
+    {
+    "id": "ignore:3.3.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
+    "md5": "623073ae841f6a00f1d93c50f97065ad",
+    "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
+    },
+    {
+    "id": "babel-types:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
+    "md5": "d12869e767169377af311247a2d247e9",
+    "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
+    },
+    {
+    "id": "object.values:1.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
+    "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
+    "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
+    },
+    {
+    "id": "es-shim-unscopables:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "702e632193201e3edf8713635d083d378e510241",
+    "md5": "b84453b40e877a87ea66b886373597f4",
+    "sha256": "a8accca616c58a9c8ce92bc27d9d287d3948cf8310af5fa05d69c1a14d156761"
+    },
+    {
+    "id": "readdirp:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
+    "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
+    "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
+    },
+    {
+    "id": "source-map-url:0.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
+    "md5": "db54d6dc84c3bfa7f420da51c493023c",
+    "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
+    },
+    {
+    "id": "redeyed:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
+    "md5": "b143ff11e6aece5ad2722daebb73c708",
+    "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
+    },
+    {
+    "id": "esutils:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:2.1.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:1.5.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
+    "md5": "fbea0e3ececd72f8135013e599bb44b3",
+    "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
+    },
+    {
+    "id": "cliui:3.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "120601537a916d29940f934da3b48d585a39213d",
+    "md5": "3a83794ba283c15042e429b11802766d",
+    "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
+    },
+    {
+    "id": "normalize-package-data:2.5.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
+    "md5": "b46c083aa373a30b8d2421e9f269d543",
+    "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
+    },
+    {
+    "id": "is-date-object:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
+    "md5": "3b3393d413d848d50129f3f80d37e86a",
+    "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
+    },
+    {
+    "id": "for-own:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
+    "md5": "6b95dc29fcffc91036164869c724d05b",
+    "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
+    },
+    {
+    "id": "is-equal-shallow:0.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "regex-cache:0.4.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
+    "md5": "79abafbc68151c75a7242adf69c9b7c5",
+    "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
+    },
+    {
+    "id": "define-property:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
+    "md5": "2751868d9fa31ebbbe851fdcb729115d",
+    "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
+    },
+    {
+    "id": "yargs:4.8.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
+    "md5": "964f012a6509b1b431de5f58a11e061a",
+    "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
+    },
+    {
+    "id": "supports-preserve-symlinks-flag:1.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
+    "md5": "2ecf7c03c814ab155c5278d61f65583f",
+    "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
+    },
+    {
+    "id": "type:2.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ext:1.6.0",
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
+    "md5": "b06b1e937cd3671d147ef4f040fa297d",
+    "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
+    },
+    {
+    "id": "micromatch:2.3.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
+    "md5": "0c6949145be8bb09e5aa63fdebea9c24",
+    "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
+    },
+    {
+    "id": "object-visit:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "map-visit:1.0.0",
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+    "md5": "0c309d8c43bc9546676100500c1db1c4",
+    "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
+    },
+    {
+    "id": "readable-stream:2.3.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "comment-parser:0.4.2",
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
+    "md5": "f060c259b513e887f551d073950f12f9",
+    "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
+    },
+    {
+    "id": "isobject:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-plain-object:2.0.4",
+    "is-extendable:1.0.1",
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.pick:1.3.0",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-visit:1.0.1",
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+    "md5": "9e7647515c0885e809f9aeb22de293f3",
+    "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
+    },
+    {
+    "id": "escope:3.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
+    "md5": "9390f529580d458bc659af81607d7114",
+    "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
+    },
+    {
+    "id": "braces:1.8.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
+    "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
+    "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
+    },
+    {
+    "id": "cardinal:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
+    "md5": "876b0338412efe635c487c4bf31a55b1",
+    "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
+    },
+    {
+    "id": "word-wrap:1.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
+    "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
+    "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
+    },
+    {
+    "id": "which:1.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
+    "md5": "3077f0c321098e78b78ddd6b4b2789e5",
+    "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
+    },
+    {
+    "id": "invariant:2.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
+    "md5": "445e70b75ab7215bc0da1fbaa36113cd",
+    "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
+    },
+    {
+    "id": "object-assign:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "figures:1.7.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
+    "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
+    "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
+    },
+    {
+    "id": "lowercase-keys:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-get-set-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-obj-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-proto-prop:1.0.1",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+    "md5": "de9b080b5e473d21200e69b8bfc7c204",
+    "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
+    },
+    {
+    "id": "es6-symbol:3.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
+    "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
+    "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
+    },
+    {
+    "id": "inquirer:0.12.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
+    "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
+    "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
+    },
+    {
+    "id": "arr-union:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
+    "md5": "f3cf2ebd1f4051917051f0c2b9287954",
+    "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
+    },
+    {
+    "id": "os-homedir:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "user-home:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+    "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
+    "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
+    },
+    {
+    "id": "for-in:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "for-own:0.1.5",
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+    "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
+    "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
+    },
+    {
+    "id": "os-locale:1.4.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
+    "md5": "fdb77de7d9374b72e7f466c27908a730",
+    "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
+    },
+    {
+    "id": "eslint:3.19.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-babel:3.3.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-flowtype:2.50.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-lodash:2.7.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-mocha:4.12.1",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
+    "md5": "2b28bed1fe16d31f22178145baa90d7a",
+    "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
+    },
+    {
+    "id": "inherits:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+    "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+    "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+    "id": "pinkie:2.0.4",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pinkie-promise:2.0.1",
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pinkie-promise:2.0.1",
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pinkie-promise:2.0.1",
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+    "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
+    "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
+    },
+    {
+    "id": "has-property-descriptors:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610708600606d36961ed04c196193b6a607fa861",
+    "md5": "7f67f61d09b2f2e9faa560ba49b21e85",
+    "sha256": "1ea75b75dc4e6f491cb9f736cb49265ada125f8bf23fc43cff6d16c1c6435f97"
+    },
+    {
+    "id": "is-shared-array-buffer:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8f259c573b60b6a32d4058a1a07430c0a7344c79",
+    "md5": "478da999f49b20d86406f760d98af885",
+    "sha256": "1fe57e0f2a80050e5b0c2d1fed9eec189c1a7650bfb2f6cb800537929961fa90"
+    },
+    {
+    "id": "is-symbol:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
+    "md5": "1d481161785d0b7c5a729e39edb86e9a",
+    "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
+    },
+    {
+    "id": "json5:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
+    "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
+    "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
+    },
+    {
+    "id": "eslint-plugin-mocha:4.12.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
+    "md5": "3e429cc644ee80c1c60c86478eee616b",
+    "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
+    },
+    {
+    "id": "get-caller-file:1.0.3",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
+    "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
+    "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
+    },
+    {
+    "id": "is-weakref:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
+    "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
+    "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
+    },
+    {
+    "id": "es6-iterator:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+    "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
+    "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
+    },
+    {
+    "id": "file-entry-cache:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
+    "md5": "329f8f032842d7a2c711bd18423e5226",
+    "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
+    },
+    {
+    "id": "snapdragon:0.8.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
+    "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
+    "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
+    },
+    {
+    "id": "type-check:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "levn:0.2.5",
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
+    "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
+    "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
+    },
+    {
+    "id": "ansi-styles:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
+    "md5": "deb5e5008ca69027719588d723cf9f91",
+    "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
+    },
+    {
+    "id": "is-my-ip-valid:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f7220d1146257c98672e6fba097a9f3f2d348442",
+    "md5": "9d9e18f4f947f111477e8ee23ee41dd2",
+    "sha256": "c189c5d6a085578b79bfc4bbbdb2470ae45244a0d89df9663eed8fab59b6925f"
+    },
+    {
+    "id": "expand-brackets:2.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
+    "md5": "a49099d108479157c6efcc4b739a00b2",
+    "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
+    },
+    {
+    "id": "es6-map:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
+    "md5": "98c9ef67294b8213745a30395f4a62b5",
+    "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
+    },
+    {
+    "id": "marked-terminal:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
+    "md5": "3fc3251d4faab2d1df0155b08258bd34",
+    "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
+    },
+    {
+    "id": "ramda:0.25.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-mocha:4.12.1",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
+    "md5": "f86f2a632aa11bb7af129304fbe22a67",
+    "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
+    },
+    {
+    "id": "is-plain-object:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-extendable:1.0.1",
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-extendable:1.0.1",
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+    "md5": "335972afae19ad1eccb8eee9aad94747",
+    "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
+    },
+    {
+    "id": "require-directory:2.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+    "md5": "f3a9010155b6a46066afbe2d07f624bd",
+    "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+    "id": "run-async:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
+    "md5": "05b4c27dcef5296aff906af32f377494",
+    "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
+    },
+    {
+    "id": "spdx-exceptions:2.3.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-expression-parse:3.0.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
+    "md5": "acbb50a4dc418357a51310b852eb2e38",
+    "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
+    },
+    {
+    "id": "find-up:1.1.2",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+    "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
+    "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
+    },
+    {
+    "id": "read-pkg-up:1.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "meow:3.7.0",
+    "dateformat:1.0.12",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
+    "md5": "02cc53c7512931912dcbdcd9c1d55265",
+    "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
+    },
+    {
+    "id": "user-home:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
+    "md5": "221f00361d182f5dfd195a7d867307c7",
+    "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
+    },
+    {
+    "id": "call-bind:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-symbol-description:1.0.0",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-regex:1.1.4",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-shared-array-buffer:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-weakref:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-boolean-object:1.1.2",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
+    "md5": "d244c20a7b3f2c607030df6337a4e68d",
+    "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
+    },
+    {
+    "id": "circular-json:0.3.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
+    "md5": "5569f191dea3cd5f952867196e41e050",
+    "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
+    },
+    {
+    "id": "levn:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+    "md5": "824680de0ed2dabe2745e88737723963",
+    "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
+    },
+    {
+    "id": "loose-envify:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "invariant:2.2.4",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
+    "md5": "5e78d5f6b1ad3ecce9605936059d087e",
+    "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
+    },
+    {
+    "id": "find-up:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
+    "md5": "cb9da6343737d03323119847685addf1",
+    "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
+    },
+    {
+    "id": "p-try:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:1.3.0",
+    "p-locate:2.0.0",
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+    "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
+    "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
+    },
+    {
+    "id": "fill-range:2.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
+    "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
+    "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
+    },
+    {
+    "id": "argparse:1.0.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+    "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+    "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+    "id": "is-number:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
+    "md5": "16a0b10f0dab47199d6536d319c0c6d5",
+    "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
+    },
+    {
+    "id": "ansi-styles:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+    "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+    "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+    "id": "is-string:1.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
+    "md5": "a7cc7f159a13b20e5fa93015d6124705",
+    "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
+    },
+    {
+    "id": "is-obj-prop:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
+    "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
+    "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
+    },
+    {
+    "id": "isarray:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "doctrine:1.5.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:1.2.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "isobject:2.1.0",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "isobject:2.1.0",
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "through2:2.0.1",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
+    "md5": "c24471c617803171eed93b3516624c97",
+    "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
+    },
+    {
+    "id": "validate-npm-package-license:3.0.4",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+    "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
+    "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
+    },
+    {
+    "id": "is-boolean-object:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
+    "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
+    "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
+    },
+    {
+    "id": "string-width:1.0.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "wrap-ansi:2.1.0",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+    "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
+    "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
+    },
+    {
+    "id": "pascalcase:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+    "md5": "0c6e0012f1d98450a08a7b76b55a3296",
+    "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
+    },
+    {
+    "id": "lodash._bindcallback:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.clonedeep:3.0.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._createassigner:3.1.1",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
+    "md5": "20bfe15e77fe081ff95fa92c73f0699e",
+    "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
+    },
+    {
+    "id": "balanced-match:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+    "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+    "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+    "id": "lodash.keys:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
+    "md5": "d2aa104b88db88e2c0f1ed627031ed03",
+    "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
+    },
+    {
+    "id": "regexp.prototype.flags:1.4.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "87cab30f80f66660181a3bb7bf5981a872b367ac",
+    "md5": "61b7a182d81b12b7c8a9bc5105726ab0",
+    "sha256": "444df1245ed8a3a8f5afbffed1e9c589e4878fc3bf9021cb5a6c127f38ccbd95"
+    },
+    {
+    "id": "progress:1.1.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
+    "md5": "06556528b7598e755a84c9c8f75c2622",
+    "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
+    },
+    {
+    "id": "is-number:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
+    "md5": "fb4c6b1ce591089d5da379104d9455b8",
+    "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
+    },
+    {
+    "id": "snapdragon-util:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
+    "md5": "17c194e41dd12d561800985ef5b4ffdf",
+    "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
+    },
+    {
+    "id": "cli-table:0.3.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
+    "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
+    "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
+    },
+    {
+    "id": "set-blocking:2.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+    "md5": "ff057cf430b35ecb25780f94cd051ab3",
+    "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+    "id": "isobject:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
+    "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
+    "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
+    },
+    {
+    "id": "ret:0.1.15",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "safe-regex:1.1.0",
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+    "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
+    "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
+    },
+    {
+    "id": "cli-width:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
+    "md5": "c9cf40c64a983c42f8fd91a97542f25e",
+    "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
+    },
+    {
+    "id": "babel-runtime:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-messages:6.23.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+    "md5": "f791f7898733e02f7216de5d6d6a1602",
+    "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
+    },
+    {
+    "id": "path-exists:2.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+    "md5": "4cc32b19e220e3ca0f4d14844996dc56",
+    "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
+    },
+    {
+    "id": "concat-map:0.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.4",
+    "minimatch:2.0.10",
+    "babel-core:6.8.0",
+    "babel-plugin-transform-regenerator:6.8.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "brace-expansion:1.1.3",
+    "minimatch:3.0.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+    "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+    "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+    "id": "jsonify:0.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "json-stable-stringify:1.0.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "json-stable-stringify:1.0.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
+    "md5": "78cc678249f2a175db1cffbd5bb25a14",
+    "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
+    },
+    {
+    "id": "lcid:1.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "os-locale:1.4.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "os-locale:1.4.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "os-locale:1.4.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
+    "md5": "33e24746875ebbcc37c40c7297388609",
+    "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
+    },
+    {
+    "id": "ansi-escapes:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
+    "md5": "7431226bb3f179e8cd7eddf297b904ec",
+    "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
+    },
+    {
+    "id": "array.prototype.flat:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b",
+    "md5": "4578f7e4eff680e7f1527b26181c52b2",
+    "sha256": "fa6ddc9a63f839e89e7eda58b50879a7c8d850d48bc281a5354b9d2160d51f76"
+    },
+    {
+    "id": "shelljs:0.7.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
+    "md5": "476ea3b109ecf2179be8b78b444245d0",
+    "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
+    },
+    {
+    "id": "ext:1.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
+    "md5": "9cf67c9330abea4cd40a86724154f246",
+    "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
+    },
+    {
+    "id": "chalk:2.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+    "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+    "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+    "id": "es5-ext:0.10.61",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "d:1.0.1",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.1",
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "event-emitter:0.3.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "311de37949ef86b6b0dcea894d1ffedb909d3269",
+    "md5": "84eb1176f35b58e8a606648d61d35584",
+    "sha256": "a4d97b74a47ac8a9364330e304949af6193537794f83005fc6e0776d0a577a77"
+    },
+    {
+    "id": "canonical:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
+    "md5": "a92c480423bdf2a2773e91c283b74ad8",
+    "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
+    },
+    {
+    "id": "generate-function:2.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f069617690c10c868e73b8465746764f97c3479f",
+    "md5": "b4fd862f79a3a0a097ea8818a5858d22",
+    "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
+    },
+    {
+    "id": "resolve-url:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "source-map-resolve:0.3.1",
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
+    "md5": "b515d6d96cd554cb0cda158563e82e00",
+    "sha256": "88e9cb578b6373125c416cacb9f42c4896fe3e072e4b94ba6948cba70e551824"
+    },
+    {
+    "id": "strip-bom:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
+    "md5": "a2045f7f89506a0f8301822998d1daf7",
+    "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
+    },
+    {
+    "id": "is-proto-prop:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
+    "md5": "78443d3b543426fda71dfcb27111473b",
+    "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
+    },
+    {
+    "id": "isexe:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which:1.3.1",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+    "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+    "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+    "id": "error-ex:1.3.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+    "md5": "5d2c673565060037f9e04d7975d04feb",
+    "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
+    },
+    {
+    "id": "jsonpointer:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2110e0af0900fd37467b5907ecd13a7884a1b559",
+    "md5": "d6ef3969001e1025effb07a76ff8e3ca",
+    "sha256": "72c2fe2b1034905ed19b2477ccea0167a8490f1ff4e306f3a63a74c7a2ef1e10"
+    },
+    {
+    "id": "table:3.8.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
+    "md5": "caa5899fd31138fdbe11b2944fdf16e4",
+    "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
+    },
+    {
+    "id": "es-abstract:1.20.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "027292cd6ef44bd12b1913b828116f54787d1814",
+    "md5": "3f67e5a17520816ff5cc668928214ed6",
+    "sha256": "54b669ef739263ae77a541d63749d7865ea4ac80a4d8802c8b93b3901327d7bb"
+    },
+    {
+    "id": "rimraf:2.6.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
+    "md5": "bd58522df35ee7b727430b41720e912d",
+    "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
+    },
+    {
+    "id": "is-accessor-descriptor:0.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+    "md5": "988cec0d99237747735bc5d84953a207",
+    "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
+    },
+    {
+    "id": "eslint-plugin-lodash:2.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
+    "md5": "7673c712d2af4c5fdc07ae78775670d6",
+    "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
+    },
+    {
+    "id": "glob:7.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "rimraf:2.6.3",
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b",
+    "md5": "16222090f290ce18931eb40cec43fa2a",
+    "sha256": "f0a38eb1318c06cb55dc28f3f32d2df7379e155cefc6a1e5ecc7a0ddad194381"
+    },
+    {
+    "id": "is-primitive:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-equal-shallow:0.1.3",
+    "regex-cache:0.4.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "207bab91638499c07b2adf240a41a87210034575",
+    "md5": "73402009e3936aeaa7b5c473d090b017",
+    "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
+    },
+    {
+    "id": "async-each:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
+    "md5": "c1130142d7ed405602b1fc38d811e360",
+    "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
+    },
+    {
+    "id": "colors:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-table:0.3.11",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
+    "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
+    "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
+    },
+    {
+    "id": "y18n:3.2.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
+    "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
+    "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
+    },
+    {
+    "id": "mute-stream:0.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
+    "md5": "597b34af22c4237293f5c05cd5f74214",
+    "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
+    },
+    {
+    "id": "has-symbols:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-symbol:1.0.4",
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-tostringtag:1.0.0",
+    "is-string:1.0.7",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb7b2c4349251dce87b125f7bdf874aa7c8b39f8",
+    "md5": "de53cc38f69c9145fd5613d6457e01b3",
+    "sha256": "ddcc17682f1e12a9d00a1a8b656af941ed584914e55fc5caf1c2e7ce892ce6a6"
+    },
+    {
+    "id": "es6-weak-map:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
+    "md5": "edb82ccad9f34520dc736bfbc67dc4be",
+    "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
+    },
+    {
+    "id": "object-copy:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+    "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
+    "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
+    },
+    {
+    "id": "slice-ansi:0.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
+    "md5": "c6a421b62848c96d57d4394964a89162",
+    "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
+    },
+    {
+    "id": "callsites:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caller-path:0.1.0",
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "caller-path:0.1.0",
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
+    "md5": "b6e9bfb992503522ddaee4e965423faa",
+    "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
+    },
+    {
+    "id": "eslint-plugin-no-use-extend-native:0.3.12",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
+    "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
+    "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
+    },
+    {
+    "id": "is-get-set-prop:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
+    "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
+    "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
+    },
+    {
+    "id": "function-bind:1.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "call-bind:1.0.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has:1.0.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+    "md5": "ee976e75439af2b82e707f3a64c69684",
+    "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
+    },
+    {
+    "id": "define-property:0.2.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+    "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
+    "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
+    },
+    {
+    "id": "function.prototype.name:1.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cce0505fe1ffb80503e6f9e46cc64e46a12a9621",
+    "md5": "791d82804001c74e1c7b5f14f9f9f9ef",
+    "sha256": "75022ef5d9b8056827769df3cc8dccb7f023baf7850ebeeced921cccfd6cce10"
+    },
+    {
+    "id": "path-parse:1.0.7",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
+    "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
+    "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
+    },
+    {
+    "id": "figures:1.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
+    "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
+    "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
+    },
+    {
+    "id": "is-number:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
+    "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
+    "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
+    },
+    {
+    "id": "has-flag:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
+    "md5": "7ba03f6b47769f2acdc743ac0b23e339",
+    "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
+    },
+    {
+    "id": "through:2.3.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-mocha:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+    "md5": "615296782d4936bd53ebe4e5baa57db7",
+    "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
+    },
+    {
+    "id": "is-resolvable:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
+    "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
+    "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
+    },
+    {
+    "id": "expand-brackets:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
+    "md5": "15d774bbd64fa32c2c427854bf58143b",
+    "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
+    },
+    {
+    "id": "to-regex-range:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
+    "md5": "5ad83eab061e092ad457387b4317ed45",
+    "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
+    },
+    {
+    "id": "safe-buffer:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string_decoder:1.1.1",
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+    "md5": "dc7142b470e0957c5c34098b6fced0ab",
+    "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+    "id": "ansicolors:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979",
+    "md5": "9a8ff703d6072578025a1a324c9005d1",
+    "sha256": "b8e260ab45c01049f6a58029b723935bcef0cb28e62888e412f217bfd4e228ef"
+    },
+    {
+    "id": "is-extendable:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
+    "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
+    "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
+    },
+    {
+    "id": "lodash._arraycopy:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+    "md5": "6de9a4e0d113c056078d1db4e75c748b",
+    "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
+    },
+    {
+    "id": "strip-bom:2.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
+    "md5": "3fa008815fc843fd20aa6f15330ebcfb",
+    "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
+    },
+    {
+    "id": "braces:2.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
+    "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
+    "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
+    },
+    {
+    "id": "has-value:0.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
+    "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
+    "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
+    },
+    {
+    "id": "resolve:1.22.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "rechoir:0.6.2",
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "27cb2ebb53f91abb49470a928bba7558066ac177",
+    "md5": "67a0957a5180922a45e1b1d326a15508",
+    "sha256": "b556a5d48802ed4d038cfe8804596e1cca2176599a776f12daf686dee92d12ea"
+    },
+    {
+    "id": "lodash:4.17.21",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-flowtype:2.50.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-lodash:2.7.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-emoji:1.11.0",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
+    "md5": "25247d3dd7029d08a6ac99adab09086b",
+    "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
+    },
+    {
+    "id": "p-limit:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:2.0.0",
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
+    "md5": "f674d1283c8ac4d11ec813efc2b5934a",
+    "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
+    },
+    {
+    "id": "concat-stream:1.6.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
+    "md5": "f3d719f26732b5206541e52972316e84",
+    "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
+    },
+    {
+    "id": "arr-diff:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
+    "md5": "42ec151186ae4bd9980a212083d98bbe",
+    "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
+    },
+    {
+    "id": "ansi-regex:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "strip-ansi:4.0.0",
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "123d6479e92ad45ad897d4054e3c7ca7db4944e1",
+    "md5": "7f893ad90437fcded52211151e305234",
+    "sha256": "989c0a482af8797e890d899bdc0c54c343900a5303617604a1c39a98c0a76457"
+    },
+    {
+    "id": "lodash._basecopy:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.toplainobject:3.0.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
+    "md5": "34a2be5e888808f5239e85ae528752bf",
+    "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
+    },
+    {
+    "id": "brace-expansion:1.1.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+    "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+    "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+    "id": "interpret:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
+    "md5": "9d7dec2c46613400992e6b9ed13175c1",
+    "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
+    },
+    {
+    "id": "esrecurse:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
+    "md5": "a39f104614e3543dd4522ac4afdace00",
+    "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
+    },
+    {
+    "id": "is-negative-zero:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
+    "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
+    "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
+    },
+    {
+    "id": "@types/json5:0.0.29",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
+    "md5": "b2b856287e2f65c5298b7747332bb633",
+    "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
+    },
+    {
+    "id": "set-value:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
+    "md5": "b1e945fff7d8430e86066db678ca6390",
+    "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
+    },
+    {
+    "id": "get-symbol-description:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
+    "md5": "e14a4c666fa15e9f9173046700ead218",
+    "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
+    },
+    {
+    "id": "es6-set:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
+    "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
+    "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
+    },
+    {
+    "id": "acorn:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "acorn-jsx:3.0.1",
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
+    "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
+    "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
+    },
+    {
+    "id": "split-string:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
+    "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
+    "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
+    },
+    {
+    "id": "fs.realpath:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+    "md5": "9f790d7180667e1d8d1110f2cf321b62",
+    "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+    "id": "ajv-keywords:1.5.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
+    "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
+    "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
+    },
+    {
+    "id": "is-extendable:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
+    "md5": "61392549d95a063512f916897d7069b7",
+    "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
+    },
+    {
+    "id": "posix-character-classes:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+    "md5": "1fc17a88bddf7099b36179e8acbb68e9",
+    "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
+    },
+    {
+    "id": "component-emitter:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
+    "md5": "6b8517f3d7ad46e95c97b6d453f82189",
+    "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
+    },
+    {
+    "id": "pinkie-promise:2.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "del:2.2.0",
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
+    "md5": "d6cf74027e88ca54043e91d59629a656",
+    "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
+    },
+    {
+    "id": "extend-shallow:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "split-string:3.1.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
+    "md5": "194095206e18756d832f5e0ad3d71cb8",
+    "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
+    },
+    {
+    "id": "babylon:6.18.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
+    "md5": "c0f769098a62e7881847657d146d9cbe",
+    "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
+    },
+    {
+    "id": "load-json-file:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
+    "md5": "939784db9c3c72c26262cebef2f9b631",
+    "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
+    },
+    {
+    "id": "locate-path:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
+    "md5": "3241773d42e4709beacb91d0e7d92331",
+    "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
+    },
+    {
+    "id": "is-binary-path:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
+    "md5": "a989667cf8d696127090b72fe8a674b3",
+    "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
+    },
+    {
+    "id": "to-fast-properties:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
+    "md5": "eb323816b9903f0e6877898c3065da5b",
+    "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
+    },
+    {
+    "id": "glob-parent:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob-base:0.3.0",
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
+    "md5": "7dc0b2d10ed856934e289df5e1f12c59",
+    "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
+    },
+    {
+    "id": "decamelize:1.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:3.10.0",
+    "uglify-js:2.6.2",
+    "handlebars:4.0.5",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "meow:3.7.0",
+    "dateformat:1.0.12",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+    "md5": "330932e4de0e60c36114facb6d3dfafa",
+    "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
+    },
+    {
+    "id": "preserve:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
+    "md5": "bca875c4e8d238ef216dc9d1bcabf976",
+    "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
+    },
+    {
+    "id": "extend-shallow:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+    "md5": "5c9316b33e9363368f4468595c700044",
+    "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
+    },
+    {
+    "id": "strip-ansi:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
+    "md5": "f0aa5746513c46c807ea71744ec2bc5c",
+    "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
+    },
+    {
+    "id": "math-random:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5dd6943c938548267016d4e34f057583080c514c",
+    "md5": "029796aed5b40e10d30518bc21ad436a",
+    "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
+    },
+    {
+    "id": "shellwords:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
+    "md5": "406c4d51a834f3ddddfaf96b9303af36",
+    "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
+    },
+    {
+    "id": "has-values:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+    "md5": "b22e4bd0ee56cd167cb12437533618b1",
+    "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
+    },
+    {
+    "id": "array-includes:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb",
+    "md5": "3e1762231dcc1a9ca68d50da2e5935e5",
+    "sha256": "bf08768417abaaeb7f8caf6cc089ae4b3bcca6c9fe814bfede8556cdfeacae6d"
+    },
+    {
+    "id": "is-number-object:1.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59d50ada4c45251784e9904f5246c742f07a42fc",
+    "md5": "01e99c61d94d3ac9cffd17b6a666c860",
+    "sha256": "ab356b0a4c4dedc7ac45456826ec5caa14aa1051402516dc86f9bd75ba0a9b75"
+    },
+    {
+    "id": "invert-kv:1.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
+    "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
+    "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
+    },
+    {
+    "id": "eslint-import-resolver-node:0.3.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
+    "md5": "bf0a201e44f3e437813f10b97923f452",
+    "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
+    },
+    {
+    "id": "util-deprecate:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.0.6",
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "through2:2.0.1",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+    "md5": "280e304a953ba3a89f52cc6ad616b284",
+    "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
+    },
+    {
+    "id": "kind-of:6.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:1.0.0",
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:1.0.0",
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
+    "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
+    "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
+    },
+    {
+    "id": "growly:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
+    "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
+    "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
+    },
+    {
+    "id": "array-unique:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+    "md5": "c7fa44b0117a3ed0d161f876c68633f7",
+    "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
+    },
+    {
+    "id": "nanomatch:1.2.13",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+    "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
+    "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
+    },
+    {
+    "id": "natural-compare:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
+    "md5": "210787ea3f1a715dd963317ebfc5193f",
+    "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
+    },
+    {
+    "id": "rechoir:0.6.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "liftoff:2.2.1",
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
+    "md5": "9a0aa4db2a887a452ef08921160c7eb4",
+    "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
+    },
+    {
+    "id": "parse-json:2.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
+    "md5": "9b98b48019fa25c226348737831cf130",
+    "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
+    },
+    {
+    "id": "babel-code-frame:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
+    "md5": "fdca204ce9b0158bcc65745baa896e4c",
+    "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
+    },
+    {
+    "id": "lodash._basefor:3.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.isplainobject:3.2.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._pickbycallback:3.0.0",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
+    "md5": "e0118d593252e3902b3769f0ff775d04",
+    "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
+    },
+    {
+    "id": "get-set-props:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-get-set-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
+    "md5": "ae71d26ef14801348a804a1b2e987ed9",
+    "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
+    },
+    {
+    "id": "repeat-string:1.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
+    "md5": "ed49a5a26c9110a28411da1cded28e3a",
+    "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+    },
+    {
+    "id": "lodash._baseclone:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.clonedeep:3.0.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "303519bf6393fe7e42f34d8b630ef7794e3542b7",
+    "md5": "553b734a6902f3363cf41de744286bab",
+    "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549"
+    },
+    {
+    "id": "prelude-ls:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "levn:0.2.5",
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "type-check:0.3.2",
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "type-check:0.3.2",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
+    "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
+    "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
+    },
+    {
+    "id": "debug:2.6.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
+    "md5": "cb6cb63ab5843aee3af94d27c60ea476",
+    "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
+    },
+    {
+    "id": "jsx-ast-utils:1.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
+    "md5": "704aebceee728c9e0120486622b35790",
+    "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
+    },
+    {
+    "id": "path-is-absolute:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+    "md5": "18bfccb10294ae19e7eb616ed1c05176",
+    "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+    "id": "doctrine:1.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
+    "md5": "8628b3ac690236d809939b9c3ec2531c",
+    "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
+    },
+    {
+    "id": "ansi-regex:2.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "has-ansi:2.0.0",
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-ansi:3.0.1",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+    "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
+    "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
+    },
+    {
+    "id": "process-nextick-args:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+    "md5": "09e1b13837638717ed3f2aae7bc700db",
+    "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
+    },
+    {
+    "id": "which-boxed-primitive:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13757bc89b209b049fe5d86430e21cf40a89a8e6",
+    "md5": "2d84f8bed229309416dffff93d5028cd",
+    "sha256": "4a4017ba9103fed80bc3ec67c529ed43b38066a626dd9595d91a57cf0c5e089d"
+    },
+    {
+    "id": "marked:0.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
+    "md5": "2981b17fa46348526d23658960663d88",
+    "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
+    },
+    {
+    "id": "has-values:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+    "md5": "59bfd41b8b69c52c77823af62b7bada7",
+    "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
+    },
+    {
+    "id": "get-value:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+    "md5": "b45bf08107e22e624dade29284abd265",
+    "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
+    },
+    {
+    "id": "doctrine:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
+    "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
+    "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
+    },
+    {
+    "id": "d:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.1",
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "event-emitter:0.3.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8698095372d58dbee346ffd0c7093f99f8f9eb5a",
+    "md5": "34f0b6b6c919df899c7c240deb36deed",
+    "sha256": "e7fb647f7a114c2f5bc547454b043c29dd13de095dc6f476b883b266993918a9"
+    },
+    {
+    "id": "supports-hyperlinks:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
+    "md5": "ac43da5665ec45c28303793339d60e5f",
+    "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
+    },
+    {
+    "id": "yargs-parser:2.4.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
+    "md5": "3ed28206e170b6c0cf902511c2d0534b",
+    "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
+    },
+    {
+    "id": "binary-extensions:1.13.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-binary-path:1.0.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
+    "md5": "013fed37056567a27186a86285f28efd",
+    "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
+    },
+    {
+    "id": "rx-lite:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
+    "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
+    "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
+    },
+    {
+    "id": "exit-hook:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
+    "md5": "d6ad3b683bee91b5a117990d68a097dd",
+    "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
+    },
+    {
+    "id": "arr-diff:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
+    "md5": "5aa32e7c03b612d64d433306ecfcd392",
+    "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
+    },
+    {
+    "id": "kind-of:5.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
+    "md5": "378018a0079fc3bc94e8ec2812d86fe6",
+    "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
+    },
+    {
+    "id": "kind-of:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20813df3d712928b207378691a45066fae72dd57",
+    "md5": "e24d0d555965b239fb2b6435b0724853",
+    "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
+    },
+    {
+    "id": "spdx-license-ids:3.0.11",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-correct:3.1.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "spdx-expression-parse:3.0.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
+    "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
+    "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
+    },
+    {
+    "id": "eslint-config-canonical:1.15.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
+    "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
+    "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
+    },
+    {
+    "id": "mkdirp:0.5.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write:0.2.1",
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7def03d2432dcae4ba1d611445c48396062255f6",
+    "md5": "673b86d8669883c517b32b04886560f6",
+    "sha256": "1b29291a054b23ddc12f63cb0f563e486bc5866fb1855b5632d1a0ba88aab569"
+    },
+    {
+    "id": "collection-visit:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+    "md5": "735947ef7cec034327b0f2b0144b8256",
+    "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
+    },
+    {
+    "id": "has-tostringtag:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-date-object:1.0.5",
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-regex:1.1.4",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-boolean-object:1.1.2",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number-object:1.0.7",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-string:1.0.7",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
+    "md5": "25e5a30ea25da9a3e5cf67924512233a",
+    "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
+    },
+    {
+    "id": "minimatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+    "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+    "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+    "id": "is-glob:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+    "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+    "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+    "id": "json-stable-stringify:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "ajv:4.11.8",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
+    "md5": "7712931a8d538cad6e4beaccd491cbb2",
+    "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
+    },
+    {
+    "id": "lodash._getnative:3.9.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._createcache:3.1.2",
+    "lodash._basedifference:3.0.3",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+    "md5": "a311ce03b077bd8a3b4bfe46776f9035",
+    "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
+    },
+    {
+    "id": "object.pick:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+    "md5": "40633da6e17a372e353e73ae28beb843",
+    "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
+    },
+    {
+    "id": "side-channel:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
+    "md5": "abcc258cdccfd0db4007c7be3888d7df",
+    "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
+    },
+    {
+    "id": "has-ansi:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+    "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
+    "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
+    },
+    {
+    "id": "debug:3.2.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
+    "md5": "0f887df93ceeaa5784063eb8733a6778",
+    "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
+    },
+    {
+    "id": "string.prototype.trimend:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "914a65baaab25fbdd4ee291ca7dde57e869cb8d0",
+    "md5": "a3663ec694367b3d5df6cd1c904159f7",
+    "sha256": "05c18fe5ad1fac049ffdbdc95aa3d03510ce4838c5d95c5763ef41dc13a75561"
+    },
+    {
+    "id": "co:4.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ajv:4.11.8",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+    "md5": "b6f068b290c84d37007997c45148ad18",
+    "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
+    },
+    {
+    "id": "core-util-is:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
+    "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
+    "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
+    },
+    {
+    "id": "supports-color:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
+    "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
+    "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
+    },
+    {
+    "id": "decode-uri-component:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
+    "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
+    "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
+    },
+    {
+    "id": "require-main-filename:1.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+    "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
+    "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
+    },
+    {
+    "id": "class-utils:0.3.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
+    "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
+    "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
     }
-]
+    ]

--- a/build/testdata/npm/project4/npmv8/linux/package-lock.json
+++ b/build/testdata/npm/project4/npmv8/linux/package-lock.json
@@ -24,7 +24,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -42,7 +42,7 @@
     "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^3.0.4"
@@ -51,7 +51,7 @@
     "node_modules/acorn-jsx/node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -63,7 +63,7 @@
     "node_modules/ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "dependencies": {
         "co": "^4.6.0",
@@ -73,7 +73,7 @@
     "node_modules/ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "peerDependencies": {
         "ajv": ">=4.10.0"
@@ -82,7 +82,7 @@
     "node_modules/ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -91,7 +91,7 @@
     "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -100,7 +100,7 @@
     "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -109,7 +109,7 @@
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "node_modules/anymatch": {
@@ -134,7 +134,7 @@
     "node_modules/arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "dependencies": {
         "arr-flatten": "^1.0.1"
@@ -155,21 +155,21 @@
     "node_modules/arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -183,35 +183,37 @@
     "node_modules/array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -223,7 +225,7 @@
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -250,7 +252,7 @@
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -261,7 +263,7 @@
     "node_modules/babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
@@ -277,7 +279,7 @@
     "node_modules/babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -286,7 +288,7 @@
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "dependencies": {
         "core-js": "^2.4.0",
@@ -296,7 +298,7 @@
     "node_modules/babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.26.0",
@@ -313,7 +315,7 @@
     "node_modules/babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -358,7 +360,7 @@
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -370,7 +372,7 @@
     "node_modules/base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -408,7 +410,7 @@
     "node_modules/braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "dependencies": {
         "expand-range": "^1.8.1",
@@ -448,7 +450,7 @@
     "node_modules/cache-base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -470,7 +472,7 @@
     "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "dependencies": {
         "callsites": "^0.2.0"
@@ -482,7 +484,7 @@
     "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -491,7 +493,7 @@
     "node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -500,7 +502,7 @@
     "node_modules/canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "bundleDependencies": [
         "babel-eslint",
         "chalk",
@@ -3567,7 +3569,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
@@ -3580,7 +3582,7 @@
     "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -3596,7 +3598,7 @@
     "node_modules/chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
@@ -3638,7 +3640,7 @@
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -3650,7 +3652,7 @@
     "node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3662,7 +3664,7 @@
     "node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3697,7 +3699,7 @@
     "node_modules/class-utils/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3706,7 +3708,7 @@
     "node_modules/cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
@@ -3746,7 +3748,7 @@
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -3757,7 +3759,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -3767,7 +3769,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3776,7 +3778,7 @@
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -3798,13 +3800,13 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
@@ -3813,7 +3815,7 @@
     "node_modules/comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.4"
@@ -3828,7 +3830,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/concat-stream": {
@@ -3849,7 +3851,7 @@
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3859,7 +3861,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -3891,7 +3893,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3900,7 +3902,7 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -3913,15 +3915,19 @@
       "dev": true
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -3940,7 +3946,7 @@
     "node_modules/define-property/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3968,37 +3974,49 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
       }
     },
     "node_modules/es-to-primitive": {
@@ -4019,20 +4037,24 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4043,7 +4065,7 @@
     "node_modules/es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4057,7 +4079,7 @@
     "node_modules/es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4070,7 +4092,7 @@
     "node_modules/es6-set/node_modules/es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4102,7 +4124,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -4111,7 +4133,7 @@
     "node_modules/escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "dependencies": {
         "es6-map": "^0.1.3",
@@ -4126,7 +4148,7 @@
     "node_modules/eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.16.0",
@@ -4175,7 +4197,7 @@
     "node_modules/eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "dependencies": {
         "babel-eslint": "^7.0.0",
@@ -4249,7 +4271,7 @@
     "node_modules/eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=1.0.0"
@@ -4271,9 +4293,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -4281,14 +4303,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "engines": {
         "node": ">=4"
@@ -4300,7 +4322,7 @@
     "node_modules/eslint-plugin-import/node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4321,7 +4343,7 @@
     "node_modules/eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "dependencies": {
         "comment-parser": "^0.4.0",
@@ -4361,7 +4383,7 @@
     "node_modules/eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "dependencies": {
         "is-get-set-prop": "^1.0.0",
@@ -4382,7 +4404,7 @@
     "node_modules/eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "dependencies": {
         "array.prototype.find": "^2.0.1",
@@ -4401,7 +4423,7 @@
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2",
@@ -4500,7 +4522,7 @@
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4510,7 +4532,7 @@
     "node_modules/exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4519,7 +4541,7 @@
     "node_modules/expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "dependencies": {
         "is-posix-bracket": "^0.1.0"
@@ -4531,7 +4553,7 @@
     "node_modules/expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "dependencies": {
         "fill-range": "^2.1.0"
@@ -4558,7 +4580,7 @@
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -4583,7 +4605,7 @@
     "node_modules/extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -4595,13 +4617,13 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5",
@@ -4614,7 +4636,7 @@
     "node_modules/file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "dependencies": {
         "flat-cache": "^1.2.1",
@@ -4634,7 +4656,7 @@
     "node_modules/filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4659,7 +4681,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4686,7 +4708,7 @@
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4695,7 +4717,7 @@
     "node_modules/for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "dependencies": {
         "for-in": "^1.0.1"
@@ -4707,7 +4729,7 @@
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "dependencies": {
         "map-cache": "^0.2.2"
@@ -4719,7 +4741,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -4747,6 +4769,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "inBundle": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -4759,7 +4808,7 @@
     "node_modules/generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "dependencies": {
         "is-property": "^1.0.0"
@@ -4772,14 +4821,14 @@
       "inBundle": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4788,7 +4837,7 @@
     "node_modules/get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4813,22 +4862,22 @@
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4842,7 +4891,7 @@
     "node_modules/glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "dependencies": {
         "glob-parent": "^2.0.0",
@@ -4855,7 +4904,7 @@
     "node_modules/glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "dependencies": {
         "is-glob": "^2.0.0"
@@ -4871,15 +4920,15 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "inBundle": true
     },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "node_modules/has": {
@@ -4897,7 +4946,7 @@
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -4907,9 +4956,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4918,16 +4967,28 @@
     "node_modules/has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4954,7 +5015,7 @@
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.6",
@@ -4968,7 +5029,7 @@
     "node_modules/has-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4977,7 +5038,7 @@
     "node_modules/has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -4990,7 +5051,7 @@
     "node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5002,7 +5063,7 @@
     "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5014,7 +5075,7 @@
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5038,7 +5099,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -5047,7 +5108,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -5063,7 +5124,7 @@
     "node_modules/inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
@@ -5116,7 +5177,7 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5146,7 +5207,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "inBundle": true
     },
     "node_modules/is-bigint": {
@@ -5164,7 +5225,7 @@
     "node_modules/is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
@@ -5208,9 +5269,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "inBundle": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -5281,7 +5342,7 @@
     "node_modules/is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5290,7 +5351,7 @@
     "node_modules/is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "dependencies": {
         "is-primitive": "^2.0.0"
@@ -5302,7 +5363,7 @@
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5311,7 +5372,7 @@
     "node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5320,7 +5381,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "inBundle": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -5332,7 +5393,7 @@
     "node_modules/is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "dependencies": {
         "get-set-props": "^0.1.0",
@@ -5342,7 +5403,7 @@
     "node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -5354,16 +5415,16 @@
     "node_modules/is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "dependencies": {
         "js-types": "^1.0.0"
       }
     },
     "node_modules/is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "node_modules/is-my-json-valid": {
@@ -5394,7 +5455,7 @@
     "node_modules/is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5404,9 +5465,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -5421,7 +5482,7 @@
     "node_modules/is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0",
@@ -5443,7 +5504,7 @@
     "node_modules/is-plain-object/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5452,7 +5513,7 @@
     "node_modules/is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5461,7 +5522,7 @@
     "node_modules/is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5470,7 +5531,7 @@
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "node_modules/is-proto-prop": {
@@ -5506,10 +5567,13 @@
       "dev": true
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5547,7 +5611,7 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "inBundle": true
     },
     "node_modules/is-weakref": {
@@ -5574,19 +5638,19 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -5598,13 +5662,13 @@
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "node_modules/js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5626,7 +5690,7 @@
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "dependencies": {
         "jsonify": "~0.0.0"
@@ -5647,16 +5711,16 @@
     "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5665,7 +5729,7 @@
     "node_modules/jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -5674,7 +5738,7 @@
     "node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5686,7 +5750,7 @@
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "inBundle": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -5698,7 +5762,7 @@
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -5711,7 +5775,7 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5727,7 +5791,7 @@
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "inBundle": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
@@ -5739,7 +5803,7 @@
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5758,19 +5822,19 @@
     "node_modules/lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "node_modules/lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "node_modules/lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "dependencies": {
         "lodash._basecopy": "^3.0.0",
@@ -5780,7 +5844,7 @@
     "node_modules/lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "dependencies": {
         "lodash._arraycopy": "^3.0.0",
@@ -5794,37 +5858,37 @@
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "node_modules/lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "node_modules/lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "inBundle": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "dependencies": {
         "lodash._baseclone": "^3.0.0",
@@ -5834,19 +5898,19 @@
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "node_modules/lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "node_modules/lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0",
@@ -5878,7 +5942,7 @@
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5887,7 +5951,7 @@
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "dependencies": {
         "object-visit": "^1.0.0"
@@ -5963,7 +6027,7 @@
     "node_modules/marked-terminal/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5990,7 +6054,7 @@
     "node_modules/micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "dependencies": {
         "arr-diff": "^2.0.0",
@@ -6012,9 +6076,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6024,9 +6088,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -6055,12 +6119,12 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -6069,19 +6133,19 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -6110,7 +6174,7 @@
     "node_modules/nanomatch/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6119,7 +6183,7 @@
     "node_modules/nanomatch/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6137,13 +6201,13 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node_modules/node-emoji": {
@@ -6158,7 +6222,7 @@
     "node_modules/node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "dependencies": {
         "cli-usage": "^0.1.1",
@@ -6188,7 +6252,7 @@
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
@@ -6200,16 +6264,16 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6218,7 +6282,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6227,7 +6291,7 @@
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "dependencies": {
         "copy-descriptor": "^0.1.0",
@@ -6241,7 +6305,7 @@
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -6253,7 +6317,7 @@
     "node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6265,7 +6329,7 @@
     "node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6298,9 +6362,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6318,7 +6382,7 @@
     "node_modules/object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.0"
@@ -6330,7 +6394,7 @@
     "node_modules/object-visit/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6357,7 +6421,7 @@
     "node_modules/object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "dependencies": {
         "for-own": "^0.1.4",
@@ -6370,7 +6434,7 @@
     "node_modules/object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
@@ -6382,7 +6446,7 @@
     "node_modules/object.pick/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6408,7 +6472,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -6417,7 +6481,7 @@
     "node_modules/onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6443,7 +6507,7 @@
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6452,7 +6516,7 @@
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "inBundle": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -6476,7 +6540,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6488,7 +6552,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6497,7 +6561,7 @@
     "node_modules/parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "dependencies": {
         "glob-base": "^0.3.0",
@@ -6512,7 +6576,7 @@
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "inBundle": true,
       "dependencies": {
         "error-ex": "^1.2.0"
@@ -6524,7 +6588,7 @@
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6533,7 +6597,7 @@
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6542,7 +6606,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6551,7 +6615,7 @@
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "node_modules/path-parse": {
@@ -6563,7 +6627,7 @@
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -6577,7 +6641,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6586,7 +6650,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6595,7 +6659,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "inBundle": true,
       "dependencies": {
         "pinkie": "^2.0.0"
@@ -6607,13 +6671,13 @@
     "node_modules/pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6622,7 +6686,7 @@
     "node_modules/pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "bundleDependencies": [
         "babel-plugin-add-module-exports",
         "babel-plugin-check-es2015-constants",
@@ -10440,7 +10504,7 @@
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -10449,7 +10513,7 @@
     "node_modules/preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10464,7 +10528,7 @@
     "node_modules/progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -10520,7 +10584,7 @@
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "inBundle": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
@@ -10534,7 +10598,7 @@
     "node_modules/read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "inBundle": true,
       "dependencies": {
         "find-up": "^1.0.0",
@@ -10547,7 +10611,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "inBundle": true,
       "dependencies": {
         "path-exists": "^2.0.0",
@@ -10560,7 +10624,7 @@
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "inBundle": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
@@ -10601,7 +10665,7 @@
     "node_modules/readdirp/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10610,7 +10674,7 @@
     "node_modules/readdirp/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10640,7 +10704,7 @@
     "node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10652,7 +10716,7 @@
     "node_modules/readdirp/node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "dev": true,
       "dependencies": {
         "debug": "^2.3.3",
@@ -10670,7 +10734,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -10682,7 +10746,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10736,7 +10800,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -10748,7 +10812,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10760,7 +10824,7 @@
     "node_modules/readdirp/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -10775,7 +10839,7 @@
     "node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10787,7 +10851,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10799,7 +10863,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10811,7 +10875,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10823,7 +10887,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10835,7 +10899,7 @@
     "node_modules/readdirp/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10847,7 +10911,7 @@
     "node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10859,7 +10923,7 @@
     "node_modules/readdirp/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10901,7 +10965,7 @@
     "node_modules/readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -10912,7 +10976,7 @@
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
@@ -10924,7 +10988,7 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "dependencies": {
         "esprima": "~4.0.0"
@@ -10961,10 +11025,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "node_modules/repeat-element": {
@@ -10979,7 +11060,7 @@
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -10988,7 +11069,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10997,13 +11078,13 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
       "inBundle": true
     },
     "node_modules/require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "dependencies": {
         "caller-path": "^0.1.0",
@@ -11014,12 +11095,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "inBundle": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11033,7 +11114,7 @@
     "node_modules/resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11042,14 +11123,14 @@
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
@@ -11083,7 +11164,7 @@
     "node_modules/run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0"
@@ -11092,7 +11173,7 @@
     "node_modules/rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "node_modules/safe-buffer": {
@@ -11104,7 +11185,7 @@
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "dependencies": {
         "ret": "~0.1.10"
@@ -11122,7 +11203,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "inBundle": true
     },
     "node_modules/set-value": {
@@ -11143,7 +11224,7 @@
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11155,7 +11236,7 @@
     "node_modules/shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -11193,7 +11274,7 @@
     "node_modules/slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11235,7 +11316,7 @@
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -11247,7 +11328,7 @@
     "node_modules/snapdragon-node/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11268,7 +11349,7 @@
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11280,7 +11361,7 @@
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11292,7 +11373,7 @@
     "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11304,7 +11385,7 @@
     "node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11339,7 +11420,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11413,13 +11494,13 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "dependencies": {
         "define-property": "^0.2.5",
@@ -11432,7 +11513,7 @@
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11444,7 +11525,7 @@
     "node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11456,7 +11537,7 @@
     "node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11500,7 +11581,7 @@
     "node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "inBundle": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -11512,26 +11593,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11540,7 +11623,7 @@
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "inBundle": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -11552,7 +11635,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11561,7 +11644,7 @@
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11570,7 +11653,7 @@
     "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -11604,7 +11687,7 @@
     "node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11625,7 +11708,7 @@
     "node_modules/table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "dependencies": {
         "ajv": "^4.7.0",
@@ -11637,9 +11720,9 @@
       }
     },
     "node_modules/table/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11648,7 +11731,7 @@
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11670,7 +11753,7 @@
     "node_modules/table/node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -11682,19 +11765,19 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11703,7 +11786,7 @@
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11730,7 +11813,7 @@
     "node_modules/to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -11743,7 +11826,7 @@
     "node_modules/to-regex-range/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11753,14 +11836,14 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -11773,7 +11856,7 @@
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -11785,18 +11868,18 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -11821,7 +11904,7 @@
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "dependencies": {
         "has-value": "^0.3.1",
@@ -11834,7 +11917,7 @@
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.3",
@@ -11848,7 +11931,7 @@
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -11860,7 +11943,7 @@
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11869,7 +11952,7 @@
     "node_modules/unset-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11878,7 +11961,7 @@
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
@@ -11894,7 +11977,7 @@
     "node_modules/user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
@@ -11906,7 +11989,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -11950,13 +12033,13 @@
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
       "inBundle": true
     },
     "node_modules/window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
       "inBundle": true,
       "bin": {
         "window-size": "cli.js"
@@ -11977,7 +12060,7 @@
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -11990,13 +12073,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
@@ -12023,7 +12106,7 @@
     "node_modules/yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "inBundle": true,
       "dependencies": {
         "cliui": "^3.2.0",
@@ -12045,7 +12128,7 @@
     "node_modules/yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "inBundle": true,
       "dependencies": {
         "camelcase": "^3.0.0",
@@ -12057,7 +12140,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "acorn": {
@@ -12069,7 +12152,7 @@
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "requires": {
         "acorn": "^3.0.4"
@@ -12078,7 +12161,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
           "dev": true
         }
       }
@@ -12086,7 +12169,7 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "requires": {
         "co": "^4.6.0",
@@ -12096,31 +12179,31 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "requires": {}
     },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
     "ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "anymatch": {
@@ -12145,7 +12228,7 @@
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1"
@@ -12160,18 +12243,18 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -12179,35 +12262,37 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
     },
     "async-each": {
@@ -12225,7 +12310,7 @@
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
@@ -12236,7 +12321,7 @@
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -12248,7 +12333,7 @@
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -12257,7 +12342,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "requires": {
         "core-js": "^2.4.0",
@@ -12267,7 +12352,7 @@
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -12284,7 +12369,7 @@
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -12323,7 +12408,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -12332,7 +12417,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12366,7 +12451,7 @@
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "requires": {
         "expand-range": "^1.8.1",
@@ -12400,7 +12485,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12418,7 +12503,7 @@
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "requires": {
         "callsites": "^0.2.0"
@@ -12427,18 +12512,18 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
     },
     "canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "dev": true,
       "requires": {
         "babel-eslint": "^6.0.4",
@@ -14818,7 +14903,7 @@
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "requires": {
         "ansicolors": "~0.3.2",
@@ -14828,7 +14913,7 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -14841,7 +14926,7 @@
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
@@ -14876,7 +14961,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -14885,7 +14970,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14894,7 +14979,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14922,7 +15007,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -14930,7 +15015,7 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "requires": {
         "restore-cursor": "^1.0.1"
@@ -14964,7 +15049,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -14974,18 +15059,18 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
@@ -15004,19 +15089,19 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true
     },
     "comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.4"
@@ -15031,7 +15116,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "concat-stream": {
@@ -15049,7 +15134,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
     "core-js": {
@@ -15086,12 +15171,12 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "deep-is": {
@@ -15101,12 +15186,13 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -15122,7 +15208,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15145,31 +15231,43 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -15184,20 +15282,20 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15208,7 +15306,7 @@
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15222,7 +15320,7 @@
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15235,7 +15333,7 @@
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
           "dev": true,
           "requires": {
             "d": "1",
@@ -15269,13 +15367,13 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "requires": {
         "es6-map": "^0.1.3",
@@ -15287,7 +15385,7 @@
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.16.0",
@@ -15330,7 +15428,7 @@
     "eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "requires": {
         "babel-eslint": "^7.0.0",
@@ -15402,7 +15500,7 @@
     "eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "requires": {}
     },
@@ -15416,9 +15514,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -15426,20 +15524,20 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
@@ -15456,7 +15554,7 @@
     "eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.4.0",
@@ -15484,7 +15582,7 @@
     "eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "requires": {
         "is-get-set-prop": "^1.0.0",
@@ -15502,7 +15600,7 @@
     "eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "requires": {
         "array.prototype.find": "^2.0.1",
@@ -15515,7 +15613,7 @@
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -15589,7 +15687,7 @@
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15599,13 +15697,13 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
@@ -15614,7 +15712,7 @@
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
@@ -15640,7 +15738,7 @@
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -15661,7 +15759,7 @@
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -15670,13 +15768,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
@@ -15686,7 +15784,7 @@
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "requires": {
         "flat-cache": "^1.2.1",
@@ -15703,7 +15801,7 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true
     },
     "fill-range": {
@@ -15722,7 +15820,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -15743,13 +15841,13 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
@@ -15758,7 +15856,7 @@
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
@@ -15767,7 +15865,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -15786,6 +15884,24 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -15798,7 +15914,7 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "requires": {
         "is-property": "^1.0.0"
@@ -15810,20 +15926,20 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true
     },
     "get-symbol-description": {
@@ -15839,19 +15955,19 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -15859,7 +15975,7 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
@@ -15869,7 +15985,7 @@
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
@@ -15882,14 +15998,14 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "has": {
@@ -15903,28 +16019,37 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-tostringtag": {
@@ -15939,7 +16064,7 @@
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "requires": {
         "get-value": "^2.0.6",
@@ -15950,7 +16075,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15958,7 +16083,7 @@
     "has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -15968,7 +16093,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15977,7 +16102,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -15988,7 +16113,7 @@
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -16010,13 +16135,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -16032,7 +16157,7 @@
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -16079,7 +16204,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -16101,7 +16226,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -16115,7 +16240,7 @@
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -16144,9 +16269,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -16199,13 +16324,13 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
@@ -16214,19 +16339,19 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -16234,7 +16359,7 @@
     "is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "requires": {
         "get-set-props": "^0.1.0",
@@ -16244,7 +16369,7 @@
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -16253,16 +16378,16 @@
     "is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "requires": {
         "js-types": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "is-my-json-valid": {
@@ -16287,16 +16412,16 @@
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -16305,7 +16430,7 @@
     "is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0",
@@ -16324,7 +16449,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -16332,19 +16457,19 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "is-proto-prop": {
@@ -16374,10 +16499,13 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-string": {
       "version": "1.0.7",
@@ -16400,7 +16528,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -16420,19 +16548,19 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
@@ -16441,13 +16569,13 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true
     },
     "js-yaml": {
@@ -16463,7 +16591,7 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
@@ -16481,25 +16609,25 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true
     },
     "jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
@@ -16508,7 +16636,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -16516,7 +16644,7 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -16526,7 +16654,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -16538,7 +16666,7 @@
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -16548,7 +16676,7 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -16564,19 +16692,19 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -16586,7 +16714,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "requires": {
         "lodash._arraycopy": "^3.0.0",
@@ -16600,36 +16728,36 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "requires": {
         "lodash._baseclone": "^3.0.0",
@@ -16639,19 +16767,19 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -16677,13 +16805,13 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
@@ -16738,7 +16866,7 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -16761,7 +16889,7 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "requires": {
         "arr-diff": "^2.0.0",
@@ -16780,18 +16908,18 @@
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -16816,30 +16944,30 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -16865,13 +16993,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "kind-of": {
@@ -16885,13 +17013,13 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node-emoji": {
@@ -16906,7 +17034,7 @@
     "node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "requires": {
         "cli-usage": "^0.1.1",
@@ -16932,7 +17060,7 @@
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -16941,24 +17069,24 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -16969,7 +17097,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -16978,7 +17106,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -16987,7 +17115,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -17015,9 +17143,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -17029,7 +17157,7 @@
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
@@ -17038,7 +17166,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17058,7 +17186,7 @@
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "requires": {
         "for-own": "^0.1.4",
@@ -17068,7 +17196,7 @@
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -17077,7 +17205,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17096,7 +17224,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -17105,7 +17233,7 @@
     "onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true
     },
     "optionator": {
@@ -17125,13 +17253,13 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -17148,7 +17276,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -17157,13 +17285,13 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
@@ -17175,7 +17303,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -17183,25 +17311,25 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "path-parse": {
@@ -17212,7 +17340,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -17222,17 +17350,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -17240,19 +17368,19 @@
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
     "pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "dev": true,
       "requires": {
         "babel-plugin-add-module-exports": "^0.2.1",
@@ -20211,13 +20339,13 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true
     },
     "process-nextick-args": {
@@ -20229,7 +20357,7 @@
     "progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true
     },
     "proto-props": {
@@ -20272,7 +20400,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -20282,7 +20410,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -20291,7 +20419,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -20300,7 +20428,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -20336,13 +20464,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "braces": {
@@ -20366,7 +20494,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20377,7 +20505,7 @@
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -20392,7 +20520,7 @@
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -20401,7 +20529,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20445,7 +20573,7 @@
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -20454,7 +20582,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20465,7 +20593,7 @@
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -20477,7 +20605,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20488,7 +20616,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20497,7 +20625,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20508,7 +20636,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20517,7 +20645,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20528,7 +20656,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20537,7 +20665,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20548,7 +20676,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         },
         "kind-of": {
@@ -20583,7 +20711,7 @@
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
@@ -20594,7 +20722,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -20603,7 +20731,7 @@
     "redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
@@ -20634,10 +20762,21 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "repeat-element": {
@@ -20649,23 +20788,23 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "requires": {
         "caller-path": "^0.1.0",
@@ -20673,11 +20812,11 @@
       }
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -20685,19 +20824,19 @@
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "requires": {
         "exit-hook": "^1.0.0",
@@ -20722,7 +20861,7 @@
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "requires": {
         "once": "^1.3.0"
@@ -20731,7 +20870,7 @@
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "safe-buffer": {
@@ -20743,7 +20882,7 @@
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
@@ -20757,7 +20896,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -20774,7 +20913,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20785,7 +20924,7 @@
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -20813,7 +20952,7 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true
     },
     "snapdragon": {
@@ -20835,7 +20974,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -20844,7 +20983,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20853,7 +20992,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20862,7 +21001,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20903,7 +21042,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -20912,7 +21051,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -20929,7 +21068,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true
     },
     "source-map-resolve": {
@@ -20991,13 +21130,13 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "requires": {
         "define-property": "^0.2.5",
@@ -21007,7 +21146,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -21016,7 +21155,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21025,7 +21164,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21064,7 +21203,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -21072,29 +21211,31 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -21102,19 +21243,19 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true
     },
     "supports-hyperlinks": {
@@ -21139,7 +21280,7 @@
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
               "dev": true
             }
           }
@@ -21154,7 +21295,7 @@
     "table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "requires": {
         "ajv": "^4.7.0",
@@ -21166,15 +21307,15 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -21190,7 +21331,7 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -21201,25 +21342,25 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -21240,7 +21381,7 @@
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -21250,7 +21391,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21259,14 +21400,14 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -21279,7 +21420,7 @@
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -21288,18 +21429,18 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -21318,7 +21459,7 @@
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "requires": {
         "has-value": "^0.3.1",
@@ -21328,7 +21469,7 @@
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
           "dev": true,
           "requires": {
             "get-value": "^2.0.3",
@@ -21339,7 +21480,7 @@
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -21350,13 +21491,13 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -21364,7 +21505,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "dev": true
     },
     "use": {
@@ -21376,7 +21517,7 @@
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
@@ -21385,7 +21526,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -21422,12 +21563,12 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ=="
     },
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw=="
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -21438,7 +21579,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -21447,13 +21588,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -21473,7 +21614,7 @@
     "yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "requires": {
         "cliui": "^3.2.0",
         "decamelize": "^1.1.1",
@@ -21494,7 +21635,7 @@
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"

--- a/build/testdata/npm/project4/npmv8/macos/excpected_dependencies_list.json
+++ b/build/testdata/npm/project4/npmv8/macos/excpected_dependencies_list.json
@@ -1,6 +1,1082 @@
 [
     {
-        "id": "ansi-escapes:3.2.0",
+        "id": "static-extend:0.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "md5": "685c7b45bd48268f9eeffbccecb2d313",
+        "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
+    },
+    {
+        "id": "jsonify:0.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "json-stable-stringify:1.0.1",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "json-stable-stringify:1.0.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
+        "md5": "78cc678249f2a175db1cffbd5bb25a14",
+        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
+    },
+    {
+        "id": "word-wrap:1.2.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "optionator:0.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
+        "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
+        "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
+    },
+    {
+        "id": "marked-terminal:3.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
+        "md5": "3fc3251d4faab2d1df0155b08258bd34",
+        "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
+    },
+    {
+        "id": "escape-string-regexp:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:1.1.3",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "figures:1.7.0",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "md5": "02440084832abe665260d5db1da1dd9e",
+        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+        "id": "babel-messages:6.23.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
+        "md5": "f7a22e78d59c180af1175172a3abee40",
+        "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
+    },
+    {
+        "id": "is-plain-object:2.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-extendable:1.0.1",
+                "extend-shallow:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "set-value:2.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-extendable:1.0.1",
+                "mixin-deep:1.3.2",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+        "md5": "335972afae19ad1eccb8eee9aad94747",
+        "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
+    },
+    {
+        "id": "spdx-correct:3.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
+        "md5": "bd668e9b71960e76e867c11ec3ec2982",
+        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
+    },
+    {
+        "id": "proto-props:1.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-proto-prop:1.0.1",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
+        "md5": "43c4cc31101ee8f37df9b66ff8353003",
+        "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
+    },
+    {
+        "id": "lodash._baseassign:3.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
+        "md5": "2438792bc711256968416ae0164b5dd9",
+        "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
+    },
+    {
+        "id": "write:0.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "flat-cache:1.0.10",
+                "file-entry-cache:1.2.4",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
+        "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
+        "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
+    },
+    {
+        "id": "braces:1.8.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
+        "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
+        "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
+    },
+    {
+        "id": "caller-path:0.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "require-uncached:1.0.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "require-uncached:1.0.2",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
+        "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
+        "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
+    },
+    {
+        "id": "rechoir:0.6.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "shelljs:0.7.8",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "liftoff:2.2.1",
+                "gulp:3.9.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
+        "md5": "9a0aa4db2a887a452ef08921160c7eb4",
+        "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
+    },
+    {
+        "id": "type:2.6.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ext:1.6.0",
+                "es6-symbol:3.1.3",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
+        "md5": "b06b1e937cd3671d147ef4f040fa297d",
+        "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
+    },
+    {
+        "id": "eslint:3.19.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-babel:3.3.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-flowtype:2.50.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-jsdoc:2.4.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-lodash:2.7.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-mocha:4.12.1",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
+        "md5": "2b28bed1fe16d31f22178145baa90d7a",
+        "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
+    },
+    {
+        "id": "has-values:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "has-value:0.3.1",
+                "unset-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "md5": "59bfd41b8b69c52c77823af62b7bada7",
+        "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
+    },
+    {
+        "id": "ansi-regex:3.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "strip-ansi:4.0.0",
+                "string-width:2.1.1",
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "123d6479e92ad45ad897d4054e3c7ca7db4944e1",
+        "md5": "7f893ad90437fcded52211151e305234",
+        "sha256": "989c0a482af8797e890d899bdc0c54c343900a5303617604a1c39a98c0a76457"
+    },
+    {
+        "id": "isobject:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-value:0.3.1",
+                "unset-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
+        "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
+        "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
+    },
+    {
+        "id": "balanced-match:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "brace-expansion:1.1.11",
+                "minimatch:3.1.2",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+        "id": "fs.realpath:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+        "md5": "9f790d7180667e1d8d1110f2cf321b62",
+        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+        "id": "eslint-plugin-flowtype:2.50.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
+        "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
+        "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
+    },
+    {
+        "id": "is-my-json-valid:2.20.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
+        "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
+        "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
+    },
+    {
+        "id": "optionator:0.8.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+        "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
+        "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
+    },
+    {
+        "id": "is-extglob:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "extglob:0.3.2",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-glob:2.0.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
+        "md5": "2abcdb854a7d2b4446afc7b636916db7",
+        "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
+    },
+    {
+        "id": "debug:2.6.9",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
+        "md5": "cb6cb63ab5843aee3af94d27c60ea476",
+        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
+    },
+    {
+        "id": "for-own:0.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "object.omit:2.0.1",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
+        "md5": "6b95dc29fcffc91036164869c724d05b",
+        "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
+    },
+    {
+        "id": "loose-envify:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "invariant:2.2.4",
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
+        "md5": "5e78d5f6b1ad3ecce9605936059d087e",
+        "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
+    },
+    {
+        "id": "eslint-config-canonical:1.15.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
+        "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
+        "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
+    },
+    {
+        "id": "source-map-resolve:0.5.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
+        "md5": "88b0cf532783413eb92e171554ddd28d",
+        "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
+    },
+    {
+        "id": "type:1.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "d:1.0.1",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
+        "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
+        "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
+    },
+    {
+        "id": "rimraf:2.6.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
+        "md5": "bd58522df35ee7b727430b41720e912d",
+        "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
+    },
+    {
+        "id": "is-glob:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "glob-base:0.3.0",
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "glob-parent:2.0.0",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
+        "md5": "094686a7618e52db5f126af328da6aff",
+        "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
+    },
+    {
+        "id": "snapdragon-util:3.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "snapdragon-node:2.1.1",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
+        "md5": "17c194e41dd12d561800985ef5b4ffdf",
+        "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
+    },
+    {
+        "id": "growly:1.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
+        "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
+        "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
+    },
+    {
+        "id": "acorn:5.7.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "espree:3.5.4",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
+        "md5": "861b7e390cd4b067b90229f4b9eec0c9",
+        "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
+    },
+    {
+        "id": "resolve:1.22.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "eslint-import-resolver-node:0.3.6",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "rechoir:0.6.2",
+                "shelljs:0.7.8",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "27cb2ebb53f91abb49470a928bba7558066ac177",
+        "md5": "67a0957a5180922a45e1b1d326a15508",
+        "sha256": "b556a5d48802ed4d038cfe8804596e1cca2176599a776f12daf686dee92d12ea"
+    },
+    {
+        "id": "path-is-absolute:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "md5": "18bfccb10294ae19e7eb616ed1c05176",
+        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+        "id": "to-fast-properties:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-types:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
+        "md5": "eb323816b9903f0e6877898c3065da5b",
+        "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
+    },
+    {
+        "id": "escope:3.6.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
+        "md5": "9390f529580d458bc659af81607d7114",
+        "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
+    },
+    {
+        "id": "jsx-ast-utils:1.4.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
+        "md5": "704aebceee728c9e0120486622b35790",
+        "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
+    },
+    {
+        "id": "internal-slot:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
+        "md5": "01f7b7499f71622547496b12f902bec8",
+        "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
+    },
+    {
+        "id": "node-emoji:1.11.0",
         "scopes": [
             "dev"
         ],
@@ -13,9 +1089,2703 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
-        "md5": "7431226bb3f179e8cd7eddf297b904ec",
-        "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
+        "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
+        "md5": "40310f4209362a8df02af58dac079c7d",
+        "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
+    },
+    {
+        "id": "yargs:4.8.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
+        "md5": "964f012a6509b1b431de5f58a11e061a",
+        "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
+    },
+    {
+        "id": "babylon:6.18.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
+        "md5": "c0f769098a62e7881847657d146d9cbe",
+        "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
+    },
+    {
+        "id": "eslint-plugin-import:2.26.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f812dc47be4f2b72b478a021605a59fc6fe8b88b",
+        "md5": "9f46ab62fb92c3f10d14890b32b7d0bb",
+        "sha256": "bddeb1bd17cefa19c56b5e9cc861f667e0c82dcc35ee49aad27b1781f616753e"
+    },
+    {
+        "id": "once:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inflight:1.0.6",
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "run-async:0.1.0",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+        "id": "kind-of:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "has-values:1.0.0",
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "20813df3d712928b207378691a45066fae72dd57",
+        "md5": "e24d0d555965b239fb2b6435b0724853",
+        "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
+    },
+    {
+        "id": "arr-union:3.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "union-value:1.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
+        "md5": "f3cf2ebd1f4051917051f0c2b9287954",
+        "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
+    },
+    {
+        "id": "color-name:1.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "color-convert:1.9.3",
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "md5": "b45186c4fe76a2450ec484149ade0066",
+        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+        "id": "get-intrinsic:1.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "call-bind:1.0.2",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-property-descriptors:1.0.0",
+                "define-properties:1.1.4",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "get-symbol-description:1.0.0",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "side-channel:1.0.4",
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "336975123e05ad0b7ba41f152ee4aadbea6cf598",
+        "md5": "100e3a1e0c452360575c70b6b6cb03ad",
+        "sha256": "4759e55e01afaed935a624731dd753bd5a4fe73f4557e007bd8e765a2c1c328b"
+    },
+    {
+        "id": "y18n:3.2.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
+        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
+        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
+    },
+    {
+        "id": "eslint-plugin-no-use-extend-native:0.3.12",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
+        "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
+        "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
+    },
+    {
+        "id": "shelljs:0.7.8",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
+        "md5": "476ea3b109ecf2179be8b78b444245d0",
+        "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
+    },
+    {
+        "id": "object.omit:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
+        "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
+        "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
+    },
+    {
+        "id": "validate-npm-package-license:3.0.4",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
+        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
+    },
+    {
+        "id": "lodash._bindcallback:3.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.clonedeep:3.0.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._createassigner:3.1.1",
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.omit:3.1.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._basecallback:3.3.1",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
+        "md5": "20bfe15e77fe081ff95fa92c73f0699e",
+        "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
+    },
+    {
+        "id": "array.prototype.flat:1.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b",
+        "md5": "4578f7e4eff680e7f1527b26181c52b2",
+        "sha256": "fa6ddc9a63f839e89e7eda58b50879a7c8d850d48bc281a5354b9d2160d51f76"
+    },
+    {
+        "id": "object-copy:0.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
+        "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
+    },
+    {
+        "id": "is-string:1.0.7",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
+        "md5": "a7cc7f159a13b20e5fa93015d6124705",
+        "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
+    },
+    {
+        "id": "eslint-plugin-babel:3.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
+        "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
+        "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
+    },
+    {
+        "id": "glob-parent:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob-base:0.3.0",
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
+        "md5": "7dc0b2d10ed856934e289df5e1f12c59",
+        "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
+    },
+    {
+        "id": "define-property:0.2.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object-copy:0.1.0",
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
+        "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
+    },
+    {
+        "id": "callsites:0.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "caller-path:0.1.0",
+                "require-uncached:1.0.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "caller-path:0.1.0",
+                "require-uncached:1.0.2",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
+        "md5": "b6e9bfb992503522ddaee4e965423faa",
+        "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
+    },
+    {
+        "id": "extend-shallow:3.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "split-string:3.1.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "regex-not:1.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "to-regex:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
+        "md5": "194095206e18756d832f5e0ad3d71cb8",
+        "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
+    },
+    {
+        "id": "levn:0.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "optionator:0.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "optionator:0.8.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+        "md5": "824680de0ed2dabe2745e88737723963",
+        "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
+    },
+    {
+        "id": "lcid:1.0.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "os-locale:1.4.0",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "os-locale:1.4.0",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "os-locale:1.4.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
+        "md5": "33e24746875ebbcc37c40c7297388609",
+        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
+    },
+    {
+        "id": "read-pkg:1.1.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
+        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
+    },
+    {
+        "id": "binary-extensions:1.13.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-binary-path:1.0.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
+        "md5": "013fed37056567a27186a86285f28efd",
+        "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
+    },
+    {
+        "id": "copy-descriptor:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "object-copy:0.1.0",
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "md5": "d6e57e9597c6af638adc414e74c3d516",
+        "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
+    },
+    {
+        "id": "decode-uri-component:0.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "source-map-resolve:0.5.3",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
+        "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
+        "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
+    },
+    {
+        "id": "has-ansi:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:1.1.3",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
+        "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
+    },
+    {
+        "id": "supports-color:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:1.1.3",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
+        "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
+        "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
+    },
+    {
+        "id": "ansi-styles:2.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:1.1.3",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "md5": "deb5e5008ca69027719588d723cf9f91",
+        "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
+    },
+    {
+        "id": "is-equal-shallow:0.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "regex-cache:0.4.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
+        "md5": "79abafbc68151c75a7242adf69c9b7c5",
+        "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
+    },
+    {
+        "id": "set-blocking:2.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "md5": "ff057cf430b35ecb25780f94cd051ab3",
+        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+        "id": "rx-lite:3.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
+        "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
+        "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
+    },
+    {
+        "id": "function.prototype.name:1.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "cce0505fe1ffb80503e6f9e46cc64e46a12a9621",
+        "md5": "791d82804001c74e1c7b5f14f9f9f9ef",
+        "sha256": "75022ef5d9b8056827769df3cc8dccb7f023baf7850ebeeced921cccfd6cce10"
+    },
+    {
+        "id": "file-entry-cache:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
+        "md5": "329f8f032842d7a2c711bd18423e5226",
+        "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
+    },
+    {
+        "id": "node-notifier:4.6.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
+        "md5": "0f04f7a88ceff67961e4277485727ce9",
+        "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
+    },
+    {
+        "id": "is-obj-prop:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
+        "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
+        "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
+    },
+    {
+        "id": "function-bind:1.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "call-bind:1.0.2",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "get-intrinsic:1.1.2",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has:1.0.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+        "md5": "ee976e75439af2b82e707f3a64c69684",
+        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
+    },
+    {
+        "id": "es-shim-unscopables:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "array.prototype.flat:1.3.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.find:2.2.0",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "702e632193201e3edf8713635d083d378e510241",
+        "md5": "b84453b40e877a87ea66b886373597f4",
+        "sha256": "a8accca616c58a9c8ce92bc27d9d287d3948cf8310af5fa05d69c1a14d156761"
+    },
+    {
+        "id": "has-flag:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-hyperlinks:1.0.1",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
+        "md5": "7ba03f6b47769f2acdc743ac0b23e339",
+        "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
+    },
+    {
+        "id": "flat-cache:1.3.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
+        "md5": "7f7fe842b74285784727aedf7cf81c4b",
+        "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
+    },
+    {
+        "id": "cache-base:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
+        "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
+        "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
+    },
+    {
+        "id": "has-value:0.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "unset-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
+        "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
+        "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
+    },
+    {
+        "id": "color-convert:1.9.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ansi-styles:3.2.1",
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+        "id": "es-abstract:1.20.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "function.prototype.name:1.1.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimend:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimstart:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.flat:1.3.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.values:1.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.find:2.2.0",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "027292cd6ef44bd12b1913b828116f54787d1814",
+        "md5": "3f67e5a17520816ff5cc668928214ed6",
+        "sha256": "54b669ef739263ae77a541d63749d7865ea4ac80a4d8802c8b93b3901327d7bb"
+    },
+    {
+        "id": "ms:2.1.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "debug:3.2.7",
+                "eslint-import-resolver-node:0.3.6",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "debug:3.2.7",
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+        "md5": "a50e4bf82f754914316bfca3dfbcf352",
+        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+        "id": "parse-glob:3.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
+        "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
+        "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
+    },
+    {
+        "id": "string-width:1.0.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "wrap-ansi:2.1.0",
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
+        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
+    },
+    {
+        "id": "core-util-is:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
+        "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
+        "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
+    },
+    {
+        "id": "brace-expansion:1.1.11",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "minimatch:3.1.2",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+        "id": "circular-json:0.3.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
+        "md5": "5569f191dea3cd5f952867196e41e050",
+        "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
+    },
+    {
+        "id": "atob:2.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "source-map-resolve:0.5.3",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
+        "md5": "45eb23f9eb24b3ff24e18466deeaa887",
+        "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
+    },
+    {
+        "id": "find-up:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
+        "md5": "cb9da6343737d03323119847685addf1",
+        "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
+    },
+    {
+        "id": "supports-preserve-symlinks-flag:1.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "resolve:1.22.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
+        "md5": "2ecf7c03c814ab155c5278d61f65583f",
+        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
+    },
+    {
+        "id": "semver:5.7.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
+        "md5": "99453010ab0aad4c49dba769e6193c35",
+        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
+    },
+    {
+        "id": "string.prototype.trimstart:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5466d93ba58cfa2134839f81d7f42437e8c01fef",
+        "md5": "1eb8bb5c0f48eb09d1729982c3b8c843",
+        "sha256": "b427df5466fec97d1dad5d4ef7e2e954ee9ad586ab6357bc9078bf996c95c501"
+    },
+    {
+        "id": "wrap-ansi:2.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
+        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
+    },
+    {
+        "id": "co:4.6.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ajv:4.11.8",
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+        "md5": "b6f068b290c84d37007997c45148ad18",
+        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
+    },
+    {
+        "id": "prelude-ls:1.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "levn:0.2.5",
+                "optionator:0.6.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "optionator:0.6.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "levn:0.3.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "type-check:0.3.2",
+                "levn:0.3.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "optionator:0.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "levn:0.3.0",
+                "optionator:0.8.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "optionator:0.8.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "type-check:0.3.2",
+                "optionator:0.8.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
+        "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
+        "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
+    },
+    {
+        "id": "ramda:0.25.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-mocha:4.12.1",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
+        "md5": "f86f2a632aa11bb7af129304fbe22a67",
+        "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
+    },
+    {
+        "id": "progress:1.1.8",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
+        "md5": "06556528b7598e755a84c9c8f75c2622",
+        "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
+    },
+    {
+        "id": "fsevents:1.2.13",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f325cb0455592428bcf11b383370ef70e3bfcc38",
+        "md5": "f275f972b6d338c71ac4cdc9b7f50dab",
+        "sha256": "dc8449e14688f08c85d73435e51467491639b56f752bcaa7015f2f97e9bca7aa"
+    },
+    {
+        "id": "object-visit:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "map-visit:1.0.0",
+                "collection-visit:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "collection-visit:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "md5": "0c309d8c43bc9546676100500c1db1c4",
+        "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
+    },
+    {
+        "id": "debug:3.2.7",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-import-resolver-node:0.3.6",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
+        "md5": "0f887df93ceeaa5784063eb8733a6778",
+        "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
+    },
+    {
+        "id": "is-primitive:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-equal-shallow:0.1.3",
+                "regex-cache:0.4.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "207bab91638499c07b2adf240a41a87210034575",
+        "md5": "73402009e3936aeaa7b5c473d090b017",
+        "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
+    },
+    {
+        "id": "es-to-primitive:1.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
+        "md5": "a32f26c478b76efa377601b8d17268a9",
+        "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
+    },
+    {
+        "id": "eslint-plugin-mocha:4.12.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
+        "md5": "3e429cc644ee80c1c60c86478eee616b",
+        "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
+    },
+    {
+        "id": "core-js:2.6.12",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-runtime:6.26.0",
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
+        "md5": "a1881352eef45832b331dc025db1b72c",
+        "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
+    },
+    {
+        "id": "concat-stream:1.6.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
+        "md5": "f3d719f26732b5206541e52972316e84",
+        "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
+    },
+    {
+        "id": "glob:7.2.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "rimraf:2.6.3",
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "shelljs:0.7.8",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b",
+        "md5": "16222090f290ce18931eb40cec43fa2a",
+        "sha256": "f0a38eb1318c06cb55dc28f3f32d2df7379e155cefc6a1e5ecc7a0ddad194381"
+    },
+    {
+        "id": "array-unique:0.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+        "md5": "c7fa44b0117a3ed0d161f876c68633f7",
+        "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
+    },
+    {
+        "id": "async-each:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
+        "md5": "c1130142d7ed405602b1fc38d811e360",
+        "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
+    },
+    {
+        "id": "has:1.0.3",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "get-intrinsic:1.1.2",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-shim-unscopables:1.0.0",
+                "array.prototype.flat:1.3.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-core-module:2.9.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+        "md5": "b765203b0d733534ee6a58d84767223a",
+        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
+    },
+    {
+        "id": "has-property-descriptors:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "define-properties:1.1.4",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "610708600606d36961ed04c196193b6a607fa861",
+        "md5": "7f67f61d09b2f2e9faa560ba49b21e85",
+        "sha256": "1ea75b75dc4e6f491cb9f736cb49265ada125f8bf23fc43cff6d16c1c6435f97"
+    },
+    {
+        "id": "string-width:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+        "md5": "b8aa95585646db49430dbaf185daec5d",
+        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
+    },
+    {
+        "id": "is-bigint:1.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
+        "md5": "54f51f1529d609a8762b6f18a9fc5f39",
+        "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
+    },
+    {
+        "id": "micromatch:3.1.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
+        "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
+        "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
+    },
+    {
+        "id": "user-home:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
+        "md5": "221f00361d182f5dfd195a7d867307c7",
+        "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
+    },
+    {
+        "id": "wrappy:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inflight:1.0.6",
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "once:1.4.0",
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "md5": "567b1699cfae49cb20f598571a6c90c7",
+        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
+    },
+    {
+        "id": "is-shared-array-buffer:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8f259c573b60b6a32d4058a1a07430c0a7344c79",
+        "md5": "478da999f49b20d86406f760d98af885",
+        "sha256": "1fe57e0f2a80050e5b0c2d1fed9eec189c1a7650bfb2f6cb800537929961fa90"
+    },
+    {
+        "id": "tsconfig-paths:3.14.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ba0734599e8ea36c862798e920bcf163277b137a",
+        "md5": "4d77fe4a7d930f1ecb5942b37f359909",
+        "sha256": "9c764c11733958e34f461ca43b430f4c54edc9167cfbbb9088660f3431e9f401"
+    },
+    {
+        "id": "to-regex-range:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
+        "md5": "5ad83eab061e092ad457387b4317ed45",
+        "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
+    },
+    {
+        "id": "eslint-import-resolver-node:0.3.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
+        "md5": "bf0a201e44f3e437813f10b97923f452",
+        "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
+    },
+    {
+        "id": "fill-range:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
+        "md5": "35483acae8b070dad60c41a99afe6b4d",
+        "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
+    },
+    {
+        "id": "side-channel:1.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
+        "md5": "abcc258cdccfd0db4007c7be3888d7df",
+        "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
+    },
+    {
+        "id": "doctrine:1.5.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
+        "md5": "8628b3ac690236d809939b9c3ec2531c",
+        "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
+    },
+    {
+        "id": "strip-ansi:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "string-width:2.1.1",
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
+        "md5": "f0aa5746513c46c807ea71744ec2bc5c",
+        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
+    },
+    {
+        "id": "eslint-plugin-jsdoc:2.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
+        "md5": "faf67209cc82f0fc3b0717ea662bbdab",
+        "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
+    },
+    {
+        "id": "posix-character-classes:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "md5": "1fc17a88bddf7099b36179e8acbb68e9",
+        "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
+    },
+    {
+        "id": "colors:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cli-table:0.3.11",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
+        "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
+        "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
+    },
+    {
+        "id": "repeat-element:1.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
+        "md5": "bf964c7d487f69452bf2196b93908917",
+        "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
+    },
+    {
+        "id": "bindings:1.5.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fsevents:1.2.13",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "10353c9e945334bc0511a6d90b38fbc7c9c504df",
+        "md5": "6ba854c931a768be46796845be6e113a",
+        "sha256": "d77781178c5bd89a91b1f6c5556acd511b1b5927eb13e2ad8189cac29eeb0907"
+    },
+    {
+        "id": "repeat-string:1.6.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "to-regex-range:2.1.1",
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
+        "md5": "ed49a5a26c9110a28411da1cded28e3a",
+        "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+    },
+    {
+        "id": "class-utils:0.3.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
+        "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
+    },
+    {
+        "id": "path-exists:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "locate-path:2.0.0",
+                "find-up:2.1.0",
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "md5": "7c2676f4502f776524cefe6e0b877136",
+        "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
+    },
+    {
+        "id": "window-size:0.2.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
+        "md5": "250499d281e44d2783aec6cfc458e96a",
+        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
+    },
+    {
+        "id": "component-emitter:1.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
+        "md5": "6b8517f3d7ad46e95c97b6d453f82189",
+        "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
+    },
+    {
+        "id": "marked:0.7.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
+        "md5": "2981b17fa46348526d23658960663d88",
+        "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
+    },
+    {
+        "id": "regenerator-runtime:0.11.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-runtime:6.26.0",
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+        "md5": "728ac808fb5276bf420fab33620d0c39",
+        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
+    },
+    {
+        "id": "is-negative-zero:2.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
+        "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
+        "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
+    },
+    {
+        "id": "cli-width:2.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
+        "md5": "c9cf40c64a983c42f8fd91a97542f25e",
+        "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
+    },
+    {
+        "id": "path-type:1.1.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "md5": "e14c138690b623db36532ff609b81b08",
+        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
+    },
+    {
+        "id": "source-map-url:0.4.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "source-map-resolve:0.5.3",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
+        "md5": "db54d6dc84c3bfa7f420da51c493023c",
+        "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
     },
     {
         "id": "require-main-filename:1.0.1",
@@ -45,39 +3815,397 @@
         "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
     },
     {
-        "id": "normalize-package-data:2.5.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
-        "md5": "b46c083aa373a30b8d2421e9f269d543",
-        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
-    },
-    {
-        "id": "jsx-ast-utils:1.4.1",
+        "id": "redeyed:2.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "eslint-plugin-react:6.10.3",
+                "cardinal:2.1.1",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
+        "md5": "b143ff11e6aece5ad2722daebb73c708",
+        "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
+    },
+    {
+        "id": "inherits:2.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "concat-stream:1.6.2",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+        "id": "mkdirp:0.5.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "write:0.2.1",
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
-        "md5": "704aebceee728c9e0120486622b35790",
-        "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
+        "sha1": "7def03d2432dcae4ba1d611445c48396062255f6",
+        "md5": "673b86d8669883c517b32b04886560f6",
+        "sha256": "1b29291a054b23ddc12f63cb0f563e486bc5866fb1855b5632d1a0ba88aab569"
+    },
+    {
+        "id": "collection-visit:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "md5": "735947ef7cec034327b0f2b0144b8256",
+        "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
+    },
+    {
+        "id": "through:2.3.8",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "gulp-mocha:2.2.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "md5": "615296782d4936bd53ebe4e5baa57db7",
+        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
+    },
+    {
+        "id": "doctrine:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
+        "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
+        "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
+    },
+    {
+        "id": "chokidar:1.7.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
+        "md5": "3b76ca6e8ebf196645910f2985f77385",
+        "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
+    },
+    {
+        "id": "graceful-fs:4.2.10",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "flat-cache:1.3.4",
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+        "md5": "094ac6976c4cec6cced67915d6c726c0",
+        "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+        "id": "is-utf8:0.2.1",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "strip-bom:2.0.0",
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "strip-bom:2.0.0",
+                "gulp-sourcemaps:2.0.0-alpha",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "strip-bom:1.0.0",
+                "vinyl-fs:0.3.14",
+                "gulp:3.9.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "strip-bom:2.0.0",
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
+        "md5": "7c483523b33b0640efedcc6561c545e2",
+        "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
+    },
+    {
+        "id": "object-inspect:1.12.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "side-channel:1.0.4",
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c0641f26394532f28ab8d796ab954e43c009a8ea",
+        "md5": "1193ad67b8d504446e7cb98275c5399b",
+        "sha256": "42e71d82a0209bda2995cae7e3d8802f631e5933646cae8cd000192dba74d65a"
+    },
+    {
+        "id": "generate-function:2.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f069617690c10c868e73b8465746764f97c3479f",
+        "md5": "b4fd862f79a3a0a097ea8818a5858d22",
+        "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
+    },
+    {
+        "id": "fill-range:2.2.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
+        "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
+        "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
+    },
+    {
+        "id": "restore-cursor:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "34661f46886327fed2991479152252df92daa541",
+        "md5": "99b769f599ac64ecf9027f8717f01bb0",
+        "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
+    },
+    {
+        "id": "os-locale:1.4.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
+        "md5": "fdb77de7d9374b72e7f466c27908a730",
+        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
     },
     {
         "id": "is-descriptor:0.1.6",
@@ -146,1929 +4274,6 @@
         "sha256": "b0d542e7aa38610efea55af9bf42c812a73d93ae522b1ceaa106f831900bb06a"
     },
     {
-        "id": "core-js:2.6.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-runtime:6.26.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
-        "md5": "a1881352eef45832b331dc025db1b72c",
-        "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
-    },
-    {
-        "id": "caller-path:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
-        "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
-        "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
-    },
-    {
-        "id": "yargs-parser:2.4.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
-        "md5": "3ed28206e170b6c0cf902511c2d0534b",
-        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
-    },
-    {
-        "id": "call-bind:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-weakref:1.0.2",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
-        "md5": "d244c20a7b3f2c607030df6337a4e68d",
-        "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
-    },
-    {
-        "id": "xtend:4.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
-        "md5": "183e6eef1df0529fd39bd932447ba547",
-        "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
-    },
-    {
-        "id": "locate-path:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
-        "md5": "3241773d42e4709beacb91d0e7d92331",
-        "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
-    },
-    {
-        "id": "p-limit:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
-        "md5": "f674d1283c8ac4d11ec813efc2b5934a",
-        "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
-    },
-    {
-        "id": "next-tick:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ca86d1fe8828169b0120208e3dc8424b9db8342c",
-        "md5": "e199ee5dd3885bfecd2d3c8856fcc85f",
-        "sha256": "589acf7512a9bef481eec81eeb8aef056e638f26257e572a0cb3e3baccbc7863"
-    },
-    {
-        "id": "side-channel:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
-        "md5": "abcc258cdccfd0db4007c7be3888d7df",
-        "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
-    },
-    {
-        "id": "is-fullwidth-code-point:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
-        "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
-        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
-    },
-    {
-        "id": "internal-slot:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
-        "md5": "01f7b7499f71622547496b12f902bec8",
-        "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
-    },
-    {
-        "id": "path-type:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "md5": "e14c138690b623db36532ff609b81b08",
-        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
-    },
-    {
-        "id": "anymatch:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
-        "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
-        "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
-    },
-    {
-        "id": "urix:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "source-map-resolve:0.3.1",
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
-        "md5": "dd3921f317a15657fad465fd215fe38d",
-        "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
-    },
-    {
-        "id": "lodash.assign:4.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
-        "md5": "5a92447d4e8669abba120d5164892902",
-        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
-    },
-    {
-        "id": "preserve:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
-        "md5": "bca875c4e8d238ef216dc9d1bcabf976",
-        "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
-    },
-    {
-        "id": "has-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
-        "md5": "0f5d46e9619fa36d9930f590ef96844b",
-        "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
-    },
-    {
-        "id": "copy-descriptor:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
-        "md5": "d6e57e9597c6af638adc414e74c3d516",
-        "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
-    },
-    {
-        "id": "eslint-plugin-mocha:4.12.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
-        "md5": "3e429cc644ee80c1c60c86478eee616b",
-        "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
-    },
-    {
-        "id": "normalize-path:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
-        "md5": "b2f3932160dc03a5604dbac60ef59c34",
-        "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
-    },
-    {
-        "id": "es6-set:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
-        "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
-        "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
-    },
-    {
-        "id": "ret:0.1.15",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "safe-regex:1.1.0",
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
-        "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
-        "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "is-arrayish:0.2.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.2",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
-        "md5": "4bbbacda455ab73d86f5eda908989f24",
-        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
-    },
-    {
-        "id": "remove-trailing-separator:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "normalize-path:2.1.1",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
-        "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
-        "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
-    },
-    {
-        "id": "kind-of:6.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
-        "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
-        "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
-    },
-    {
-        "id": "extglob:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
-        "md5": "c8be79678101bbc03ea2018b80a8ac0a",
-        "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
-    },
-    {
-        "id": "class-utils:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
-        "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
-        "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
-    },
-    {
-        "id": "supports-color:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
-        "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
-        "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
-    },
-    {
-        "id": "deep-is:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
-        "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
-        "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
-    },
-    {
-        "id": "is-binary-path:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
-        "md5": "a989667cf8d696127090b72fe8a674b3",
-        "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
-    },
-    {
-        "id": "object.values:1.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
-        "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
-        "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
-    },
-    {
-        "id": "ansi-regex:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "has-ansi:2.0.0",
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-ansi:3.0.1",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
-        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
-        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
-    },
-    {
-        "id": "unset-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
-        "md5": "d69bb4d1f65e08acd32debce863b513e",
-        "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
-    },
-    {
-        "id": "buffer-from:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
-        "md5": "5fe5f473dc3263473041a56654581058",
-        "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
-    },
-    {
-        "id": "file-uri-to-path:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "bindings:1.5.0",
-                "fsevents:1.2.13",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "553a7b8446ff6f684359c445f1e37a05dacc33dd",
-        "md5": "2215c58ead5bbd5a52c572db0cf977d2",
-        "sha256": "5440cdf67e75ab96f36a6be63c1d4c3d54255b1d0970273710fecfebfab06fb3"
-    },
-    {
-        "id": "through:2.3.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
-        "md5": "615296782d4936bd53ebe4e5baa57db7",
-        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
-    },
-    {
-        "id": "esquery:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
-        "md5": "67c3703f159c91ae9bd06b896a863b19",
-        "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
-    },
-    {
-        "id": "text-table:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
-        "md5": "4e595139988957453229d6ccd229f626",
-        "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "lowercase-keys:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
-        "md5": "de9b080b5e473d21200e69b8bfc7c204",
-        "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
-    },
-    {
-        "id": "string-width:1.0.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
-        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
-        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
-    },
-    {
-        "id": "is-date-object:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
-        "md5": "3b3393d413d848d50129f3f80d37e86a",
-        "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
-    },
-    {
-        "id": "find-up:1.1.2",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
-        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
-    },
-    {
-        "id": "define-properties:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
-        "md5": "d06819a7b947f1b335da2f41519994ac",
-        "sha256": "5524f4db15bb95af92c791ba208e2fc774bd8ae17eb347865492d444f95a70a5"
-    },
-    {
-        "id": "is-symbol:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
-        "md5": "1d481161785d0b7c5a729e39edb86e9a",
-        "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
-    },
-    {
-        "id": "levn:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
-        "md5": "824680de0ed2dabe2745e88737723963",
-        "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
-    },
-    {
-        "id": "is-extendable:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
-        "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
-        "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
-    },
-    {
-        "id": "safe-regex:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
-        "md5": "6729d2a26cdabb856b9506e567bd8a57",
-        "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
-    },
-    {
-        "id": "lodash._getnative:3.9.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createcache:3.1.2",
-                "lodash._basedifference:3.0.3",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
-        "md5": "a311ce03b077bd8a3b4bfe46776f9035",
-        "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
-    },
-    {
-        "id": "object-assign:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
-        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
-        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
-    },
-    {
-        "id": "user-home:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
-        "md5": "221f00361d182f5dfd195a7d867307c7",
-        "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
-    },
-    {
-        "id": "source-map-url:0.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
-        "md5": "db54d6dc84c3bfa7f420da51c493023c",
-        "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "spdx-expression-parse:3.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
-        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
-        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
-    },
-    {
-        "id": "eslint-plugin-promise:3.8.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
-        "md5": "ba6f09078795c4b8612de3a95a483603",
-        "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
-    },
-    {
-        "id": "doctrine:1.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
-        "md5": "8628b3ac690236d809939b9c3ec2531c",
-        "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
-    },
-    {
-        "id": "has-ansi:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
-        "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
-        "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
-    },
-    {
-        "id": "@types/json5:0.0.29",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
-        "md5": "b2b856287e2f65c5298b7747332bb633",
-        "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
-    },
-    {
-        "id": "is-dotfile:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
-        "md5": "9c1b18df01884a55636db529eca19fe2",
-        "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
-    },
-    {
-        "id": "is-accessor-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
-        "md5": "71d1d01f8028c245544a9a1217fb2bce",
-        "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
-    },
-    {
-        "id": "extglob:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
-        "md5": "5e368678ebf35fe8dbaa173517e7adc1",
-        "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
-    },
-    {
-        "id": "marked-terminal:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
-        "md5": "3fc3251d4faab2d1df0155b08258bd34",
-        "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
-    },
-    {
-        "id": "find-up:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
-        "md5": "cb9da6343737d03323119847685addf1",
-        "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
-    },
-    {
-        "id": "mixin-deep:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
-        "md5": "53fb379c1187b97eecfcf06399958566",
-        "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
-    },
-    {
-        "id": "es6-symbol:3.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
-        "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
-        "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
-    },
-    {
         "id": "arr-flatten:1.1.0",
         "scopes": [
             "dev"
@@ -2096,74 +4301,19 @@
         "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a"
     },
     {
-        "id": "esrecurse:4.3.0",
+        "id": "json-stable-stringify:1.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
                 "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
-        "md5": "a39f104614e3543dd4522ac4afdace00",
-        "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
-    },
-    {
-        "id": "bindings:1.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fsevents:1.2.13",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "10353c9e945334bc0511a6d90b38fbc7c9c504df",
-        "md5": "6ba854c931a768be46796845be6e113a",
-        "sha256": "d77781178c5bd89a91b1f6c5556acd511b1b5927eb13e2ad8189cac29eeb0907"
-    },
-    {
-        "id": "glob-parent:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
-        "md5": "7dc0b2d10ed856934e289df5e1f12c59",
-        "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
-    },
-    {
-        "id": "jsonify:0.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json-stable-stringify:1.0.1",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -2171,97 +4321,53 @@
                 "bundle-dependencies"
             ],
             [
-                "json-stable-stringify:1.0.1",
+                "ajv:4.11.8",
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
                 "eslint:2.9.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
-        "md5": "78cc678249f2a175db1cffbd5bb25a14",
-        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
+        "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
+        "md5": "7712931a8d538cad6e4beaccd491cbb2",
+        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
     },
     {
-        "id": "which-module:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
-        "md5": "004cd541632e781023b01a91b2d4b851",
-        "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
-    },
-    {
-        "id": "resolve:1.22.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "rechoir:0.6.2",
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5e0b8c67c15df57a89bdbabe603a002f21731198",
-        "md5": "aaf15861cf0f8af2222bd383a475bc28",
-        "sha256": "06536fa0cbfbf8d6b2d5e6971437f4eb02110c84961b698d1b8ba5c6ae8f760d"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "lodash._basefor:3.0.3",
+        "id": "union-value:1.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "lodash.isplainobject:3.2.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
+        "md5": "5438ca0bb737dc01e85a61121dcc3626",
+        "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
+    },
+    {
+        "id": "lodash.keys:3.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "lodash.merge:3.3.2",
                 "eslint:1.10.3",
                 "css-lint:1.0.1",
@@ -2270,9 +4376,9 @@
                 "bundle-dependencies"
             ],
             [
-                "lodash._pickbycallback:3.0.0",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
+                "lodash._baseassign:3.2.0",
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
                 "css-lint:1.0.1",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
@@ -2287,6 +4393,54 @@
                 "bundle-dependencies"
             ],
             [
+                "lodash._baseisequal:3.0.7",
+                "lodash._basecallback:3.3.1",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.pairs:3.0.1",
+                "lodash._basecallback:3.3.1",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseeach:3.0.4",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.template:3.6.2",
+                "gulp-util:3.0.7",
+                "gulp-babel:6.1.2",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseassign:3.2.0",
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
                 "lodash._baseclone:3.3.0",
                 "lodash.clonedeep:3.0.2",
                 "node-notifier:4.6.1",
@@ -2294,175 +4448,17 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
-        "md5": "e0118d593252e3902b3769f0ff775d04",
-        "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
+        "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
+        "md5": "d2aa104b88db88e2c0f1ed627031ed03",
+        "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
     },
     {
-        "id": "is-string:1.0.7",
+        "id": "ajv-keywords:1.5.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
-        "md5": "a7cc7f159a13b20e5fa93015d6124705",
-        "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
-    },
-    {
-        "id": "math-random:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5dd6943c938548267016d4e34f057583080c514c",
-        "md5": "029796aed5b40e10d30518bc21ad436a",
-        "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
-    },
-    {
-        "id": "is-extglob:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:0.3.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-glob:2.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
-        "md5": "2abcdb854a7d2b4446afc7b636916db7",
-        "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
-    },
-    {
-        "id": "define-property:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
-        "md5": "8a6929a07bffc6c4c16bb506e31834c1",
-        "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
-    },
-    {
-        "id": "ms:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:2.6.9",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
-        "md5": "9615634070dd7751f127b2a0fb362484",
-        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
-    },
-    {
-        "id": "co:4.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv:4.11.8",
                 "table:3.8.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
@@ -2471,37 +4467,85 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
-        "md5": "b6f068b290c84d37007997c45148ad18",
-        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
+        "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
+        "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
+        "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
     },
     {
-        "id": "cli-width:2.2.1",
+        "id": "is-fullwidth-code-point:1.0.0",
         "scopes": [
+            "prod",
             "dev"
         ],
         "requestedBy": [
             [
+                "readline2:1.0.1",
                 "inquirer:0.12.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
+            ],
+            [
+                "readline2:1.0.1",
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.1",
+                "table:3.7.8",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.2",
+                "yargs:4.8.1",
+                "bundle-dependencies"
             ]
         ],
-        "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
-        "md5": "c9cf40c64a983c42f8fd91a97542f25e",
-        "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
+        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "md5": "edbd4281a6ac4fb8d1082592c411f250",
+        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
     },
     {
-        "id": "loose-envify:1.4.0",
+        "id": "to-object-path:0.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "invariant:2.2.4",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "md5": "ed213d48acc6db7b01883673013ba398",
+        "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
+    },
+    {
+        "id": "invariant:2.2.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "babel-traverse:6.26.0",
                 "babel-eslint:7.2.3",
                 "eslint-config-canonical:1.15.0",
@@ -2510,20 +4554,18 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
-        "md5": "5e78d5f6b1ad3ecce9605936059d087e",
-        "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
+        "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
+        "md5": "445e70b75ab7215bc0da1fbaa36113cd",
+        "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
     },
     {
-        "id": "es5-ext:0.10.53",
+        "id": "resolve-from:1.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
+                "require-uncached:1.0.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -2531,137 +4573,64 @@
                 "bundle-dependencies"
             ],
             [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
+                "require-uncached:1.0.2",
+                "eslint:2.9.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.1",
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "event-emitter:0.3.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "gulp-mocha:2.2.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "93c5a3acfdbef275220ad72644ad02ee18368de1",
-        "md5": "fae9645d4e605a9cda5974baa7dc1733",
-        "sha256": "03e3c58089f1bcc66467ee24b4625d39b3279fccf2d937121289f3145e7b6ec2"
+        "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
+        "md5": "e19abe316d7d524402ff940ff923406c",
+        "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
     },
     {
-        "id": "ms:2.1.3",
+        "id": "isarray:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "debug:3.2.7",
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
+                "doctrine:1.5.0",
+                "eslint-plugin-react:6.10.3",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "debug:3.2.7",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
+                "readable-stream:2.0.6",
+                "concat-stream:1.5.1",
+                "eslint:2.9.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "get-value:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
+                "doctrine:1.2.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "isobject:2.1.0",
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
                 "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
+                "isobject:2.1.0",
                 "has-value:0.3.1",
                 "unset-value:1.0.0",
                 "cache-base:1.0.1",
@@ -2672,207 +4641,43 @@
                 "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
-        "md5": "b45bf08107e22e624dade29284abd265",
-        "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
-    },
-    {
-        "id": "ajv:4.11.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv-keywords:1.5.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ],
             [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
-        "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
-        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
-    },
-    {
-        "id": "estraverse:5.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "esrecurse:4.3.0",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "esquery:1.4.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
-        "md5": "ac5d5752d7928d448689899477f994b0",
-        "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "node-emoji:1.11.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
-        "md5": "40310f4209362a8df02af58dac079c7d",
-        "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
-    },
-    {
-        "id": "es6-map:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
-        "md5": "98c9ef67294b8213745a30395f4a62b5",
-        "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
-    },
-    {
-        "id": "arr-diff:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
+                "readable-stream:2.3.7",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
+                "readable-stream:2.0.6",
+                "through2:2.0.1",
+                "gulp-babel:6.1.2",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
-        "md5": "42ec151186ae4bd9980a212083d98bbe",
-        "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
+        "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
+        "md5": "c24471c617803171eed93b3516624c97",
+        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
     },
     {
-        "id": "babel-types:6.26.0",
+        "id": "for-in:1.0.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "for-own:0.1.5",
+                "object.omit:2.0.1",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
-        "md5": "d12869e767169377af311247a2d247e9",
-        "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
-    },
-    {
-        "id": "es6-symbol:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
-        "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
-        "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
-    },
-    {
-        "id": "static-extend:0.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "class-utils:0.3.6",
+                "mixin-deep:1.3.2",
                 "base:0.11.2",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
@@ -2882,91 +4687,29 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
-        "md5": "685c7b45bd48268f9eeffbccecb2d313",
-        "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
+        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+        "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
+        "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
     },
     {
-        "id": "is-regex:1.1.4",
+        "id": "locate-path:2.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
+                "find-up:2.1.0",
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
-        "md5": "13a02d0abc63ff0093ca592e999f713c",
-        "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
-    },
-    {
-        "id": "redeyed:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
-        "md5": "b143ff11e6aece5ad2722daebb73c708",
-        "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
-    },
-    {
-        "id": "es-abstract:1.19.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d4885796876916959de78edaa0df456627115ec3",
-        "md5": "11444142629b2eb1c6cc47907ca74f1f",
-        "sha256": "10fd94f8d892b32a91429bb7be44e1256d891c69467ae522e79bd6400f8946bc"
+        "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
+        "md5": "3241773d42e4709beacb91d0e7d92331",
+        "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
     },
     {
         "id": "d:1.0.1",
@@ -3049,47 +4792,34 @@
         "sha256": "e7fb647f7a114c2f5bc547454b043c29dd13de095dc6f476b883b266993918a9"
     },
     {
-        "id": "object.pick:1.3.0",
+        "id": "buffer-from:1.1.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
+                "concat-stream:1.6.2",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
-        "md5": "40633da6e17a372e353e73ae28beb843",
-        "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
+        "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
+        "md5": "5fe5f473dc3263473041a56654581058",
+        "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
     },
     {
-        "id": "run-async:0.1.0",
+        "id": "es6-symbol:3.1.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
+                "es5-ext:0.10.61",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -3097,33 +4827,206 @@
                 "bundle-dependencies"
             ],
             [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
-        "md5": "05b4c27dcef5296aff906af32f377494",
-        "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
-    },
-    {
-        "id": "object.assign:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
+                "es6-iterator:2.0.3",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-weak-map:2.0.3",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
+        "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
+        "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
+    },
+    {
+        "id": "argparse:1.0.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "js-yaml:3.14.1",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+        "id": "hosted-git-info:2.8.9",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
+        "md5": "e50583bc39341b531466e5de5b6aef94",
+        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
+    },
+    {
+        "id": "is-extglob:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-glob:4.0.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+        "id": "set-value:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "union-value:1.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
+        "md5": "b1e945fff7d8430e86066db678ca6390",
+        "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
+    },
+    {
+        "id": "define-properties:1.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "function.prototype.name:1.1.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "regexp.prototype.flags:1.4.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimend:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimstart:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.flat:1.3.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.values:1.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.find:2.2.0",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.assign:4.1.2",
                 "eslint-plugin-react:6.10.3",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -3131,202 +5034,34 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
-        "md5": "87b8da296ced17d6e062b791d48ed38b",
-        "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
+        "sha1": "0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1",
+        "md5": "d2ec48d9ec2ffc96c1cade78993d2fc4",
+        "sha256": "db524cc69a1fb36e417553bcf82df6511685c6b94d4b82eae99759589a686948"
     },
     {
-        "id": "is-glob:4.0.3",
+        "id": "eslint-module-utils:2.7.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "eslint-plugin-import:2.25.4",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+        "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
+        "md5": "b209efc416d3e5b3f9b15c9177a19fec",
+        "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
     },
     {
-        "id": "table:3.8.3",
+        "id": "map-visit:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
-        "md5": "caa5899fd31138fdbe11b2944fdf16e4",
-        "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "snapdragon:0.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
-        "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
-        "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
-    },
-    {
-        "id": "collection-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
-        "md5": "735947ef7cec034327b0f2b0144b8256",
-        "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
-    },
-    {
-        "id": "pragmatist:3.0.24",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
-        "md5": "282125ff6b702db1e05de93b7b866982",
-        "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
-    },
-    {
-        "id": "define-property:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
-        "md5": "2751868d9fa31ebbbe851fdcb729115d",
-        "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
-    },
-    {
-        "id": "object-visit:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "map-visit:1.0.0",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
             [
                 "collection-visit:1.0.0",
                 "cache-base:1.0.1",
@@ -3339,52 +5074,91 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
-        "md5": "0c309d8c43bc9546676100500c1db1c4",
-        "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
+        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "md5": "1911d8539476d5e5b03c42e63a87b49a",
+        "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
     },
     {
-        "id": "invariant:2.2.4",
+        "id": "get-value:2.0.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "union-value:1.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-value:0.3.1",
+                "unset-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
-        "md5": "445e70b75ab7215bc0da1fbaa36113cd",
-        "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
+        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "md5": "b45bf08107e22e624dade29284abd265",
+        "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
     },
     {
-        "id": "node-notifier:4.6.1",
+        "id": "ansi-escapes:3.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
-        "md5": "0f04f7a88ceff67961e4277485727ce9",
-        "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
+        "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
+        "md5": "7431226bb3f179e8cd7eddf297b904ec",
+        "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
     },
     {
-        "id": "figures:1.7.0",
+        "id": "es6-weak-map:2.0.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "inquirer:0.12.0",
+                "escope:3.6.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -3392,9 +5166,652 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
-        "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
-        "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
+        "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
+        "md5": "edb82ccad9f34520dc736bfbc67dc4be",
+        "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
+    },
+    {
+        "id": "anymatch:1.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
+        "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
+        "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
+    },
+    {
+        "id": "is-boolean-object:1.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
+        "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
+        "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
+    },
+    {
+        "id": "normalize-package-data:2.5.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
+        "md5": "b46c083aa373a30b8d2421e9f269d543",
+        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
+    },
+    {
+        "id": "is-number:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "randomatic:3.1.1",
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
+        "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
+        "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
+    },
+    {
+        "id": "pluralize:1.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
+        "md5": "10ffc865fc0a65a38893463e1ab77403",
+        "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
+    },
+    {
+        "id": "has-values:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "md5": "b22e4bd0ee56cd167cb12437533618b1",
+        "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
+    },
+    {
+        "id": "spdx-license-ids:3.0.11",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "spdx-correct:3.1.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "spdx-expression-parse:3.0.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
+        "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
+        "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
+    },
+    {
+        "id": "error-ex:1.3.2",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+        "md5": "5d2c673565060037f9e04d7975d04feb",
+        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
+    },
+    {
+        "id": "is-proto-prop:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
+        "md5": "78443d3b543426fda71dfcb27111473b",
+        "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
+    },
+    {
+        "id": "regex-cache:0.4.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
+        "md5": "c08a04a26436892d55f3d2fb294d8b73",
+        "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
+    },
+    {
+        "id": "sprintf-js:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "argparse:1.0.7",
+                "js-yaml:3.6.0",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "argparse:1.0.10",
+                "js-yaml:3.14.1",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+        "md5": "8e6b31a052754055683e4a35a317feab",
+        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+        "id": "ext:1.6.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es6-symbol:3.1.3",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
+        "md5": "9cf67c9330abea4cd40a86724154f246",
+        "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
+    },
+    {
+        "id": "isexe:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "which:1.3.1",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+        "id": "arr-diff:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
+        "md5": "5aa32e7c03b612d64d433306ecfcd392",
+        "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
+    },
+    {
+        "id": "glob-base:0.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
+        "md5": "ea2fd4074a1f129431de415f1c5387aa",
+        "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
+    },
+    {
+        "id": "expand-range:1.8.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
+        "md5": "b9375c64d875584bb5bf5a4829007f32",
+        "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
+    },
+    {
+        "id": "@types/json5:0.0.29",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "tsconfig-paths:3.14.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
+        "md5": "b2b856287e2f65c5298b7747332bb633",
+        "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
+    },
+    {
+        "id": "readable-stream:2.3.7",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "comment-parser:0.4.2",
+                "eslint-plugin-jsdoc:2.4.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "concat-stream:1.6.2",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
+        "md5": "f060c259b513e887f551d073950f12f9",
+        "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
+    },
+    {
+        "id": "chalk:2.4.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+        "id": "has-symbols:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-symbol:1.0.4",
+                "es-to-primitive:1.2.1",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "get-intrinsic:1.1.2",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-tostringtag:1.0.0",
+                "is-string:1.0.7",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.assign:4.1.2",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bb7b2c4349251dce87b125f7bdf874aa7c8b39f8",
+        "md5": "de53cc38f69c9145fd5613d6457e01b3",
+        "sha256": "ddcc17682f1e12a9d00a1a8b656af941ed584914e55fc5caf1c2e7ce892ce6a6"
+    },
+    {
+        "id": "json5:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "tsconfig-paths:3.14.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
+        "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
+        "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
+    },
+    {
+        "id": "strip-bom:2.0.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "gulp-sourcemaps:2.0.0-alpha",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
+        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
+    },
+    {
+        "id": "xtend:4.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
+        "md5": "183e6eef1df0529fd39bd932447ba547",
+        "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
+    },
+    {
+        "id": "deep-is:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "optionator:0.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
+        "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
+        "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
+    },
+    {
+        "id": "safe-buffer:5.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string_decoder:1.1.1",
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "md5": "dc7142b470e0957c5c34098b6fced0ab",
+        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+        "id": "get-caller-file:1.0.3",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
+        "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
+        "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
+    },
+    {
+        "id": "lodash._arraycopy:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+        "md5": "6de9a4e0d113c056078d1db4e75c748b",
+        "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
     },
     {
         "id": "is-descriptor:1.0.2",
@@ -3445,237 +5862,30 @@
         "sha256": "fe5ee7a359c2ae4ec7c12a075d903150c23365bf55c0c471b8d34fade96c6ead"
     },
     {
-        "id": "micromatch:3.1.10",
+        "id": "string_decoder:1.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "readable-stream:2.3.7",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
-        "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
-        "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
+        "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+        "md5": "7b93eea8153258fea64c3192922effaa",
+        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
     },
     {
-        "id": "es6-iterator:2.0.3",
+        "id": "array-unique:0.2.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
-        "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
-        "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
-    },
-    {
-        "id": "code-point-at:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
-        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
-        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
-    },
-    {
-        "id": "progress:1.1.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
-        "md5": "06556528b7598e755a84c9c8f75c2622",
-        "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
-    },
-    {
-        "id": "pify:2.3.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
-        "md5": "475310192b9d153240ac82eb66b827e8",
-        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
-    },
-    {
-        "id": "typedarray:0.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
-        "md5": "54a18bcd7fd55c812993e9ce90a0709d",
-        "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
-    },
-    {
-        "id": "expand-range:1.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
                 "micromatch:2.3.11",
                 "anymatch:1.3.2",
                 "chokidar:1.7.0",
@@ -3683,85 +5893,17 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
-        "md5": "b9375c64d875584bb5bf5a4829007f32",
-        "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
+        "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
+        "md5": "7b3ac4760380d655957c68e59748f438",
+        "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
     },
     {
-        "id": "js-types:1.0.0",
+        "id": "nanomatch:1.2.13",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "is-js-type:2.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
-        "md5": "60cccf96110592ca167c2c9b98155a45",
-        "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
-    },
-    {
-        "id": "is-callable:1.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "47301d58dd0259407865547853df6d61fe471945",
-        "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
-        "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
-    },
-    {
-        "id": "is-get-set-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
-        "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
-        "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
-    },
-    {
-        "id": "base:0.11.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -3769,33 +5911,138 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
-        "md5": "b457a16eb8603bc0d84d252716f5b0d5",
-        "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
+        "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+        "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
+        "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
     },
     {
-        "id": "wrap-ansi:2.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
-        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
-    },
-    {
-        "id": "fill-range:2.2.4",
+        "id": "object.pick:1.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "md5": "40633da6e17a372e353e73ae28beb843",
+        "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
+    },
+    {
+        "id": "text-table:0.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
+        "md5": "4e595139988957453229d6ccd229f626",
+        "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
+    },
+    {
+        "id": "is-weakref:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
+        "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
+        "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
+    },
+    {
+        "id": "find-up:1.1.2",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
+        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
+    },
+    {
+        "id": "is-number:2.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:2.2.4",
                 "expand-range:1.8.2",
                 "braces:1.8.5",
                 "micromatch:2.3.11",
@@ -3805,18 +6052,77 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
-        "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
-        "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
+        "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
+        "md5": "16a0b10f0dab47199d6536d319c0c6d5",
+        "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
     },
     {
-        "id": "slice-ansi:0.0.4",
+        "id": "babel-code-frame:6.26.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "table:3.8.3",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
+        "md5": "fdca204ce9b0158bcc65745baa896e4c",
+        "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
+    },
+    {
+        "id": "strip-bom:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "tsconfig-paths:3.14.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
+        "md5": "a2045f7f89506a0f8301822998d1daf7",
+        "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
+    },
+    {
+        "id": "estraverse:4.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "escope:3.6.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -3824,24 +6130,6 @@
                 "bundle-dependencies"
             ],
             [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
-        "md5": "c6a421b62848c96d57d4394964a89162",
-        "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
-    },
-    {
-        "id": "ajv-keywords:1.5.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -3849,28 +6137,179 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
-        "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
-        "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
+        "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+        "md5": "fe475b154e52864c56c3fc8f4b4af81b",
+        "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
     },
     {
-        "id": "has-flag:2.0.0",
+        "id": "babel-types:6.26.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
+        "md5": "d12869e767169377af311247a2d247e9",
+        "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
+    },
+    {
+        "id": "which:1.3.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "node-notifier:4.6.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
-        "md5": "7ba03f6b47769f2acdc743ac0b23e339",
-        "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
+        "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
+        "md5": "3077f0c321098e78b78ddd6b4b2789e5",
+        "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
+    },
+    {
+        "id": "minimatch:3.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+        "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+        "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+        "id": "is-symbol:1.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-to-primitive:1.2.1",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
+        "md5": "1d481161785d0b7c5a729e39edb86e9a",
+        "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
+    },
+    {
+        "id": "eslint-plugin-react:6.10.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
+        "md5": "fabc99b1e4722b4e10fe41f348940da3",
+        "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
+    },
+    {
+        "id": "parse-json:2.2.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "md5": "9b98b48019fa25c226348737831cf130",
+        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
+    },
+    {
+        "id": "is-dotfile:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "parse-glob:3.0.4",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
+        "md5": "9c1b18df01884a55636db529eca19fe2",
+        "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
     },
     {
         "id": "resolve-url:0.2.1",
@@ -3900,705 +6339,30 @@
         "sha256": "88e9cb578b6373125c416cacb9f42c4896fe3e072e4b94ba6948cba70e551824"
     },
     {
-        "id": "lodash._bindcallback:3.0.1",
+        "id": "p-try:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "lodash.clonedeep:3.0.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createassigner:3.1.1",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
-        "md5": "20bfe15e77fe081ff95fa92c73f0699e",
-        "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
-    },
-    {
-        "id": "pinkie-promise:2.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
-        "md5": "d6cf74027e88ca54043e91d59629a656",
-        "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
-    },
-    {
-        "id": "is-glob:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-parent:2.0.0",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
-        "md5": "094686a7618e52db5f126af328da6aff",
-        "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
-    },
-    {
-        "id": "json5:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
+                "p-limit:1.3.0",
+                "p-locate:2.0.0",
+                "locate-path:2.0.0",
+                "find-up:2.1.0",
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
-        "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
-        "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
+        "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+        "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
+        "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
     },
     {
-        "id": "snapdragon-node:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
-        "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
-        "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
-    },
-    {
-        "id": "strip-bom:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
-        "md5": "a2045f7f89506a0f8301822998d1daf7",
-        "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
-    },
-    {
-        "id": "binary-extensions:1.13.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:1.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
-        "md5": "013fed37056567a27186a86285f28efd",
-        "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
-    },
-    {
-        "id": "to-regex-range:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
-        "md5": "5ad83eab061e092ad457387b4317ed45",
-        "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
-    },
-    {
-        "id": "nanomatch:1.2.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
-        "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
-        "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
-    },
-    {
-        "id": "set-value:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
-        "md5": "b1e945fff7d8430e86066db678ca6390",
-        "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
-    },
-    {
-        "id": "object-copy:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
-        "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
-        "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
-    },
-    {
-        "id": "strip-ansi:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
-        "md5": "f0aa5746513c46c807ea71744ec2bc5c",
-        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
-    },
-    {
-        "id": "babel-runtime:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-messages:6.23.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
-        "md5": "f791f7898733e02f7216de5d6d6a1602",
-        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
-    },
-    {
-        "id": "marked:0.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
-        "md5": "2981b17fa46348526d23658960663d88",
-        "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "is-number:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
-        "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
-        "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
-    },
-    {
-        "id": "isobject:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-plain-object:2.0.4",
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.pick:1.3.0",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-visit:1.0.1",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
-        "md5": "9e7647515c0885e809f9aeb22de293f3",
-        "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
-    },
-    {
-        "id": "to-object-path:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
-        "md5": "ed213d48acc6db7b01883673013ba398",
-        "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
-    },
-    {
-        "id": "define-property:0.2.5",
+        "id": "regex-not:1.0.2",
         "scopes": [
             "dev"
         ],
@@ -4613,9 +6377,7 @@
                 "bundle-dependencies"
             ],
             [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
+                "extglob:2.0.4",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -4623,10 +6385,7 @@
                 "bundle-dependencies"
             ],
             [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
+                "nanomatch:1.2.13",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -4634,11 +6393,6 @@
                 "bundle-dependencies"
             ],
             [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -4646,7 +6400,7 @@
                 "bundle-dependencies"
             ],
             [
-                "snapdragon:0.8.2",
+                "to-regex:3.0.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -4654,171 +6408,50 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
-        "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
-        "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
+        "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+        "md5": "e54f51e5d23c17edae9f9d199b337531",
+        "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
     },
     {
-        "id": "word-wrap:1.2.3",
+        "id": "has-bigints:1.0.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
-        "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
-        "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
-    },
-    {
-        "id": "is-number:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ],
             [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
-        "md5": "fb4c6b1ce591089d5da379104d9455b8",
-        "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
-    },
-    {
-        "id": "is-boolean-object:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "is-bigint:1.0.4",
                 "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
-        "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
-        "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
+        "sha1": "0871bd3e3d51626f6ca0966668ba35d5602d6eaa",
+        "md5": "df87410ab4558f7e29b52e8733c1a3e6",
+        "sha256": "207b82f1fa30704c5cd488074a29582f64e20c3ceb29d78f2295d68268570ce3"
     },
     {
-        "id": "expand-brackets:2.1.4",
+        "id": "base:0.11.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
-        "md5": "a49099d108479157c6efcc4b739a00b2",
-        "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
-    },
-    {
-        "id": "kind-of:5.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -4827,415 +6460,9 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
-        "md5": "378018a0079fc3bc94e8ec2812d86fe6",
-        "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
-    },
-    {
-        "id": "colors:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-table:0.3.11",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
-        "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
-        "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
-    },
-    {
-        "id": "spdx-exceptions:2.3.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
-        "md5": "acbb50a4dc418357a51310b852eb2e38",
-        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
-    },
-    {
-        "id": "babel-eslint:7.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
-        "md5": "85d7580cf18c64e2b1cd165832032bbc",
-        "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "run-async:0.1.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "window-size:0.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
-        "md5": "250499d281e44d2783aec6cfc458e96a",
-        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
-    },
-    {
-        "id": "union-value:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
-        "md5": "5438ca0bb737dc01e85a61121dcc3626",
-        "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
-    },
-    {
-        "id": "filename-regex:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
-        "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
-        "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
-    },
-    {
-        "id": "y18n:3.2.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
-        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
-        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
-    },
-    {
-        "id": "has-values:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
-        "md5": "b22e4bd0ee56cd167cb12437533618b1",
-        "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
-    },
-    {
-        "id": "number-is-nan:1.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "is-fullwidth-code-point:1.0.0",
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "097b602b53422a522c1afb8790318336941a011d",
-        "md5": "1c192095065e6b72a7e20a747b110469",
-        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
-    },
-    {
-        "id": "cliui:3.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "120601537a916d29940f934da3b48d585a39213d",
-        "md5": "3a83794ba283c15042e429b11802766d",
-        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
-    },
-    {
-        "id": "function-bind:1.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has:1.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
-        "md5": "ee976e75439af2b82e707f3a64c69684",
-        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
-    },
-    {
-        "id": "array-unique:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
-        "md5": "7b3ac4760380d655957c68e59748f438",
-        "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
-    },
-    {
-        "id": "which:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
-        "md5": "3077f0c321098e78b78ddd6b4b2789e5",
-        "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
-    },
-    {
-        "id": "eslint-plugin-babel:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
-        "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
-        "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
-    },
-    {
-        "id": "string-width:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
-        "md5": "b8aa95585646db49430dbaf185daec5d",
-        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
-    },
-    {
-        "id": "is-equal-shallow:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
-        "md5": "79abafbc68151c75a7242adf69c9b7c5",
-        "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
-    },
-    {
-        "id": "type:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
-        "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
-        "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
+        "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
+        "md5": "b457a16eb8603bc0d84d252716f5b0d5",
+        "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
     },
     {
         "id": "path-is-inside:1.0.2",
@@ -5256,110 +6483,6 @@
         "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d"
     },
     {
-        "id": "expand-brackets:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
-        "md5": "15d774bbd64fa32c2c427854bf58143b",
-        "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
-    },
-    {
-        "id": "has-symbols:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-symbol:1.0.4",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-tostringtag:1.0.0",
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "165d3070c00309752a1236a479331e3ac56f1423",
-        "md5": "6fa03a33b382263eedbbdc38c48cd24b",
-        "sha256": "005c4ea47993c807c8a535827b56db30dde39400e918c424fc3de1cc3eb165dd"
-    },
-    {
-        "id": "eslint-import-resolver-node:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
-        "md5": "bf0a201e44f3e437813f10b97923f452",
-        "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
-    },
-    {
         "id": "p-locate:2.0.0",
         "scopes": [
             "dev"
@@ -5369,7 +6492,7 @@
                 "locate-path:2.0.0",
                 "find-up:2.1.0",
                 "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
@@ -5381,490 +6504,7 @@
         "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46"
     },
     {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "redeyed:2.1.1",
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "arr-union:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
-        "md5": "f3cf2ebd1f4051917051f0c2b9287954",
-        "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
-    },
-    {
-        "id": "ansi-styles:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
-        "md5": "deb5e5008ca69027719588d723cf9f91",
-        "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
-    },
-    {
-        "id": "has-tostringtag:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-date-object:1.0.5",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number-object:1.0.6",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
-        "md5": "25e5a30ea25da9a3e5cf67924512233a",
-        "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
-    },
-    {
-        "id": "generate-object-property:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
-        "md5": "275dde8134c99f03d9ff31a8fa861f19",
-        "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
-    },
-    {
-        "id": "regex-cache:0.4.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
-        "md5": "c08a04a26436892d55f3d2fb294d8b73",
-        "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
-    },
-    {
-        "id": "get-caller-file:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
-        "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
-        "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
-    },
-    {
-        "id": "extend-shallow:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
-        "md5": "5c9316b33e9363368f4468595c700044",
-        "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
-    },
-    {
-        "id": "string.prototype.trimend:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e75ae90c2942c63504686c18b287b4a0b1a45f80",
-        "md5": "88b629f9cb3e49990b0fbd7c2c06a4f9",
-        "sha256": "984cce7dab0d22dfe19301aeedfca180c9243c97d16cdd7c0f31c7be744e6710"
-    },
-    {
-        "id": "ext:1.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
-        "md5": "9cf67c9330abea4cd40a86724154f246",
-        "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
-    },
-    {
-        "id": "flat-cache:1.3.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
-        "md5": "7f7fe842b74285784727aedf7cf81c4b",
-        "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
-    },
-    {
-        "id": "esutils:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:2.1.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
-        "md5": "fbea0e3ececd72f8135013e599bb44b3",
-        "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
-    },
-    {
-        "id": "mkdirp:0.5.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write:0.2.1",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d91cefd62d1436ca0f41620e251288d420099def",
-        "md5": "7e445b65cc532ae036e685117d5fe44d",
-        "sha256": "4e5ab01a61e329dd14d4020ce846e3abd93ee79b0f788f22fd5d5b4a61b1bb0a"
-    },
-    {
-        "id": "exit-hook:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
-        "md5": "d6ad3b683bee91b5a117990d68a097dd",
-        "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
-    },
-    {
-        "id": "validate-npm-package-license:3.0.4",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
-        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
-        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
-    },
-    {
-        "id": "interpret:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
-        "md5": "9d7dec2c46613400992e6b9ed13175c1",
-        "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
-    },
-    {
-        "id": "ignore:3.3.10",
+        "id": "js-yaml:3.14.1",
         "scopes": [
             "dev"
         ],
@@ -5877,734 +6517,49 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
-        "md5": "623073ae841f6a00f1d93c50f97065ad",
-        "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
+        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+        "md5": "2a522c3e23f7999abd8f852c012c20dd",
+        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
     },
     {
-        "id": "cardinal:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
-        "md5": "876b0338412efe635c487c4bf31a55b1",
-        "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
-    },
-    {
-        "id": "eslint-config-canonical:1.15.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
-        "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
-        "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
-    },
-    {
-        "id": "is-js-type:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
-        "md5": "89c1378f5a53fec687827f000e40d29b",
-        "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
-    },
-    {
-        "id": "concat-stream:1.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
-        "md5": "f3d719f26732b5206541e52972316e84",
-        "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
-    },
-    {
-        "id": "os-locale:1.4.0",
+        "id": "pinkie:2.0.4",
         "scopes": [
             "dev",
             "prod"
         ],
         "requestedBy": [
             [
-                "yargs:4.6.0",
+                "pinkie-promise:2.0.1",
+                "globby:4.0.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "yargs:4.7.0",
+                "pinkie-promise:2.0.1",
+                "del:2.2.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "md5": "fdb77de7d9374b72e7f466c27908a730",
-        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
-    },
-    {
-        "id": "is-number:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
-        "md5": "16a0b10f0dab47199d6536d319c0c6d5",
-        "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
-    },
-    {
-        "id": "type-check:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "levn:0.2.5",
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
-        "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
-        "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
-    },
-    {
-        "id": "get-symbol-description:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
-        "md5": "e14a4c666fa15e9f9173046700ead218",
-        "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
-    },
-    {
-        "id": "isarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.2.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
-        "md5": "c24471c617803171eed93b3516624c97",
-        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:1.0.1",
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mkdirp:0.5.5",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "camelcase:3.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
-        "md5": "d9d2d730959290cbbb9ef3900cd6126c",
-        "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.4",
-                "minimatch:2.0.10",
-                "babel-core:6.8.0",
-                "babel-plugin-transform-regenerator:6.8.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.3",
-                "minimatch:3.0.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "js-tokens:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "loose-envify:1.4.0",
-                "invariant:2.2.4",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9866df395102130e38f7f996bceb65443209c25b",
-        "md5": "969180644218c18794b6df26d42accd5",
-        "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
-    },
-    {
-        "id": "lodash._arrayeach:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
-        "md5": "2500bac4195ee774f346d80500ad77ef",
-        "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
-    },
-    {
-        "id": "is-bigint:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
-        "md5": "54f51f1529d609a8762b6f18a9fc5f39",
-        "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
-    },
-    {
-        "id": "lodash._basecopy:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.toplainobject:3.0.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
-        "md5": "34a2be5e888808f5239e85ae528752bf",
-        "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "use:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
-        "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
-        "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
-    },
-    {
-        "id": "path-parse:1.0.7",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
-        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
-        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
-    },
-    {
-        "id": "map-cache:0.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fragment-cache:0.2.1",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
-        "md5": "7ed5e46ed67d87ec937cedc485559cb6",
-        "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
-    },
-    {
-        "id": "decode-uri-component:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
-        "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
-        "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
-    },
-    {
-        "id": "hosted-git-info:2.8.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
+                "pinkie-promise:2.0.1",
+                "find-up:1.1.2",
                 "read-pkg-up:1.0.1",
                 "yargs:4.8.1",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
-        "md5": "e50583bc39341b531466e5de5b6aef94",
-        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
+        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
+        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
     },
     {
-        "id": "spdx-license-ids:3.0.11",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
-        "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
-        "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
-    },
-    {
-        "id": "unbox-primitive:1.0.1",
+        "id": "extglob:0.3.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "085e215625ec3162574dc8859abee78a59b14471",
-        "md5": "23d12db3c5ca7db2738571b3e610d09d",
-        "sha256": "dccea4f58520131a5e103a44a7f45e734a0161d7ef7490ba93008afe707eed3e"
-    },
-    {
-        "id": "is-posix-bracket:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:0.1.5",
                 "micromatch:2.3.11",
                 "anymatch:1.3.2",
                 "chokidar:1.7.0",
@@ -6612,36 +6567,12 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
-        "md5": "cd1bc456317e6cf7357683e79b8354c5",
-        "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
+        "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
+        "md5": "c8be79678101bbc03ea2018b80a8ac0a",
+        "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
     },
     {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "require-uncached:1.0.3",
+        "id": "esquery:1.4.0",
         "scopes": [
             "dev"
         ],
@@ -6654,97 +6585,9 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
-        "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
-        "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
-    },
-    {
-        "id": "pluralize:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
-        "md5": "10ffc865fc0a65a38893463e1ab77403",
-        "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
-    },
-    {
-        "id": "os-homedir:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "user-home:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
-        "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
-        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
-    },
-    {
-        "id": "repeat-string:1.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
-        "md5": "ed49a5a26c9110a28411da1cded28e3a",
-        "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+        "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
+        "md5": "67c3703f159c91ae9bd06b896a863b19",
+        "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
     },
     {
         "id": "which-boxed-primitive:1.0.2",
@@ -6753,10 +6596,10 @@
         ],
         "requestedBy": [
             [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
@@ -6766,6 +6609,42 @@
         "sha1": "13757bc89b209b049fe5d86430e21cf40a89a8e6",
         "md5": "2d84f8bed229309416dffff93d5028cd",
         "sha256": "4a4017ba9103fed80bc3ec67c529ed43b38066a626dd9595d91a57cf0c5e089d"
+    },
+    {
+        "id": "nan:2.16.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fsevents:1.2.13",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "664f43e45460fb98faf00edca0bb0d7b8dce7916",
+        "md5": "68fb1de1d6bd9d63f06c05e4c373333d",
+        "sha256": "31a79eeaa628e9fabe6d49de6c5c0b535f7a88ec4b4370e4009669a237db7a86"
+    },
+    {
+        "id": "es6-map:0.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
+        "md5": "98c9ef67294b8213745a30395f4a62b5",
+        "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
     },
     {
         "id": "ansicolors:0.3.2",
@@ -6787,13 +6666,53 @@
         "sha256": "b8e260ab45c01049f6a58029b723935bcef0cb28e62888e412f217bfd4e228ef"
     },
     {
-        "id": "acorn-jsx:3.0.1",
+        "id": "is-number-object:1.0.7",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "espree:3.5.4",
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "59d50ada4c45251784e9904f5246c742f07a42fc",
+        "md5": "01e99c61d94d3ac9cffd17b6a666c860",
+        "sha256": "ab356b0a4c4dedc7ac45456826ec5caa14aa1051402516dc86f9bd75ba0a9b75"
+    },
+    {
+        "id": "remove-trailing-separator:1.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "normalize-path:2.1.1",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+        "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
+        "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
+    },
+    {
+        "id": "os-homedir:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "user-home:2.0.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -6801,27 +6720,82 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
-        "md5": "4b90c954f940a0891370c7d265ce0fc6",
-        "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
+        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
+        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
     },
     {
-        "id": "core-util-is:1.0.3",
+        "id": "ansi-escapes:1.4.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
-        "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
-        "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
+        "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
+        "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
+        "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
+    },
+    {
+        "id": "regexp.prototype.flags:1.4.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "87cab30f80f66660181a3bb7bf5981a872b367ac",
+        "md5": "61b7a182d81b12b7c8a9bc5105726ab0",
+        "sha256": "444df1245ed8a3a8f5afbffed1e9c589e4878fc3bf9021cb5a6c127f38ccbd95"
+    },
+    {
+        "id": "fast-levenshtein:2.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "optionator:0.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
+        "md5": "443a739d106c51a33470c9f018d82e85",
+        "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
     },
     {
         "id": "kind-of:3.2.2",
@@ -7050,198 +7024,7 @@
         "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47"
     },
     {
-        "id": "readdirp:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
-        "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
-        "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
-    },
-    {
-        "id": "to-regex:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
-        "md5": "8a6359bf8c570483aad2a767191e87bb",
-        "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
-    },
-    {
-        "id": "is-property:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "generate-function:2.3.1",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
-        "md5": "29d8709ba7392da7846b05c30cb83832",
-        "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
-    },
-    {
-        "id": "parse-glob:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
-        "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
-        "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "supports-color:5.5.0",
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "randomatic:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
-        "md5": "da226719644d2e64d1127424e028f827",
-        "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
-    },
-    {
-        "id": "supports-preserve-symlinks-flag:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
-        "md5": "2ecf7c03c814ab155c5278d61f65583f",
-        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
-    },
-    {
-        "id": "inquirer:0.12.0",
+        "id": "is-resolvable:1.1.0",
         "scopes": [
             "dev"
         ],
@@ -7252,474 +7035,11 @@
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ]
         ],
-        "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
-        "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
-        "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
-    },
-    {
-        "id": "util-deprecate:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
-        "md5": "280e304a953ba3a89f52cc6ad616b284",
-        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
-    },
-    {
-        "id": "fragment-cache:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
-        "md5": "14306688d4947a100f6cce5b00d07afd",
-        "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
-    },
-    {
-        "id": "fsevents:1.2.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f325cb0455592428bcf11b383370ef70e3bfcc38",
-        "md5": "f275f972b6d338c71ac4cdc9b7f50dab",
-        "sha256": "dc8449e14688f08c85d73435e51467491639b56f752bcaa7015f2f97e9bca7aa"
-    },
-    {
-        "id": "arr-diff:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
-        "md5": "5aa32e7c03b612d64d433306ecfcd392",
-        "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
-    },
-    {
-        "id": "event-emitter:0.3.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
-        "md5": "5e969bf0d73326a36ab0eede156d48e3",
-        "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
-    },
-    {
-        "id": "rechoir:0.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "liftoff:2.2.1",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
-        "md5": "9a0aa4db2a887a452ef08921160c7eb4",
-        "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
-    },
-    {
-        "id": "regex-not:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
-        "md5": "e54f51e5d23c17edae9f9d199b337531",
-        "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
-    },
-    {
-        "id": "get-set-props:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
-        "md5": "ae71d26ef14801348a804a1b2e987ed9",
-        "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
-    },
-    {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
-    },
-    {
-        "id": "shellwords:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
-        "md5": "406c4d51a834f3ddddfaf96b9303af36",
-        "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "spdx-correct:3.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
-        "md5": "bd668e9b71960e76e867c11ec3ec2982",
-        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
-    },
-    {
-        "id": "ramda:0.25.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
-        "md5": "f86f2a632aa11bb7af129304fbe22a67",
-        "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
-    },
-    {
-        "id": "eslint-module-utils:2.7.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
-        "md5": "b209efc416d3e5b3f9b15c9177a19fec",
-        "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
-    },
-    {
-        "id": "pinkie:2.0.4",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pinkie-promise:2.0.1",
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
-        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
-        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
-    },
-    {
-        "id": "braces:2.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
-        "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
-        "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
-    },
-    {
-        "id": "ansi-escapes:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
-        "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
-        "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
-    },
-    {
-        "id": "semver:5.7.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
+        "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
+        "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
+        "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
     },
     {
         "id": "decamelize:1.2.0",
@@ -7767,193 +7087,32 @@
         "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
     },
     {
-        "id": "sprintf-js:1.0.3",
+        "id": "readdirp:2.2.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "argparse:1.0.7",
-                "js-yaml:3.6.0",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+        "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
+        "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
+        "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
     },
     {
-        "id": "acorn:5.7.4",
+        "id": "snapdragon:0.8.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
-        "md5": "861b7e390cd4b067b90229f4b9eec0c9",
-        "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
-    },
-    {
-        "id": "is-shared-array-buffer:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6",
-        "md5": "262a0c4a277cb35dc227ce4a0f552be1",
-        "sha256": "14b35068e9505161afce57efbd849b33c519d4524f4b2548587d017e51d25897"
-    },
-    {
-        "id": "assign-symbols:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extend-shallow:3.0.2",
+                "braces:2.3.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
-        "md5": "e9bb66200b728da39a79c2f235780331",
-        "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
-    },
-    {
-        "id": "eslint-plugin-jsdoc:2.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
-        "md5": "faf67209cc82f0fc3b0717ea662bbdab",
-        "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
-    },
-    {
-        "id": "kind-of:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20813df3d712928b207378691a45066fae72dd57",
-        "md5": "e24d0d555965b239fb2b6435b0724853",
-        "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
-    },
-    {
-        "id": "string_decoder:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
-        "md5": "7b93eea8153258fea64c3192922effaa",
-        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
-    },
-    {
-        "id": "babel-messages:6.23.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
-        "md5": "f7a22e78d59c180af1175172a3abee40",
-        "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
-    },
-    {
-        "id": "debug:2.6.9",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
@@ -7967,6 +7126,338 @@
                 "bundle-dependencies"
             ],
             [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
+        "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
+    },
+    {
+        "id": "minimist:1.2.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "json5:1.0.1",
+                "tsconfig-paths:3.14.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "tsconfig-paths:3.14.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "mkdirp:0.5.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8637a5b759ea0d6e98702cfb3a9283323c93af44",
+        "md5": "0d781b9eda1d585527fb8e1edcfce4c6",
+        "sha256": "49c9124665fc1900e589be610b8dc69d5e61a179e9ed8547c6d61d30a225e726"
+    },
+    {
+        "id": "inflight:1.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "glob:7.2.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+        "id": "ignore:3.3.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
+        "md5": "623073ae841f6a00f1d93c50f97065ad",
+        "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
+    },
+    {
+        "id": "natural-compare:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
+        "md5": "210787ea3f1a715dd963317ebfc5193f",
+        "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
+    },
+    {
+        "id": "es5-ext:0.10.61",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "d:1.0.1",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-iterator:2.0.3",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-set:0.1.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-symbol:3.1.1",
+                "es6-set:0.1.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "event-emitter:0.3.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-weak-map:2.0.3",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "311de37949ef86b6b0dcea894d1ffedb909d3269",
+        "md5": "84eb1176f35b58e8a606648d61d35584",
+        "sha256": "a4d97b74a47ac8a9364330e304949af6193537794f83005fc6e0776d0a577a77"
+    },
+    {
+        "id": "is-accessor-descriptor:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-descriptor:1.0.2",
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
+        "md5": "71d1d01f8028c245544a9a1217fb2bce",
+        "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
+    },
+    {
+        "id": "comment-parser:0.4.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-jsdoc:2.4.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
+        "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
+        "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
+    },
+    {
+        "id": "array.prototype.find:2.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "153b8a28ad8965cd86d3117b07e6596af6f2880d",
+        "md5": "ec713f547ad22ceb5cf77b1282059b4c",
+        "sha256": "132f73797a28c9f91511f20662cc43ee6a51473b191b4d7aa5987861c540513d"
+    },
+    {
+        "id": "onetime:1.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "restore-cursor:1.0.1",
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "restore-cursor:1.0.1",
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
+        "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
+        "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
+    },
+    {
+        "id": "number-is-nan:1.0.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "is-fullwidth-code-point:1.0.0",
+                "string-width:1.0.2",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "097b602b53422a522c1afb8790318336941a011d",
+        "md5": "1c192095065e6b72a7e20a747b110469",
+        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
+    },
+    {
+        "id": "is-get-set-prop:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
+        "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
+        "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
+    },
+    {
+        "id": "mixin-deep:1.3.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "base:0.11.2",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -7975,16 +7466,221 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
-        "md5": "cb6cb63ab5843aee3af94d27c60ea476",
-        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
+        "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
+        "md5": "53fb379c1187b97eecfcf06399958566",
+        "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
     },
     {
-        "id": "globals:9.18.0",
+        "id": "fragment-cache:0.2.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
+            [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "md5": "14306688d4947a100f6cce5b00d07afd",
+        "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
+    },
+    {
+        "id": "pragmatist:3.0.24",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
+        "md5": "282125ff6b702db1e05de93b7b866982",
+        "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
+    },
+    {
+        "id": "yargs-parser:2.4.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
+        "md5": "3ed28206e170b6c0cf902511c2d0534b",
+        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
+    },
+    {
+        "id": "interpret:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "shelljs:0.7.8",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
+        "md5": "9d7dec2c46613400992e6b9ed13175c1",
+        "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
+    },
+    {
+        "id": "lodash._basecopy:3.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.toplainobject:3.0.0",
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseassign:3.2.0",
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.template:3.6.2",
+                "gulp-util:3.0.7",
+                "gulp-babel:6.1.2",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseassign:3.2.0",
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
+        "md5": "34a2be5e888808f5239e85ae528752bf",
+        "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
+    },
+    {
+        "id": "is-glob:4.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+        "id": "object.values:1.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
+        "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
+        "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
+    },
+    {
+        "id": "run-async:0.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
+        "md5": "05b4c27dcef5296aff906af32f377494",
+        "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
+    },
+    {
+        "id": "babel-runtime:6.26.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-messages:6.23.0",
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
             [
                 "babel-traverse:6.26.0",
                 "babel-eslint:7.2.3",
@@ -7994,6 +7690,59 @@
                 "bundle-dependencies"
             ],
             [
+                "babel-types:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+        "md5": "f791f7898733e02f7216de5d6d6a1602",
+        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
+    },
+    {
+        "id": "inquirer:0.12.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
+        "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
+        "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
+    },
+    {
+        "id": "ajv:4.11.8",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "ajv-keywords:1.5.1",
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "table:3.8.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -8001,87 +7750,12 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
-        "md5": "746bb222029d9fd52336a7503c6e110b",
-        "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
+        "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
+        "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
+        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
     },
     {
-        "id": "graceful-fs:4.2.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "041b05df45755e587a24942279b9d113146e1c96",
-        "md5": "e387a6dfac11fd5d79bd2718100e08b6",
-        "sha256": "16677911bf936576c5c73447657a30b4c535ddf8dc2fa0c8109ae93fa9319f0a"
-    },
-    {
-        "id": "process-nextick-args:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
-        "md5": "09e1b13837638717ed3f2aae7bc700db",
-        "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
-    },
-    {
-        "id": "micromatch:2.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
-        "md5": "0c6949145be8bb09e5aa63fdebea9c24",
-        "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
-    },
-    {
-        "id": "prelude-ls:1.1.2",
+        "id": "type-check:0.3.2",
         "scopes": [
             "dev"
         ],
@@ -8112,15 +7786,6 @@
                 "bundle-dependencies"
             ],
             [
-                "type-check:0.3.2",
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
                 "optionator:0.8.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
@@ -8142,118 +7807,35 @@
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ],
-            [
-                "type-check:0.3.2",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ]
         ],
-        "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
-        "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
-        "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
+        "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
+        "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
+        "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
     },
     {
-        "id": "readable-stream:2.3.7",
+        "id": "babel-eslint:7.2.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "comment-parser:0.4.2",
-                "eslint-plugin-jsdoc:2.4.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ]
         ],
-        "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
-        "md5": "f060c259b513e887f551d073950f12f9",
-        "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
+        "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
+        "md5": "85d7580cf18c64e2b1cd165832032bbc",
+        "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
     },
     {
-        "id": "extend-shallow:3.0.2",
+        "id": "figures:1.7.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
-            [
-                "split-string:3.1.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
-        "md5": "194095206e18756d832f5e0ad3d71cb8",
-        "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
-    },
-    {
-        "id": "readline2:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
             [
                 "inquirer:0.12.0",
                 "eslint:3.19.0",
@@ -8261,26 +7843,21 @@
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ]
         ],
-        "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
-        "md5": "4e61bfb7db0673cc96401d5c3eea081c",
-        "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
+        "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
+        "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
+        "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
     },
     {
-        "id": "is-resolvable:1.1.0",
+        "id": "is-fullwidth-code-point:2.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "string-width:2.1.1",
+                "table:3.8.3",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -8288,439 +7865,55 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
-        "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
-        "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
+        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
+        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
     },
     {
-        "id": "babel-code-frame:6.26.0",
+        "id": "supports-color:5.5.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "supports-hyperlinks:1.0.1",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
-        "md5": "fdca204ce9b0158bcc65745baa896e4c",
-        "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
+        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+        "md5": "17b1003344e0e0d2719205be85946698",
+        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
     },
     {
-        "id": "strip-ansi:3.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
-        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
-        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
-    },
-    {
-        "id": "is-core-module:2.8.1",
+        "id": "camelcase:3.0.0",
         "scopes": [
             "prod"
         ],
         "requestedBy": [
             [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f59fdfca701d5879d0a6b100a40aa1560ce27211",
-        "md5": "b7203baea21d3312e5c49f374855b4b3",
-        "sha256": "a5476c788ef83b7ff627631136a2dfefe49e0f3c6ed00bee6ec426223c751e20"
-    },
-    {
-        "id": "write:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
-        "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
-        "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
-    },
-    {
-        "id": "fast-levenshtein:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
-        "md5": "443a739d106c51a33470c9f018d82e85",
-        "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
-    },
-    {
-        "id": "minimatch:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "879ad447200773912898b46cd516a7abbb5e50b0",
-        "md5": "22992838af1452c5cccc92cdf6c21025",
-        "sha256": "2b4e6fc003c29d58cb6f21c9b235ffa6ad29c7e94eba24c60d42973113629280"
-    },
-    {
-        "id": "rx-lite:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
-        "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
-        "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
-    },
-    {
-        "id": "comment-parser:0.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
-        "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
-        "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
-    },
-    {
-        "id": "posix-character-classes:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
-        "md5": "1fc17a88bddf7099b36179e8acbb68e9",
-        "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
-    },
-    {
-        "id": "map-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
-        "md5": "1911d8539476d5e5b03c42e63a87b49a",
-        "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "path-exists:2.1.0",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
+                "yargs-parser:2.4.1",
                 "yargs:4.8.1",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
-        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
+        "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
+        "md5": "d9d2d730959290cbbb9ef3900cd6126c",
+        "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
     },
     {
-        "id": "is-fullwidth-code-point:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
-        "md5": "edbd4281a6ac4fb8d1082592c411f250",
-        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
-    },
-    {
-        "id": "is-data-descriptor:0.1.4",
+        "id": "is-accessor-descriptor:0.1.6",
         "scopes": [
             "dev"
         ],
@@ -8786,79 +7979,24 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
-        "md5": "f8d653ce6e504d83c985de8d182f1ae5",
-        "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
+        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+        "md5": "988cec0d99237747735bc5d84953a207",
+        "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
     },
     {
-        "id": "rimraf:2.6.3",
+        "id": "esutils:2.0.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
-        "md5": "bd58522df35ee7b727430b41720e912d",
-        "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
-    },
-    {
-        "id": "restore-cursor:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
+                "babel-code-frame:6.26.0",
+                "babel-eslint:7.2.3",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34661f46886327fed2991479152252df92daa541",
-        "md5": "99b769f599ac64ecf9027f8717f01bb0",
-        "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
-    },
-    {
-        "id": "canonical:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
-        "md5": "a92c480423bdf2a2773e91c283b74ad8",
-        "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
-    },
-    {
-        "id": "to-fast-properties:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
             [
                 "babel-types:6.26.0",
                 "babel-eslint:7.2.3",
@@ -8866,299 +8004,17 @@
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
-        "md5": "eb323816b9903f0e6877898c3065da5b",
-        "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
-    },
-    {
-        "id": "es-to-primitive:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
-        "md5": "a32f26c478b76efa377601b8d17268a9",
-        "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
-    },
-    {
-        "id": "lodash.isarguments:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
-        "md5": "5aee2d8dc451d10cdc97666d9964074d",
-        "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
-    },
-    {
-        "id": "lodash.keys:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
             ],
             [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
-        "md5": "d2aa104b88db88e2c0f1ed627031ed03",
-        "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
-    },
-    {
-        "id": "invert-kv:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
-        "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
-        "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
-    },
-    {
-        "id": "cli-usage:0.1.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
-        "md5": "9f20b9678f9a13b909660a21fee052a4",
-        "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
-    },
-    {
-        "id": "pascalcase:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
-        "md5": "0c6e0012f1d98450a08a7b76b55a3296",
-        "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
-    },
-    {
-        "id": "strip-bom:2.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
-        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
-    },
-    {
-        "id": "eslint:3.19.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-babel:3.3.0",
+                "doctrine:2.1.0",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "eslint-plugin-flowtype:2.50.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-lodash:2.7.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
+                "doctrine:1.5.0",
                 "eslint-plugin-react:6.10.3",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -9166,23 +8022,6 @@
                 "bundle-dependencies"
             ],
             [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
-        "md5": "2b28bed1fe16d31f22178145baa90d7a",
-        "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
-    },
-    {
-        "id": "shelljs:0.7.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -9190,189 +8029,87 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
-        "md5": "476ea3b109ecf2179be8b78b444245d0",
-        "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
+        "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
+        "md5": "fbea0e3ececd72f8135013e599bb44b3",
+        "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
     },
     {
-        "id": "eslint-plugin-react:6.10.3",
+        "id": "preserve:0.2.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
-        "md5": "fabc99b1e4722b4e10fe41f348940da3",
-        "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
-    },
-    {
-        "id": "is-my-ip-valid:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7b351b8e8edd4d3995d4d066680e664d94696824",
-        "md5": "933f3e907a361ef18be30c70737b7808",
-        "sha256": "5ffa08e4ea7c36daf2ab805d31f678457823c347262856f9d819b5d99ee53e24"
-    },
-    {
-        "id": "is-weakref:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
-        "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
-        "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
-    },
-    {
-        "id": "cli-table:0.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
-        "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
-        "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
-    },
-    {
-        "id": "parse-json:2.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "md5": "9b98b48019fa25c226348737831cf130",
-        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
-    },
-    {
-        "id": "chokidar:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
-        "md5": "3b76ca6e8ebf196645910f2985f77385",
-        "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
-    },
-    {
-        "id": "resolve-from:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
-        "md5": "e19abe316d7d524402ff940ff923406c",
-        "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
-    },
-    {
-        "id": "async-each:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
                 "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
-        "md5": "c1130142d7ed405602b1fc38d811e360",
-        "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
+        "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
+        "md5": "bca875c4e8d238ef216dc9d1bcabf976",
+        "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
     },
     {
-        "id": "is-plain-object:2.0.4",
+        "id": "is-extendable:0.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
+                "object.omit:2.0.1",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
+                "set-value:2.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -9391,9 +8128,18 @@
                 "bundle-dependencies"
             ],
             [
-                "is-extendable:1.0.1",
-                "mixin-deep:1.3.2",
+                "union-value:1.0.1",
+                "cache-base:1.0.1",
                 "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extend-shallow:2.0.1",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -9402,35 +8148,17 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
-        "md5": "335972afae19ad1eccb8eee9aad94747",
-        "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
+        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
+        "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
+        "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
     },
     {
-        "id": "eslint-plugin-import:2.25.4",
+        "id": "table:3.8.3",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "322f3f916a4e9e991ac7af32032c25ce313209f1",
-        "md5": "441bc6892fc8ba6a5b335b241d27954b",
-        "sha256": "96d40d97f89261c792a276dc515c20fafbbc4c2e24d6e51d34a53b700957021d"
-    },
-    {
-        "id": "generate-function:2.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -9438,54 +8166,31 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "f069617690c10c868e73b8465746764f97c3479f",
-        "md5": "b4fd862f79a3a0a097ea8818a5858d22",
-        "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
+        "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
+        "md5": "caa5899fd31138fdbe11b2944fdf16e4",
+        "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
     },
     {
-        "id": "is-utf8:0.2.1",
+        "id": "assign-symbols:1.0.0",
         "scopes": [
-            "dev",
-            "prod"
+            "dev"
         ],
         "requestedBy": [
             [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
+                "extend-shallow:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:1.0.0",
-                "vinyl-fs:0.3.14",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
-        "md5": "7c483523b33b0640efedcc6561c545e2",
-        "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
+        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "md5": "e9bb66200b728da39a79c2f235780331",
+        "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
     },
     {
-        "id": "read-pkg-up:1.0.1",
+        "id": "cliui:3.2.0",
         "scopes": [
             "dev",
             "prod"
@@ -9494,14 +8199,6 @@
             [
                 "yargs:4.6.0",
                 "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "meow:3.7.0",
-                "dateformat:1.0.12",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
@@ -9515,71 +8212,19 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
-        "md5": "02cc53c7512931912dcbdcd9c1d55265",
-        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
+        "sha1": "120601537a916d29940f934da3b48d585a39213d",
+        "md5": "3a83794ba283c15042e429b11802766d",
+        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
     },
     {
-        "id": "isobject:2.1.0",
+        "id": "acorn:3.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
-        "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
-        "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "es6-weak-map:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
+                "acorn-jsx:3.0.1",
+                "espree:3.5.4",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -9587,496 +8232,9 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
-        "md5": "edb82ccad9f34520dc736bfbc67dc4be",
-        "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
-    },
-    {
-        "id": "escope:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
-        "md5": "9390f529580d458bc659af81607d7114",
-        "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "eslint-plugin-flowtype:2.50.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
-        "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
-        "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
-    },
-    {
-        "id": "glob-base:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
-        "md5": "ea2fd4074a1f129431de415f1c5387aa",
-        "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
-    },
-    {
-        "id": "is-number-object:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a7aaf838c7f0686a50b4553f7e54a96494e89f0",
-        "md5": "b9541523302c3dcfc0ed3f819496057c",
-        "sha256": "0d6833a8c4f62895368ccb95fbd08ba8a6ff9124974aba410a58ad9104cc6683"
-    },
-    {
-        "id": "atob:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
-        "md5": "45eb23f9eb24b3ff24e18466deeaa887",
-        "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
-    },
-    {
-        "id": "path-exists:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
-        "md5": "7c2676f4502f776524cefe6e0b877136",
-        "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
-    },
-    {
-        "id": "array.prototype.find:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6abbd0c2573925d8094f7d23112306af8c16d534",
-        "md5": "bd2ad5f97c8a124851aa316833fb8dd7",
-        "sha256": "f35b78cc51239d0c6edcc59872e03487a401d2ea995065a0526386e38a80baea"
-    },
-    {
-        "id": "cli-cursor:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
-        "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
-        "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
-    },
-    {
-        "id": "source-map-resolve:0.5.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
-        "md5": "88b0cf532783413eb92e171554ddd28d",
-        "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
-    },
-    {
-        "id": "object-inspect:1.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6e2c120e868fd1fd18cb4f18c31741d0d6e776f0",
-        "md5": "3b663a84af220988fe04b4a283676fb0",
-        "sha256": "c172809067d5c1e1a9d02dbef2abbe8e602676c3b78dbe7effd3274dee7d7646"
-    },
-    {
-        "id": "callsites:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
-        "md5": "b6e9bfb992503522ddaee4e965423faa",
-        "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "eslint-plugin-lodash:2.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
-        "md5": "7673c712d2af4c5fdc07ae78775670d6",
-        "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "rimraf:2.6.3",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "onetime:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
-        "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
-        "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
-    },
-    {
-        "id": "string.prototype.trimstart:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b36399af4ab2999b4c9c648bd7a3fb2bb26feeed",
-        "md5": "ad7c83cedfcdcafa713e957c027893c6",
-        "sha256": "8f5bffcc06a218d0106e9aba6216621e4f7e12667470e9b25d1ae3d4b13be75a"
-    },
-    {
-        "id": "mute-stream:0.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
-        "md5": "597b34af22c4237293f5c05cd5f74214",
-        "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
-    },
-    {
-        "id": "file-entry-cache:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
-        "md5": "329f8f032842d7a2c711bd18423e5226",
-        "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
-    },
-    {
-        "id": "is-data-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
-        "md5": "d4fe7614279e3f4718d383035209c33e",
-        "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
+        "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
+        "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
+        "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
     },
     {
         "id": "lodash._baseclone:3.3.0",
@@ -10111,289 +8269,13 @@
         "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549"
     },
     {
-        "id": "get-intrinsic:1.1.1",
+        "id": "esrecurse:4.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "15f59f376f855c446963948f0d24cd3637b4abc6",
-        "md5": "dcf91ab5448081811d382dfabad32bb6",
-        "sha256": "5a1b968faf5a6c2c3833e40321641651cbee32e41296e573d84b88ed2fe07b1b"
-    },
-    {
-        "id": "is-negative-zero:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
-        "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
-        "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
-    },
-    {
-        "id": "obj-props:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8884ab21c8d8496c4a7f696c78bf82289c51680b",
-        "md5": "ab45790d12ef25b271e0705f15cbdc4e",
-        "sha256": "ca7dad5516740c0db50ebeec237f934b90afcdc2cab6f4faae7774c08c2ca14e"
-    },
-    {
-        "id": "repeat-element:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
-        "md5": "bf964c7d487f69452bf2196b93908917",
-        "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
-    },
-    {
-        "id": "lodash.clonedeep:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
-        "md5": "dfef3b8bee7adea034e7224d909d92f5",
-        "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
-    },
-    {
-        "id": "babylon:6.18.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
-        "md5": "c0f769098a62e7881847657d146d9cbe",
-        "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
-    },
-    {
-        "id": "has:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-core-module:2.8.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
-        "md5": "b765203b0d733534ee6a58d84767223a",
-        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
-    },
-    {
-        "id": "has-values:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
-        "md5": "59bfd41b8b69c52c77823af62b7bada7",
-        "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
-    },
-    {
-        "id": "espree:3.5.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "escope:3.6.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -10401,65 +8283,37 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
-        "md5": "84b02c58a8ae5ce3da5886773141518b",
-        "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
+        "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
+        "md5": "a39f104614e3543dd4522ac4afdace00",
+        "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
     },
     {
-        "id": "jsonpointer:5.0.0",
+        "id": "ms:2.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
+                "debug:2.6.9",
+                "eslint-plugin-import:2.26.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "f802669a524ec4805fa7389eadbc9921d5dc8072",
-        "md5": "463322a0a00674acd3366d4c3bfd152f",
-        "sha256": "5d92ea00b9af9a6eadf29006039b37c7612d1c02ca17fcc142b4ceb30be75f4c"
+        "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "md5": "9615634070dd7751f127b2a0fb362484",
+        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
     },
     {
-        "id": "object.omit:2.0.1",
+        "id": "define-property:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
-        "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
-        "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
-    },
-    {
-        "id": "is-buffer:1.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "kind-of:3.2.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "fill-range:4.0.0",
+                "snapdragon-node:2.1.1",
                 "braces:2.3.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -10468,11 +8322,6 @@
                 "bundle-dependencies"
             ],
             [
-                "kind-of:3.2.2",
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
                 "extglob:2.0.4",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -10481,37 +8330,6 @@
                 "bundle-dependencies"
             ],
             [
-                "kind-of:3.2.2",
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:4.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
                 "base:0.11.2",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
@@ -10521,159 +8339,9 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
-        "md5": "374af5d9a1a7e4d3e686419412fa6b72",
-        "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
-    },
-    {
-        "id": "error-ex:1.3.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
-        "md5": "5d2c673565060037f9e04d7975d04feb",
-        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
-    },
-    {
-        "id": "array.prototype.flat:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07e0975d84bbc7c48cd1879d609e682598d33e13",
-        "md5": "97648174e504c24169cf0eda8f034788",
-        "sha256": "846fec18a5be9e6f972b366954db8b98812ee8b8873592b364a7a3e54dcb19bb"
-    },
-    {
-        "id": "natural-compare:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
-        "md5": "210787ea3f1a715dd963317ebfc5193f",
-        "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
-    },
-    {
-        "id": "read-pkg:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
-        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:1.3.1",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "braces:1.8.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
-        "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
-        "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
-    },
-    {
-        "id": "for-in:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "for-own:0.1.5",
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
-        "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
-        "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
+        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "md5": "8a6929a07bffc6c4c16bb506e31834c1",
+        "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
     },
     {
         "id": "chalk:1.1.3",
@@ -10795,197 +8463,6 @@
         "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
         "md5": "d7e0f89d6888d5d9ced994c205926555",
         "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d"
-    },
-    {
-        "id": "optionator:0.8.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
-        "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
-        "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
-    },
-    {
-        "id": "split-string:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
-        "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
-        "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
-    },
-    {
-        "id": "growly:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
-        "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
-        "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
-    },
-    {
-        "id": "circular-json:0.3.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
-        "md5": "5569f191dea3cd5f952867196e41e050",
-        "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
-    },
-    {
-        "id": "is-my-json-valid:2.20.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
-        "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
-        "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
-    },
-    {
-        "id": "cache-base:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
-        "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
-        "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
-    },
-    {
-        "id": "lodash._baseassign:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
-        "md5": "2438792bc711256968416ae0164b5dd9",
-        "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
-    },
-    {
-        "id": "array-includes:3.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5b493162c760f3539631f005ba2bb46acb45ba9",
-        "md5": "9d752dc8689c23a402be29863f5c1079",
-        "sha256": "9cdcf83ee2d54701efc89e0a73785538d154bd0d7db7218bdaab94047801b95c"
-    },
-    {
-        "id": "doctrine:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
-        "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
-        "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
     },
     {
         "id": "lodash.isarray:3.0.4",
@@ -11184,60 +8661,14 @@
         "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd"
     },
     {
-        "id": "ansi-regex:3.0.0",
+        "id": "estraverse:5.3.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "strip-ansi:4.0.0",
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
-        "md5": "1cc176457cc56d720f68eaf26b2afe8b",
-        "sha256": "bdadb0d036d35d54a71c47d94b2abfedb595775f41b8137bec044dc5efe43d35"
-    },
-    {
-        "id": "acorn:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "acorn-jsx:3.0.1",
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
-        "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
-        "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
-    },
-    {
-        "id": "json-stable-stringify:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
+                "esrecurse:4.3.0",
+                "escope:3.6.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
@@ -11245,102 +8676,111 @@
                 "bundle-dependencies"
             ],
             [
-                "ajv:4.11.8",
-                "table:3.8.3",
+                "esquery:1.4.0",
                 "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
+        "md5": "ac5d5752d7928d448689899477f994b0",
+        "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
+    },
+    {
+        "id": "expand-brackets:2.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
+        "md5": "a49099d108479157c6efcc4b739a00b2",
+        "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
+    },
+    {
+        "id": "is-arrayish:0.2.1",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "error-ex:1.3.0",
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
             ],
             [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
-        "md5": "7712931a8d538cad6e4beaccd491cbb2",
-        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
-    },
-    {
-        "id": "has-bigints:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "error-ex:1.3.0",
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "is-bigint:1.0.4",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
+                "error-ex:1.3.2",
+                "parse-json:2.2.0",
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "64fe6acb020673e3b78db035a5af69aa9d07b113",
-        "md5": "3d1a6fa2571c73144e864272fd5e2e75",
-        "sha256": "7bd053a7d11cfd00367859ca9d06020f643cb6b305a400e424dfd872ebcc223a"
+        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "md5": "4bbbacda455ab73d86f5eda908989f24",
+        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
     },
     {
-        "id": "is-extglob:2.1.1",
+        "id": "isobject:3.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "is-glob:4.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "babel-traverse:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "snapdragon-node:2.1.1",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
-        "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
-        "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
-    },
-    {
-        "id": "is-extendable:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-plain-object:2.0.4",
+                "is-extendable:1.0.1",
                 "extend-shallow:3.0.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -11349,7 +8789,68 @@
                 "bundle-dependencies"
             ],
             [
-                "mixin-deep:1.3.2",
+                "object.pick:1.3.0",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object-visit:1.0.1",
+                "collection-visit:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "unset-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
                 "base:0.11.2",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
@@ -11359,9 +8860,420 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
-        "md5": "61392549d95a063512f916897d7069b7",
-        "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
+        "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+        "md5": "9e7647515c0885e809f9aeb22de293f3",
+        "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
+    },
+    {
+        "id": "source-map:0.5.7",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+        "md5": "3773f963d18f1aca320fae40b04aded2",
+        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
+    },
+    {
+        "id": "event-emitter:0.3.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es6-set:0.1.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
+        "md5": "5e969bf0d73326a36ab0eede156d48e3",
+        "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
+    },
+    {
+        "id": "is-my-ip-valid:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f7220d1146257c98672e6fba097a9f3f2d348442",
+        "md5": "9d9e18f4f947f111477e8ee23ee41dd2",
+        "sha256": "c189c5d6a085578b79bfc4bbbdb2470ae45244a0d89df9663eed8fab59b6925f"
+    },
+    {
+        "id": "has-value:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
+        "md5": "0f5d46e9619fa36d9930f590ef96844b",
+        "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
+    },
+    {
+        "id": "js-types:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-js-type:2.0.0",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
+        "md5": "60cccf96110592ca167c2c9b98155a45",
+        "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
+    },
+    {
+        "id": "strip-ansi:3.0.1",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "chalk:1.1.3",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.1",
+                "table:3.7.8",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "table:3.7.8",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cliui:3.2.0",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "chalk:1.1.3",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cliui:3.2.0",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "wrap-ansi:2.1.0",
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.2",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
+        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
+    },
+    {
+        "id": "object.assign:4.1.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
+        "md5": "87b8da296ced17d6e062b791d48ed38b",
+        "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
+    },
+    {
+        "id": "filename-regex:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
+        "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
+        "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
+    },
+    {
+        "id": "mute-stream:0.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readline2:1.0.1",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readline2:1.0.1",
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
+        "md5": "597b34af22c4237293f5c05cd5f74214",
+        "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
+    },
+    {
+        "id": "pinkie-promise:2.0.1",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "del:2.2.0",
+                "flat-cache:1.0.10",
+                "file-entry-cache:1.2.4",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "globby:4.0.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-exists:2.1.0",
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "del:2.2.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "globby:4.0.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-exists:2.1.0",
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-exists:2.1.0",
+                "find-up:1.1.2",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "find-up:1.1.2",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
+        "md5": "d6cf74027e88ca54043e91d59629a656",
+        "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
     },
     {
         "id": "load-json-file:1.1.0",
@@ -11410,54 +9322,61 @@
         "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
     },
     {
-        "id": "p-try:1.0.0",
+        "id": "is-buffer:1.1.6",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "p-limit:1.3.0",
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "kind-of:3.2.2",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
-        "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
-        "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
-    },
-    {
-        "id": "proto-props:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
+                "kind-of:3.2.2",
+                "is-number:3.0.0",
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
-        "md5": "43c4cc31101ee8f37df9b66ff8353003",
-        "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
-    },
-    {
-        "id": "component-emitter:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
+            ],
             [
+                "kind-of:3.2.2",
+                "is-accessor-descriptor:0.1.6",
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "kind-of:3.2.2",
+                "is-data-descriptor:0.1.4",
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "kind-of:3.2.2",
+                "is-number:3.0.0",
+                "has-values:1.0.0",
+                "has-value:1.0.0",
                 "cache-base:1.0.1",
                 "base:0.11.2",
                 "snapdragon:0.8.2",
@@ -11468,6 +9387,10 @@
                 "bundle-dependencies"
             ],
             [
+                "kind-of:4.0.0",
+                "has-values:1.0.0",
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
                 "base:0.11.2",
                 "snapdragon:0.8.2",
                 "micromatch:3.1.10",
@@ -11477,26 +9400,637 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
-        "md5": "6b8517f3d7ad46e95c97b6d453f82189",
-        "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
+        "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+        "md5": "374af5d9a1a7e4d3e686419412fa6b72",
+        "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
     },
     {
-        "id": "supports-color:5.5.0",
+        "id": "is-core-module:2.9.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "resolve:1.22.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "e1c34429cd51c6dd9e09e0799e396e27b19a9c69",
+        "md5": "9862dd9912e0d8158cdb2b339c0ee148",
+        "sha256": "2ba3f3317b3f4055f45e879068a1c37dafef035b407282e420ccf5fa8c13cc6d"
+    },
+    {
+        "id": "braces:2.3.2",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
+        "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
+        "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
+    },
+    {
+        "id": "spdx-exceptions:2.3.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "spdx-expression-parse:3.0.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
+        "md5": "acbb50a4dc418357a51310b852eb2e38",
+        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
+    },
+    {
+        "id": "acorn-jsx:3.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "espree:3.5.4",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
+        "md5": "4b90c954f940a0891370c7d265ce0fc6",
+        "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
+    },
+    {
+        "id": "process-nextick-args:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+        "md5": "09e1b13837638717ed3f2aae7bc700db",
+        "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
+    },
+    {
+        "id": "read-pkg-up:1.0.1",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.6.0",
+                "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "supports-hyperlinks:1.0.1",
+                "meow:3.7.0",
+                "dateformat:1.0.12",
+                "gulp-util:3.0.7",
+                "gulp-babel:6.1.2",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
+        "md5": "02cc53c7512931912dcbdcd9c1d55265",
+        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
+    },
+    {
+        "id": "spdx-expression-parse:3.0.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "spdx-correct:3.1.1",
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "validate-npm-package-license:3.0.4",
+                "normalize-package-data:2.5.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
+        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
+        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
+    },
+    {
+        "id": "obj-props:1.4.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-obj-prop:1.0.0",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9a9beebb6faf8b287ff7dc1cd133a4247dc85641",
+        "md5": "ace7f0609a71a11dbb9532032b2acab8",
+        "sha256": "41eaa9b49ccc882b9db952d448a180d1c4a5ee17c344634c046ff58ecb4da71a"
+    },
+    {
+        "id": "ret:0.1.15",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "safe-regex:1.1.0",
+                "regex-not:1.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+        "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
+        "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
+    },
+    {
+        "id": "is-callable:1.2.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-to-primitive:1.2.1",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "47301d58dd0259407865547853df6d61fe471945",
+        "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
+        "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
+    },
+    {
+        "id": "extglob:2.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
+        "md5": "5e368678ebf35fe8dbaa173517e7adc1",
+        "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
+    },
+    {
+        "id": "pify:2.3.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "del:2.2.0",
+                "flat-cache:1.0.10",
+                "file-entry-cache:1.2.4",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "globby:4.0.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "del:2.2.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "globby:4.0.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "load-json-file:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "path-type:1.1.0",
+                "read-pkg:1.1.0",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "md5": "475310192b9d153240ac82eb66b827e8",
+        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
+    },
+    {
+        "id": "globals:9.18.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-traverse:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
+        "md5": "746bb222029d9fd52336a7503c6e110b",
+        "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
+    },
+    {
+        "id": "is-property:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "generate-function:2.3.1",
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "generate-object-property:1.2.0",
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "generate-object-property:1.2.0",
+                "is-my-json-valid:2.13.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
+        "md5": "29d8709ba7392da7846b05c30cb83832",
+        "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
+    },
+    {
+        "id": "define-property:2.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "to-regex:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
+        "md5": "2751868d9fa31ebbbe851fdcb729115d",
+        "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
+    },
+    {
+        "id": "typedarray:0.0.6",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "concat-stream:1.6.2",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "concat-stream:1.5.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
+        "md5": "54a18bcd7fd55c812993e9ce90a0709d",
+        "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
+    },
+    {
+        "id": "generate-object-property:1.2.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-my-json-valid:2.13.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
+        "md5": "275dde8134c99f03d9ff31a8fa861f19",
+        "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
+    },
+    {
+        "id": "object-keys:1.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "define-properties:1.1.4",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.assign:4.1.2",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
+        "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
+        "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
+    },
+    {
+        "id": "espree:3.5.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
+        "md5": "84b02c58a8ae5ce3da5886773141518b",
+        "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
+    },
+    {
+        "id": "es6-iterator:2.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es5-ext:0.10.61",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-set:0.1.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es6-weak-map:2.0.3",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+        "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
+        "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
+    },
+    {
+        "id": "urix:0.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "source-map-resolve:0.5.3",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "source-map-resolve:0.3.1",
+                "css:2.2.1",
+                "gulp-sourcemaps:2.0.0-alpha",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "css:2.2.1",
+                "gulp-sourcemaps:2.0.0-alpha",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "md5": "dd3921f317a15657fad465fd215fe38d",
+        "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
+    },
+    {
+        "id": "cardinal:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "marked-terminal:3.3.0",
                 "cli-usage:0.1.10",
                 "node-notifier:4.6.1",
@@ -11504,19 +10038,18 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
+        "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
+        "md5": "876b0338412efe635c487c4bf31a55b1",
+        "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
     },
     {
-        "id": "type:2.6.0",
+        "id": "next-tick:1.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "ext:1.6.0",
-                "es6-symbol:3.1.3",
+                "es5-ext:0.10.61",
                 "es6-map:0.1.5",
                 "escope:3.6.0",
                 "eslint:3.19.0",
@@ -11526,113 +10059,31 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
-        "md5": "b06b1e937cd3671d147ef4f040fa297d",
-        "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
+        "sha1": "1836ee30ad56d67ef281b22bd199f709449b35eb",
+        "md5": "faaf65a0216bc6be06b5cf1139315f60",
+        "sha256": "f29d4d707449588c7200d1d4d05286fd3b8c0f63ad2e595f9bcd011c8d0ed755"
     },
     {
-        "id": "safe-buffer:5.1.2",
+        "id": "jsonpointer:5.0.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string_decoder:1.1.1",
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "for-own:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
-        "md5": "6b95dc29fcffc91036164869c724d05b",
-        "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
-    },
-    {
-        "id": "eslint-plugin-no-use-extend-native:0.3.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
+                "is-my-json-valid:2.20.6",
+                "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
-        "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
-        "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
+        "sha1": "2110e0af0900fd37467b5907ecd13a7884a1b559",
+        "md5": "d6ef3969001e1025effb07a76ff8e3ca",
+        "sha256": "72c2fe2b1034905ed19b2477ccea0167a8490f1ff4e306f3a63a74c7a2ef1e10"
     },
     {
-        "id": "is-primitive:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-equal-shallow:0.1.3",
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "207bab91638499c07b2adf240a41a87210034575",
-        "md5": "73402009e3936aeaa7b5c473d090b017",
-        "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
-    },
-    {
-        "id": "fill-range:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
-        "md5": "35483acae8b070dad60c41a99afe6b4d",
-        "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
-    },
-    {
-        "id": "is-accessor-descriptor:0.1.6",
+        "id": "kind-of:5.1.0",
         "scopes": [
             "dev"
         ],
@@ -11698,18 +10149,689 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
-        "md5": "988cec0d99237747735bc5d84953a207",
-        "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
+        "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
+        "md5": "378018a0079fc3bc94e8ec2812d86fe6",
+        "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
     },
     {
-        "id": "regenerator-runtime:0.11.1",
+        "id": "randomatic:3.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "babel-runtime:6.26.0",
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
+        "md5": "da226719644d2e64d1127424e028f827",
+        "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
+    },
+    {
+        "id": "kind-of:6.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "randomatic:3.1.1",
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-accessor-descriptor:1.0.0",
+                "is-descriptor:1.0.2",
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-data-descriptor:1.0.0",
+                "is-descriptor:1.0.2",
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-descriptor:1.0.2",
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
+        "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
+        "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
+    },
+    {
+        "id": "is-posix-bracket:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "expand-brackets:0.1.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
+        "md5": "cd1bc456317e6cf7357683e79b8354c5",
+        "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
+    },
+    {
+        "id": "readline2:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
+        "md5": "4e61bfb7db0673cc96401d5c3eea081c",
+        "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
+    },
+    {
+        "id": "string.prototype.trimend:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "914a65baaab25fbdd4ee291ca7dde57e869cb8d0",
+        "md5": "a3663ec694367b3d5df6cd1c904159f7",
+        "sha256": "05c18fe5ad1fac049ffdbdc95aa3d03510ce4838c5d95c5763ef41dc13a75561"
+    },
+    {
+        "id": "ansi-styles:3.2.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+        "id": "has-flag:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "supports-color:5.5.0",
+                "chalk:2.4.2",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "supports-color:5.5.0",
+                "supports-hyperlinks:1.0.1",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "md5": "1fa1fa951639c7058277abcecca86922",
+        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+        "id": "path-exists:2.1.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "find-up:1.1.2",
+                "pkg-conf:1.1.2",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "find-up:1.1.2",
+                "read-pkg-up:1.0.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
+        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
+    },
+    {
+        "id": "get-set-props:0.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-get-set-prop:1.0.0",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
+        "md5": "ae71d26ef14801348a804a1b2e987ed9",
+        "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
+    },
+    {
+        "id": "shellwords:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
+        "md5": "406c4d51a834f3ddddfaf96b9303af36",
+        "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
+    },
+    {
+        "id": "concat-map:0.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "brace-expansion:1.1.4",
+                "minimatch:2.0.10",
+                "babel-core:6.8.0",
+                "babel-plugin-transform-regenerator:6.8.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "brace-expansion:1.1.3",
+                "minimatch:3.0.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "brace-expansion:1.1.11",
+                "minimatch:3.1.2",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+        "id": "babel-traverse:6.26.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
+        "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
+        "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
+    },
+    {
+        "id": "unbox-primitive:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "29032021057d5e6cdbd08c5129c226dff8ed6f9e",
+        "md5": "f8a4b8d86554bfb4b6901ac51bf00863",
+        "sha256": "733eb170b51adb49104a823ed62f1a4606b45ee1e886178f12a1a00fb04fca1d"
+    },
+    {
+        "id": "expand-brackets:0.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
+        "md5": "15d774bbd64fa32c2c427854bf58143b",
+        "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
+    },
+    {
+        "id": "to-regex:3.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+        "md5": "8a6359bf8c570483aad2a767191e87bb",
+        "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
+    },
+    {
+        "id": "is-regex:1.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
+        "md5": "13a02d0abc63ff0093ca592e999f713c",
+        "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
+    },
+    {
+        "id": "ansi-regex:2.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "has-ansi:2.0.0",
+                "chalk:1.1.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "strip-ansi:3.0.1",
+                "cliui:3.2.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
+        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
+    },
+    {
+        "id": "is-number:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "to-regex-range:2.1.1",
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "has-values:1.0.0",
+                "has-value:1.0.0",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
+        "md5": "fb4c6b1ce591089d5da379104d9455b8",
+        "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
+    },
+    {
+        "id": "is-extendable:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "extend-shallow:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "mixin-deep:1.3.2",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
+        "md5": "61392549d95a063512f916897d7069b7",
+        "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
+    },
+    {
+        "id": "lodash.assign:4.2.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ],
+            [
+                "yargs-parser:2.4.1",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
+        "md5": "5a92447d4e8669abba120d5164892902",
+        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
+    },
+    {
+        "id": "functions-have-names:1.2.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "function.prototype.name:1.1.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "regexp.prototype.flags:1.4.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0404fe4ee2ba2f607f0e0ec3c80bae994133b834",
+        "md5": "89a2b8928f2e27c2087690ab9f5d846a",
+        "sha256": "3be0c99c006f7c53093e3f6a56a1128f1a72fec3b041ec585a4175b809fab1dc"
+    },
+    {
+        "id": "exit-hook:1.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "restore-cursor:1.0.1",
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "restore-cursor:1.0.1",
+                "cli-cursor:1.0.2",
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
+        "md5": "d6ad3b683bee91b5a117990d68a097dd",
+        "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
+    },
+    {
+        "id": "require-uncached:1.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
+        "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
+        "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
+    },
+    {
+        "id": "strip-json-comments:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "md5": "af7d37e88560f64851d5c27b0abc617e",
+        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
+    },
+    {
+        "id": "js-tokens:3.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "babel-code-frame:6.26.0",
+                "babel-eslint:7.2.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "loose-envify:1.4.0",
+                "invariant:2.2.4",
                 "babel-traverse:6.26.0",
                 "babel-eslint:7.2.3",
                 "eslint-config-canonical:1.15.0",
@@ -11718,63 +10840,254 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
-        "md5": "728ac808fb5276bf420fab33620d0c39",
-        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
+        "sha1": "9866df395102130e38f7f996bceb65443209c25b",
+        "md5": "969180644218c18794b6df26d42accd5",
+        "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
     },
     {
-        "id": "debug:3.2.7",
+        "id": "require-directory:2.1.1",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "md5": "f3a9010155b6a46066afbe2d07f624bd",
+        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+        "id": "math-random:1.0.4",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
+                "randomatic:3.1.1",
+                "fill-range:2.2.4",
+                "expand-range:1.8.2",
+                "braces:1.8.5",
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "5dd6943c938548267016d4e34f057583080c514c",
+        "md5": "029796aed5b40e10d30518bc21ad436a",
+        "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
+    },
+    {
+        "id": "object-assign:4.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "file-entry-cache:2.0.0",
+                "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ],
             [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
+                "figures:1.7.0",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
                 "eslint-config-canonical:1.15.0",
                 "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
-        "md5": "0f887df93ceeaa5784063eb8733a6778",
-        "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
+        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
+        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
     },
     {
-        "id": "supports-hyperlinks:1.0.1",
+        "id": "lodash.isarguments:3.1.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
+                "lodash.keys:3.1.2",
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
                 "node-notifier:4.6.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
-        "md5": "ac43da5665ec45c28303793339d60e5f",
-        "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
+        "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
+        "md5": "5aee2d8dc451d10cdc97666d9964074d",
+        "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
     },
     {
-        "id": "lodash._arraycopy:3.0.0",
+        "id": "which-module:1.0.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
+        "md5": "004cd541632e781023b01a91b2d4b851",
+        "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
+    },
+    {
+        "id": "array-includes:3.1.5",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb",
+        "md5": "3e1762231dcc1a9ca68d50da2e5935e5",
+        "sha256": "bf08768417abaaeb7f8caf6cc089ae4b3bcca6c9fe814bfede8556cdfeacae6d"
+    },
+    {
+        "id": "map-cache:0.2.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "fragment-cache:0.2.1",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "md5": "7ed5e46ed67d87ec937cedc485559cb6",
+        "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
+    },
+    {
+        "id": "normalize-path:2.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "micromatch:2.3.11",
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+        "md5": "b2f3932160dc03a5604dbac60ef59c34",
+        "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
+    },
+    {
+        "id": "is-windows:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "nanomatch:1.2.13",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "md5": "bcc9525ed3558792d281951c90ad366e",
+        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+        "id": "use:3.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+        "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
+        "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
+    },
+    {
+        "id": "get-symbol-description:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
+        "md5": "e14a4c666fa15e9f9173046700ead218",
+        "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
+    },
+    {
+        "id": "lodash._basefor:3.0.3",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.isplainobject:3.2.0",
                 "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._pickbycallback:3.0.0",
+                "lodash.omit:3.1.0",
                 "eslint:1.10.3",
                 "css-lint:1.0.1",
                 "canonical:3.2.1",
@@ -11797,23 +11110,37 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
-        "md5": "6de9a4e0d113c056078d1db4e75c748b",
-        "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
+        "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
+        "md5": "e0118d593252e3902b3769f0ff775d04",
+        "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
     },
     {
-        "id": "array-unique:0.3.2",
+        "id": "es6-symbol:3.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
+                "es6-set:0.1.5",
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
                 "pragmatist:3.0.24",
                 "bundle-dependencies"
-            ],
+            ]
+        ],
+        "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
+        "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
+        "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
+    },
+    {
+        "id": "split-string:3.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
             [
                 "braces:2.3.2",
                 "micromatch:3.1.10",
@@ -11823,7 +11150,145 @@
                 "bundle-dependencies"
             ],
             [
-                "extglob:2.0.4",
+                "set-value:2.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
+        "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
+    },
+    {
+        "id": "has-tostringtag:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-date-object:1.0.5",
+                "es-to-primitive:1.2.1",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-regex:1.1.4",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-boolean-object:1.1.2",
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-number-object:1.0.7",
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-string:1.0.7",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
+        "md5": "25e5a30ea25da9a3e5cf67924512233a",
+        "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
+    },
+    {
+        "id": "path-parse:1.0.7",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "resolve:1.22.1",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
+        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
+        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
+    },
+    {
+        "id": "eslint-plugin-promise:3.8.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
+        "md5": "ba6f09078795c4b8612de3a95a483603",
+        "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
+    },
+    {
+        "id": "is-binary-path:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
+        "md5": "a989667cf8d696127090b72fe8a674b3",
+        "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
+    },
+    {
+        "id": "arr-diff:4.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
                 "chokidar:1.7.0",
@@ -11839,73 +11304,17 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
-        "md5": "c7fa44b0117a3ed0d161f876c68633f7",
-        "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
+        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
+        "md5": "42ec151186ae4bd9980a212083d98bbe",
+        "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
     },
     {
-        "id": "balanced-match:1.0.2",
+        "id": "snapdragon-node:2.1.1",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
-        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
-        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
-    },
-    {
-        "id": "tsconfig-paths:3.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19769aca6ee8f6a1a341e38c8fa45dd9fb18899b",
-        "md5": "864704be71309d70ae4a2045ce17e2e0",
-        "sha256": "99c2bb5ac67ade10dc163b295eabb1b2a827e7857cdfeeccf5c9f8e496af3f81"
-    },
-    {
-        "id": "nan:2.15.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fsevents:1.2.13",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3f34a473ff18e15c1b5626b62903b5ad6e665fee",
-        "md5": "d738e181d051cf3a0ad8a80f537801ea",
-        "sha256": "411fe0c215dc822884aec437759a595f5c4581d0e40571496173f5413dc48f01"
-    },
-    {
-        "id": "snapdragon-util:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
                 "braces:2.3.2",
                 "micromatch:3.1.10",
                 "readdirp:2.2.1",
@@ -11914,23 +11323,391 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
-        "md5": "17c194e41dd12d561800985ef5b4ffdf",
-        "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
+        "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
+        "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
+        "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
     },
     {
-        "id": "yargs:4.8.1",
+        "id": "canonical:3.2.1",
         "scopes": [
-            "prod"
+            "dev"
         ],
         "requestedBy": [
             [
+                "pragmatist:3.0.24",
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
-        "md5": "964f012a6509b1b431de5f58a11e061a",
-        "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
+        "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
+        "md5": "a92c480423bdf2a2773e91c283b74ad8",
+        "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
+    },
+    {
+        "id": "call-bind:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "function.prototype.name:1.1.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "get-symbol-description:1.0.0",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "side-channel:1.0.4",
+                "internal-slot:1.0.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-regex:1.1.4",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-shared-array-buffer:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-weakref:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "regexp.prototype.flags:1.4.3",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimend:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string.prototype.trimstart:1.0.5",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-boolean-object:1.1.2",
+                "which-boxed-primitive:1.0.2",
+                "unbox-primitive:1.0.2",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.flat:1.3.0",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.values:1.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "array.prototype.find:2.2.0",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "object.assign:4.1.2",
+                "eslint-plugin-react:6.10.3",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
+        "md5": "d244c20a7b3f2c607030df6337a4e68d",
+        "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
+    },
+    {
+        "id": "eslint-plugin-lodash:2.7.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
+        "md5": "7673c712d2af4c5fdc07ae78775670d6",
+        "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
+    },
+    {
+        "id": "util-deprecate:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "readable-stream:2.0.6",
+                "concat-stream:1.5.1",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readable-stream:2.3.7",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "readable-stream:2.0.6",
+                "through2:2.0.1",
+                "gulp-babel:6.1.2",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "md5": "280e304a953ba3a89f52cc6ad616b284",
+        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
+    },
+    {
+        "id": "p-limit:1.3.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "p-locate:2.0.0",
+                "locate-path:2.0.0",
+                "find-up:2.1.0",
+                "eslint-module-utils:2.7.3",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
+        "md5": "f674d1283c8ac4d11ec813efc2b5934a",
+        "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
+    },
+    {
+        "id": "is-data-descriptor:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-descriptor:1.0.2",
+                "define-property:2.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
+        "md5": "d4fe7614279e3f4718d383035209c33e",
+        "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
+    },
+    {
+        "id": "file-uri-to-path:1.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "bindings:1.5.0",
+                "fsevents:1.2.13",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "553a7b8446ff6f684359c445f1e37a05dacc33dd",
+        "md5": "2215c58ead5bbd5a52c572db0cf977d2",
+        "sha256": "5440cdf67e75ab96f36a6be63c1d4c3d54255b1d0970273710fecfebfab06fb3"
+    },
+    {
+        "id": "extend-shallow:2.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "fill-range:4.0.0",
+                "braces:2.3.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "set-value:2.0.1",
+                "cache-base:1.0.1",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "md5": "5c9316b33e9363368f4468595c700044",
+        "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
+    },
+    {
+        "id": "pascalcase:0.1.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "md5": "0c6e0012f1d98450a08a7b76b55a3296",
+        "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
     },
     {
         "id": "lodash:4.17.21",
@@ -12012,160 +11789,12 @@
         "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
     },
     {
-        "id": "object-keys:1.1.1",
+        "id": "unset-value:1.0.0",
         "scopes": [
             "dev"
         ],
         "requestedBy": [
             [
-                "define-properties:1.1.3",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
-        "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
-        "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
-    },
-    {
-        "id": "estraverse:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
-        "md5": "fe475b154e52864c56c3fc8f4b4af81b",
-        "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
-    },
-    {
-        "id": "lcid:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "md5": "33e24746875ebbcc37c40c7297388609",
-        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
-    },
-    {
-        "id": "is-proto-prop:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
-        "md5": "78443d3b543426fda71dfcb27111473b",
-        "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
-    },
-    {
-        "id": "strip-json-comments:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
-        "md5": "af7d37e88560f64851d5c27b0abc617e",
-        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
-    },
-    {
-        "id": "is-obj-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
-        "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
-        "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
-    },
-    {
-        "id": "has-value:0.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unset-value:1.0.0",
                 "cache-base:1.0.1",
                 "base:0.11.2",
                 "snapdragon:0.8.2",
@@ -12176,8 +11805,605 @@
                 "bundle-dependencies"
             ]
         ],
-        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
-        "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
-        "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
+        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "md5": "d69bb4d1f65e08acd32debce863b513e",
+        "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
+    },
+    {
+        "id": "cli-usage:0.1.10",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
+        "md5": "9f20b9678f9a13b909660a21fee052a4",
+        "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
+    },
+    {
+        "id": "imurmurhash:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+        "id": "supports-hyperlinks:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
+        "md5": "ac43da5665ec45c28303793339d60e5f",
+        "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
+    },
+    {
+        "id": "is-js-type:2.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
+        "md5": "89c1378f5a53fec687827f000e40d29b",
+        "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
+    },
+    {
+        "id": "invert-kv:1.0.0",
+        "scopes": [
+            "dev",
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "lcid:1.0.0",
+                "os-locale:1.4.0",
+                "yargs:4.6.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lcid:1.0.0",
+                "os-locale:1.4.0",
+                "yargs:4.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lcid:1.0.0",
+                "os-locale:1.4.0",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
+        "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
+        "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
+    },
+    {
+        "id": "micromatch:2.3.11",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "anymatch:1.3.2",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
+        "md5": "0c6949145be8bb09e5aa63fdebea9c24",
+        "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
+    },
+    {
+        "id": "is-data-descriptor:0.1.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "expand-brackets:2.1.4",
+                "extglob:2.0.4",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "object-copy:0.1.0",
+                "static-extend:0.1.2",
+                "class-utils:0.3.6",
+                "base:0.11.2",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-descriptor:0.1.6",
+                "define-property:0.2.5",
+                "snapdragon:0.8.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
+        "md5": "f8d653ce6e504d83c985de8d182f1ae5",
+        "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
+    },
+    {
+        "id": "cli-cursor:1.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "inquirer:0.11.4",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "inquirer:0.12.0",
+                "eslint:2.9.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
+        "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
+        "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
+    },
+    {
+        "id": "lodash._getnative:3.9.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._createcache:3.1.2",
+                "lodash._basedifference:3.0.3",
+                "lodash.omit:3.1.0",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash._baseassign:3.2.0",
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash._baseisequal:3.0.7",
+                "lodash._basecallback:3.3.1",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash.pairs:3.0.1",
+                "lodash._basecallback:3.3.1",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash._baseeach:3.0.4",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash.sortby:3.1.5",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash.template:3.6.2",
+                "gulp-util:3.0.7",
+                "gulp-babel:6.1.2",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash.keys:3.1.2",
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+        "md5": "a311ce03b077bd8a3b4bfe46776f9035",
+        "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
+    },
+    {
+        "id": "lodash._arrayeach:3.0.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "lodash.merge:3.3.2",
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clone:3.0.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "lodash._baseclone:3.3.0",
+                "lodash.clonedeep:3.0.2",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
+        "md5": "2500bac4195ee774f346d80500ad77ef",
+        "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
+    },
+    {
+        "id": "is-date-object:1.0.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es-to-primitive:1.2.1",
+                "es-abstract:1.20.1",
+                "array-includes:3.1.5",
+                "eslint-plugin-import:2.26.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
+        "md5": "3b3393d413d848d50129f3f80d37e86a",
+        "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
+    },
+    {
+        "id": "esprima:4.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "js-yaml:3.14.1",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "redeyed:2.1.1",
+                "cardinal:2.1.1",
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+        "md5": "c9d44a818c324d707a81b08dd36cd079",
+        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+        "id": "safe-regex:1.1.0",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "regex-not:1.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "to-regex:3.0.2",
+                "micromatch:3.1.10",
+                "readdirp:2.2.1",
+                "chokidar:1.7.0",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "md5": "6729d2a26cdabb856b9506e567bd8a57",
+        "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
+    },
+    {
+        "id": "lodash.clonedeep:3.0.2",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "eslint:1.10.3",
+                "css-lint:1.0.1",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
+        "md5": "dfef3b8bee7adea034e7224d909d92f5",
+        "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
+    },
+    {
+        "id": "code-point-at:1.1.0",
+        "scopes": [
+            "prod"
+        ],
+        "requestedBy": [
+            [
+                "readline2:1.0.1",
+                "inquirer:0.12.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "string-width:1.0.2",
+                "yargs:4.8.1",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
+        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
+    },
+    {
+        "id": "slice-ansi:0.0.4",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "table:3.8.3",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "table:3.7.8",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
+        "md5": "c6a421b62848c96d57d4394964a89162",
+        "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
+    },
+    {
+        "id": "cli-table:0.3.11",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "marked-terminal:3.3.0",
+                "cli-usage:0.1.10",
+                "node-notifier:4.6.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
+        "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
+        "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
+    },
+    {
+        "id": "es6-set:0.1.5",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "es6-map:0.1.5",
+                "escope:3.6.0",
+                "eslint:3.19.0",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
+        "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
+        "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
+    },
+    {
+        "id": "lowercase-keys:1.0.1",
+        "scopes": [
+            "dev"
+        ],
+        "requestedBy": [
+            [
+                "is-get-set-prop:1.0.0",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-obj-prop:1.0.0",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ],
+            [
+                "is-proto-prop:1.0.1",
+                "eslint-plugin-no-use-extend-native:0.3.12",
+                "eslint-config-canonical:1.15.0",
+                "canonical:3.2.1",
+                "pragmatist:3.0.24",
+                "bundle-dependencies"
+            ]
+        ],
+        "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+        "md5": "de9b080b5e473d21200e69b8bfc7c204",
+        "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
     }
 ]

--- a/build/testdata/npm/project4/npmv8/macos/package-lock.json
+++ b/build/testdata/npm/project4/npmv8/macos/package-lock.json
@@ -24,7 +24,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -42,7 +42,7 @@
     "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^3.0.4"
@@ -51,7 +51,7 @@
     "node_modules/acorn-jsx/node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -63,7 +63,7 @@
     "node_modules/ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "dependencies": {
         "co": "^4.6.0",
@@ -73,7 +73,7 @@
     "node_modules/ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "peerDependencies": {
         "ajv": ">=4.10.0"
@@ -82,7 +82,7 @@
     "node_modules/ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -91,7 +91,7 @@
     "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -100,7 +100,7 @@
     "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -109,7 +109,7 @@
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "node_modules/anymatch": {
@@ -134,7 +134,7 @@
     "node_modules/arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "dependencies": {
         "arr-flatten": "^1.0.1"
@@ -155,21 +155,21 @@
     "node_modules/arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -183,35 +183,37 @@
     "node_modules/array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -223,7 +225,7 @@
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -250,7 +252,7 @@
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -261,7 +263,7 @@
     "node_modules/babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
@@ -277,7 +279,7 @@
     "node_modules/babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -286,7 +288,7 @@
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "dependencies": {
         "core-js": "^2.4.0",
@@ -296,7 +298,7 @@
     "node_modules/babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.26.0",
@@ -313,7 +315,7 @@
     "node_modules/babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -358,7 +360,7 @@
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -370,7 +372,7 @@
     "node_modules/base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -408,7 +410,7 @@
     "node_modules/braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "dependencies": {
         "expand-range": "^1.8.1",
@@ -448,7 +450,7 @@
     "node_modules/cache-base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -470,7 +472,7 @@
     "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "dependencies": {
         "callsites": "^0.2.0"
@@ -482,7 +484,7 @@
     "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -491,7 +493,7 @@
     "node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -500,7 +502,7 @@
     "node_modules/canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "bundleDependencies": [
         "babel-eslint",
         "chalk",
@@ -3567,7 +3569,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
@@ -3580,7 +3582,7 @@
     "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -3596,7 +3598,7 @@
     "node_modules/chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
@@ -3638,7 +3640,7 @@
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -3650,7 +3652,7 @@
     "node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3662,7 +3664,7 @@
     "node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3697,7 +3699,7 @@
     "node_modules/class-utils/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3706,7 +3708,7 @@
     "node_modules/cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
@@ -3746,7 +3748,7 @@
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -3757,7 +3759,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -3767,7 +3769,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3776,7 +3778,7 @@
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -3798,13 +3800,13 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
@@ -3813,7 +3815,7 @@
     "node_modules/comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.4"
@@ -3828,7 +3830,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/concat-stream": {
@@ -3849,7 +3851,7 @@
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3859,7 +3861,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -3891,7 +3893,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3900,7 +3902,7 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -3913,15 +3915,19 @@
       "dev": true
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -3940,7 +3946,7 @@
     "node_modules/define-property/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3968,37 +3974,49 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
       }
     },
     "node_modules/es-to-primitive": {
@@ -4019,20 +4037,24 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4043,7 +4065,7 @@
     "node_modules/es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4057,7 +4079,7 @@
     "node_modules/es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4070,7 +4092,7 @@
     "node_modules/es6-set/node_modules/es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4102,7 +4124,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -4111,7 +4133,7 @@
     "node_modules/escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "dependencies": {
         "es6-map": "^0.1.3",
@@ -4126,7 +4148,7 @@
     "node_modules/eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.16.0",
@@ -4175,7 +4197,7 @@
     "node_modules/eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "dependencies": {
         "babel-eslint": "^7.0.0",
@@ -4249,7 +4271,7 @@
     "node_modules/eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=1.0.0"
@@ -4271,9 +4293,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -4281,14 +4303,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "engines": {
         "node": ">=4"
@@ -4300,7 +4322,7 @@
     "node_modules/eslint-plugin-import/node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4321,7 +4343,7 @@
     "node_modules/eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "dependencies": {
         "comment-parser": "^0.4.0",
@@ -4361,7 +4383,7 @@
     "node_modules/eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "dependencies": {
         "is-get-set-prop": "^1.0.0",
@@ -4382,7 +4404,7 @@
     "node_modules/eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "dependencies": {
         "array.prototype.find": "^2.0.1",
@@ -4401,7 +4423,7 @@
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2",
@@ -4500,7 +4522,7 @@
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4510,7 +4532,7 @@
     "node_modules/exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4519,7 +4541,7 @@
     "node_modules/expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "dependencies": {
         "is-posix-bracket": "^0.1.0"
@@ -4531,7 +4553,7 @@
     "node_modules/expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "dependencies": {
         "fill-range": "^2.1.0"
@@ -4558,7 +4580,7 @@
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -4583,7 +4605,7 @@
     "node_modules/extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -4595,13 +4617,13 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5",
@@ -4614,7 +4636,7 @@
     "node_modules/file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "dependencies": {
         "flat-cache": "^1.2.1",
@@ -4634,7 +4656,7 @@
     "node_modules/filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4659,7 +4681,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4686,7 +4708,7 @@
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4695,7 +4717,7 @@
     "node_modules/for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "dependencies": {
         "for-in": "^1.0.1"
@@ -4707,7 +4729,7 @@
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "dependencies": {
         "map-cache": "^0.2.2"
@@ -4719,7 +4741,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -4747,6 +4769,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "inBundle": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -4759,7 +4808,7 @@
     "node_modules/generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "dependencies": {
         "is-property": "^1.0.0"
@@ -4772,14 +4821,14 @@
       "inBundle": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4788,7 +4837,7 @@
     "node_modules/get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4813,22 +4862,22 @@
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4842,7 +4891,7 @@
     "node_modules/glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "dependencies": {
         "glob-parent": "^2.0.0",
@@ -4855,7 +4904,7 @@
     "node_modules/glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "dependencies": {
         "is-glob": "^2.0.0"
@@ -4871,15 +4920,15 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "inBundle": true
     },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "node_modules/has": {
@@ -4897,7 +4946,7 @@
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -4907,9 +4956,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4918,16 +4967,28 @@
     "node_modules/has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4954,7 +5015,7 @@
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.6",
@@ -4968,7 +5029,7 @@
     "node_modules/has-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4977,7 +5038,7 @@
     "node_modules/has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -4990,7 +5051,7 @@
     "node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5002,7 +5063,7 @@
     "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5014,7 +5075,7 @@
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5038,7 +5099,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -5047,7 +5108,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -5063,7 +5124,7 @@
     "node_modules/inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
@@ -5116,7 +5177,7 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5146,7 +5207,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "inBundle": true
     },
     "node_modules/is-bigint": {
@@ -5164,7 +5225,7 @@
     "node_modules/is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
@@ -5208,9 +5269,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "inBundle": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -5281,7 +5342,7 @@
     "node_modules/is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5290,7 +5351,7 @@
     "node_modules/is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "dependencies": {
         "is-primitive": "^2.0.0"
@@ -5302,7 +5363,7 @@
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5311,7 +5372,7 @@
     "node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5320,7 +5381,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "inBundle": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -5332,7 +5393,7 @@
     "node_modules/is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "dependencies": {
         "get-set-props": "^0.1.0",
@@ -5342,7 +5403,7 @@
     "node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -5354,16 +5415,16 @@
     "node_modules/is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "dependencies": {
         "js-types": "^1.0.0"
       }
     },
     "node_modules/is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "node_modules/is-my-json-valid": {
@@ -5394,7 +5455,7 @@
     "node_modules/is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5404,9 +5465,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -5421,7 +5482,7 @@
     "node_modules/is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0",
@@ -5443,7 +5504,7 @@
     "node_modules/is-plain-object/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5452,7 +5513,7 @@
     "node_modules/is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5461,7 +5522,7 @@
     "node_modules/is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5470,7 +5531,7 @@
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "node_modules/is-proto-prop": {
@@ -5506,10 +5567,13 @@
       "dev": true
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5547,7 +5611,7 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "inBundle": true
     },
     "node_modules/is-weakref": {
@@ -5574,19 +5638,19 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -5598,13 +5662,13 @@
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "node_modules/js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5626,7 +5690,7 @@
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "dependencies": {
         "jsonify": "~0.0.0"
@@ -5647,16 +5711,16 @@
     "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5665,7 +5729,7 @@
     "node_modules/jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -5674,7 +5738,7 @@
     "node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5686,7 +5750,7 @@
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "inBundle": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -5698,7 +5762,7 @@
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -5711,7 +5775,7 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5727,7 +5791,7 @@
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "inBundle": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
@@ -5739,7 +5803,7 @@
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5758,19 +5822,19 @@
     "node_modules/lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "node_modules/lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "node_modules/lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "dependencies": {
         "lodash._basecopy": "^3.0.0",
@@ -5780,7 +5844,7 @@
     "node_modules/lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "dependencies": {
         "lodash._arraycopy": "^3.0.0",
@@ -5794,37 +5858,37 @@
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "node_modules/lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "node_modules/lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "inBundle": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "dependencies": {
         "lodash._baseclone": "^3.0.0",
@@ -5834,19 +5898,19 @@
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "node_modules/lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "node_modules/lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0",
@@ -5878,7 +5942,7 @@
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5887,7 +5951,7 @@
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "dependencies": {
         "object-visit": "^1.0.0"
@@ -5963,7 +6027,7 @@
     "node_modules/marked-terminal/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5990,7 +6054,7 @@
     "node_modules/micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "dependencies": {
         "arr-diff": "^2.0.0",
@@ -6012,9 +6076,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6024,9 +6088,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -6055,12 +6119,12 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -6069,19 +6133,19 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -6110,7 +6174,7 @@
     "node_modules/nanomatch/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6119,7 +6183,7 @@
     "node_modules/nanomatch/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6137,13 +6201,13 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node_modules/node-emoji": {
@@ -6158,7 +6222,7 @@
     "node_modules/node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "dependencies": {
         "cli-usage": "^0.1.1",
@@ -6188,7 +6252,7 @@
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
@@ -6200,16 +6264,16 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6218,7 +6282,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6227,7 +6291,7 @@
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "dependencies": {
         "copy-descriptor": "^0.1.0",
@@ -6241,7 +6305,7 @@
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -6253,7 +6317,7 @@
     "node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6265,7 +6329,7 @@
     "node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6298,9 +6362,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6318,7 +6382,7 @@
     "node_modules/object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.0"
@@ -6330,7 +6394,7 @@
     "node_modules/object-visit/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6357,7 +6421,7 @@
     "node_modules/object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "dependencies": {
         "for-own": "^0.1.4",
@@ -6370,7 +6434,7 @@
     "node_modules/object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
@@ -6382,7 +6446,7 @@
     "node_modules/object.pick/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6408,7 +6472,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -6417,7 +6481,7 @@
     "node_modules/onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6443,7 +6507,7 @@
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6452,7 +6516,7 @@
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "inBundle": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -6476,7 +6540,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6488,7 +6552,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6497,7 +6561,7 @@
     "node_modules/parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "dependencies": {
         "glob-base": "^0.3.0",
@@ -6512,7 +6576,7 @@
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "inBundle": true,
       "dependencies": {
         "error-ex": "^1.2.0"
@@ -6524,7 +6588,7 @@
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6533,7 +6597,7 @@
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6542,7 +6606,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6551,7 +6615,7 @@
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "node_modules/path-parse": {
@@ -6563,7 +6627,7 @@
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -6577,7 +6641,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6586,7 +6650,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6595,7 +6659,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "inBundle": true,
       "dependencies": {
         "pinkie": "^2.0.0"
@@ -6607,13 +6671,13 @@
     "node_modules/pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6622,7 +6686,7 @@
     "node_modules/pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "bundleDependencies": [
         "babel-plugin-add-module-exports",
         "babel-plugin-check-es2015-constants",
@@ -10440,7 +10504,7 @@
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -10449,7 +10513,7 @@
     "node_modules/preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10464,7 +10528,7 @@
     "node_modules/progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -10520,7 +10584,7 @@
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "inBundle": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
@@ -10534,7 +10598,7 @@
     "node_modules/read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "inBundle": true,
       "dependencies": {
         "find-up": "^1.0.0",
@@ -10547,7 +10611,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "inBundle": true,
       "dependencies": {
         "path-exists": "^2.0.0",
@@ -10560,7 +10624,7 @@
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "inBundle": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
@@ -10601,7 +10665,7 @@
     "node_modules/readdirp/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10610,7 +10674,7 @@
     "node_modules/readdirp/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10640,7 +10704,7 @@
     "node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10652,7 +10716,7 @@
     "node_modules/readdirp/node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "dev": true,
       "dependencies": {
         "debug": "^2.3.3",
@@ -10670,7 +10734,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -10682,7 +10746,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10736,7 +10800,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -10748,7 +10812,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10760,7 +10824,7 @@
     "node_modules/readdirp/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -10775,7 +10839,7 @@
     "node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10787,7 +10851,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10799,7 +10863,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10811,7 +10875,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10823,7 +10887,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10835,7 +10899,7 @@
     "node_modules/readdirp/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10847,7 +10911,7 @@
     "node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10859,7 +10923,7 @@
     "node_modules/readdirp/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10901,7 +10965,7 @@
     "node_modules/readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -10912,7 +10976,7 @@
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
@@ -10924,7 +10988,7 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "dependencies": {
         "esprima": "~4.0.0"
@@ -10961,10 +11025,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "node_modules/repeat-element": {
@@ -10979,7 +11060,7 @@
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -10988,7 +11069,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10997,13 +11078,13 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
       "inBundle": true
     },
     "node_modules/require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "dependencies": {
         "caller-path": "^0.1.0",
@@ -11014,12 +11095,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "inBundle": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11033,7 +11114,7 @@
     "node_modules/resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11042,14 +11123,14 @@
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
@@ -11083,7 +11164,7 @@
     "node_modules/run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0"
@@ -11092,7 +11173,7 @@
     "node_modules/rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "node_modules/safe-buffer": {
@@ -11104,7 +11185,7 @@
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "dependencies": {
         "ret": "~0.1.10"
@@ -11122,7 +11203,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "inBundle": true
     },
     "node_modules/set-value": {
@@ -11143,7 +11224,7 @@
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11155,7 +11236,7 @@
     "node_modules/shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -11193,7 +11274,7 @@
     "node_modules/slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11235,7 +11316,7 @@
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -11247,7 +11328,7 @@
     "node_modules/snapdragon-node/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11268,7 +11349,7 @@
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11280,7 +11361,7 @@
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11292,7 +11373,7 @@
     "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11304,7 +11385,7 @@
     "node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11339,7 +11420,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11413,13 +11494,13 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "dependencies": {
         "define-property": "^0.2.5",
@@ -11432,7 +11513,7 @@
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11444,7 +11525,7 @@
     "node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11456,7 +11537,7 @@
     "node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11500,7 +11581,7 @@
     "node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "inBundle": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -11512,26 +11593,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11540,7 +11623,7 @@
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "inBundle": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -11552,7 +11635,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11561,7 +11644,7 @@
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11570,7 +11653,7 @@
     "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -11604,7 +11687,7 @@
     "node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11625,7 +11708,7 @@
     "node_modules/table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "dependencies": {
         "ajv": "^4.7.0",
@@ -11637,9 +11720,9 @@
       }
     },
     "node_modules/table/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11648,7 +11731,7 @@
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11670,7 +11753,7 @@
     "node_modules/table/node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -11682,19 +11765,19 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11703,7 +11786,7 @@
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11730,7 +11813,7 @@
     "node_modules/to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -11743,7 +11826,7 @@
     "node_modules/to-regex-range/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11753,14 +11836,14 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -11773,7 +11856,7 @@
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -11785,18 +11868,18 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -11821,7 +11904,7 @@
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "dependencies": {
         "has-value": "^0.3.1",
@@ -11834,7 +11917,7 @@
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.3",
@@ -11848,7 +11931,7 @@
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -11860,7 +11943,7 @@
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11869,7 +11952,7 @@
     "node_modules/unset-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11878,7 +11961,7 @@
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
@@ -11894,7 +11977,7 @@
     "node_modules/user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
@@ -11906,7 +11989,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -11950,13 +12033,13 @@
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
       "inBundle": true
     },
     "node_modules/window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
       "inBundle": true,
       "bin": {
         "window-size": "cli.js"
@@ -11977,7 +12060,7 @@
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -11990,13 +12073,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
@@ -12023,7 +12106,7 @@
     "node_modules/yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "inBundle": true,
       "dependencies": {
         "cliui": "^3.2.0",
@@ -12045,7 +12128,7 @@
     "node_modules/yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "inBundle": true,
       "dependencies": {
         "camelcase": "^3.0.0",
@@ -12057,7 +12140,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "acorn": {
@@ -12069,7 +12152,7 @@
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "requires": {
         "acorn": "^3.0.4"
@@ -12078,7 +12161,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
           "dev": true
         }
       }
@@ -12086,7 +12169,7 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "requires": {
         "co": "^4.6.0",
@@ -12096,31 +12179,31 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "requires": {}
     },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
     "ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "anymatch": {
@@ -12145,7 +12228,7 @@
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1"
@@ -12160,18 +12243,18 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -12179,35 +12262,37 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
     },
     "async-each": {
@@ -12225,7 +12310,7 @@
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
@@ -12236,7 +12321,7 @@
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -12248,7 +12333,7 @@
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -12257,7 +12342,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "requires": {
         "core-js": "^2.4.0",
@@ -12267,7 +12352,7 @@
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -12284,7 +12369,7 @@
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -12323,7 +12408,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -12332,7 +12417,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12366,7 +12451,7 @@
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "requires": {
         "expand-range": "^1.8.1",
@@ -12400,7 +12485,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12418,7 +12503,7 @@
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "requires": {
         "callsites": "^0.2.0"
@@ -12427,18 +12512,18 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
     },
     "canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "dev": true,
       "requires": {
         "babel-eslint": "^6.0.4",
@@ -14818,7 +14903,7 @@
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "requires": {
         "ansicolors": "~0.3.2",
@@ -14828,7 +14913,7 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -14841,7 +14926,7 @@
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
@@ -14876,7 +14961,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -14885,7 +14970,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14894,7 +14979,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14922,7 +15007,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -14930,7 +15015,7 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "requires": {
         "restore-cursor": "^1.0.1"
@@ -14964,7 +15049,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -14974,18 +15059,18 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
@@ -15004,19 +15089,19 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true
     },
     "comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.4"
@@ -15031,7 +15116,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "concat-stream": {
@@ -15049,7 +15134,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
     "core-js": {
@@ -15086,12 +15171,12 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "deep-is": {
@@ -15101,12 +15186,13 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -15122,7 +15208,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15145,31 +15231,43 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -15184,20 +15282,20 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15208,7 +15306,7 @@
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15222,7 +15320,7 @@
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15235,7 +15333,7 @@
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
           "dev": true,
           "requires": {
             "d": "1",
@@ -15269,13 +15367,13 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "requires": {
         "es6-map": "^0.1.3",
@@ -15287,7 +15385,7 @@
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.16.0",
@@ -15330,7 +15428,7 @@
     "eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "requires": {
         "babel-eslint": "^7.0.0",
@@ -15402,7 +15500,7 @@
     "eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "requires": {}
     },
@@ -15416,9 +15514,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -15426,20 +15524,20 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
@@ -15456,7 +15554,7 @@
     "eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.4.0",
@@ -15484,7 +15582,7 @@
     "eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "requires": {
         "is-get-set-prop": "^1.0.0",
@@ -15502,7 +15600,7 @@
     "eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "requires": {
         "array.prototype.find": "^2.0.1",
@@ -15515,7 +15613,7 @@
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -15589,7 +15687,7 @@
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15599,13 +15697,13 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
@@ -15614,7 +15712,7 @@
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
@@ -15640,7 +15738,7 @@
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -15661,7 +15759,7 @@
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -15670,13 +15768,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
@@ -15686,7 +15784,7 @@
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "requires": {
         "flat-cache": "^1.2.1",
@@ -15703,7 +15801,7 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true
     },
     "fill-range": {
@@ -15722,7 +15820,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -15743,13 +15841,13 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
@@ -15758,7 +15856,7 @@
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
@@ -15767,7 +15865,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -15786,6 +15884,24 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -15798,7 +15914,7 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "requires": {
         "is-property": "^1.0.0"
@@ -15810,20 +15926,20 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true
     },
     "get-symbol-description": {
@@ -15839,19 +15955,19 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -15859,7 +15975,7 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
@@ -15869,7 +15985,7 @@
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
@@ -15882,14 +15998,14 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "has": {
@@ -15903,28 +16019,37 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-tostringtag": {
@@ -15939,7 +16064,7 @@
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "requires": {
         "get-value": "^2.0.6",
@@ -15950,7 +16075,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15958,7 +16083,7 @@
     "has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -15968,7 +16093,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15977,7 +16102,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -15988,7 +16113,7 @@
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -16010,13 +16135,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -16032,7 +16157,7 @@
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -16079,7 +16204,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -16101,7 +16226,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -16115,7 +16240,7 @@
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -16144,9 +16269,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -16199,13 +16324,13 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
@@ -16214,19 +16339,19 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -16234,7 +16359,7 @@
     "is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "requires": {
         "get-set-props": "^0.1.0",
@@ -16244,7 +16369,7 @@
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -16253,16 +16378,16 @@
     "is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "requires": {
         "js-types": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "is-my-json-valid": {
@@ -16287,16 +16412,16 @@
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -16305,7 +16430,7 @@
     "is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0",
@@ -16324,7 +16449,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -16332,19 +16457,19 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "is-proto-prop": {
@@ -16374,10 +16499,13 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-string": {
       "version": "1.0.7",
@@ -16400,7 +16528,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -16420,19 +16548,19 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
@@ -16441,13 +16569,13 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true
     },
     "js-yaml": {
@@ -16463,7 +16591,7 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
@@ -16481,25 +16609,25 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true
     },
     "jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
@@ -16508,7 +16636,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -16516,7 +16644,7 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -16526,7 +16654,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -16538,7 +16666,7 @@
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -16548,7 +16676,7 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -16564,19 +16692,19 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -16586,7 +16714,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "requires": {
         "lodash._arraycopy": "^3.0.0",
@@ -16600,36 +16728,36 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "requires": {
         "lodash._baseclone": "^3.0.0",
@@ -16639,19 +16767,19 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -16677,13 +16805,13 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
@@ -16738,7 +16866,7 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -16761,7 +16889,7 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "requires": {
         "arr-diff": "^2.0.0",
@@ -16780,18 +16908,18 @@
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -16816,30 +16944,30 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -16865,13 +16993,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "kind-of": {
@@ -16885,13 +17013,13 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node-emoji": {
@@ -16906,7 +17034,7 @@
     "node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "requires": {
         "cli-usage": "^0.1.1",
@@ -16932,7 +17060,7 @@
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -16941,24 +17069,24 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -16969,7 +17097,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -16978,7 +17106,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -16987,7 +17115,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -17015,9 +17143,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -17029,7 +17157,7 @@
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
@@ -17038,7 +17166,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17058,7 +17186,7 @@
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "requires": {
         "for-own": "^0.1.4",
@@ -17068,7 +17196,7 @@
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -17077,7 +17205,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17096,7 +17224,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -17105,7 +17233,7 @@
     "onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true
     },
     "optionator": {
@@ -17125,13 +17253,13 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -17148,7 +17276,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -17157,13 +17285,13 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
@@ -17175,7 +17303,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -17183,25 +17311,25 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "path-parse": {
@@ -17212,7 +17340,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -17222,17 +17350,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -17240,19 +17368,19 @@
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
     "pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "dev": true,
       "requires": {
         "babel-plugin-add-module-exports": "^0.2.1",
@@ -20211,13 +20339,13 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true
     },
     "process-nextick-args": {
@@ -20229,7 +20357,7 @@
     "progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true
     },
     "proto-props": {
@@ -20272,7 +20400,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -20282,7 +20410,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -20291,7 +20419,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -20300,7 +20428,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -20336,13 +20464,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "braces": {
@@ -20366,7 +20494,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20377,7 +20505,7 @@
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -20392,7 +20520,7 @@
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -20401,7 +20529,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20445,7 +20573,7 @@
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -20454,7 +20582,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20465,7 +20593,7 @@
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -20477,7 +20605,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20488,7 +20616,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20497,7 +20625,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20508,7 +20636,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20517,7 +20645,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20528,7 +20656,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20537,7 +20665,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20548,7 +20676,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         },
         "kind-of": {
@@ -20583,7 +20711,7 @@
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
@@ -20594,7 +20722,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -20603,7 +20731,7 @@
     "redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
@@ -20634,10 +20762,21 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "repeat-element": {
@@ -20649,23 +20788,23 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "requires": {
         "caller-path": "^0.1.0",
@@ -20673,11 +20812,11 @@
       }
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -20685,19 +20824,19 @@
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "requires": {
         "exit-hook": "^1.0.0",
@@ -20722,7 +20861,7 @@
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "requires": {
         "once": "^1.3.0"
@@ -20731,7 +20870,7 @@
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "safe-buffer": {
@@ -20743,7 +20882,7 @@
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
@@ -20757,7 +20896,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -20774,7 +20913,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20785,7 +20924,7 @@
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -20813,7 +20952,7 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true
     },
     "snapdragon": {
@@ -20835,7 +20974,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -20844,7 +20983,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20853,7 +20992,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20862,7 +21001,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20903,7 +21042,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -20912,7 +21051,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -20929,7 +21068,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true
     },
     "source-map-resolve": {
@@ -20991,13 +21130,13 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "requires": {
         "define-property": "^0.2.5",
@@ -21007,7 +21146,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -21016,7 +21155,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21025,7 +21164,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21064,7 +21203,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -21072,29 +21211,31 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -21102,19 +21243,19 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true
     },
     "supports-hyperlinks": {
@@ -21139,7 +21280,7 @@
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
               "dev": true
             }
           }
@@ -21154,7 +21295,7 @@
     "table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "requires": {
         "ajv": "^4.7.0",
@@ -21166,15 +21307,15 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -21190,7 +21331,7 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -21201,25 +21342,25 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -21240,7 +21381,7 @@
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -21250,7 +21391,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21259,14 +21400,14 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -21279,7 +21420,7 @@
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -21288,18 +21429,18 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -21318,7 +21459,7 @@
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "requires": {
         "has-value": "^0.3.1",
@@ -21328,7 +21469,7 @@
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
           "dev": true,
           "requires": {
             "get-value": "^2.0.3",
@@ -21339,7 +21480,7 @@
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -21350,13 +21491,13 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -21364,7 +21505,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "dev": true
     },
     "use": {
@@ -21376,7 +21517,7 @@
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
@@ -21385,7 +21526,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -21422,12 +21563,12 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ=="
     },
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw=="
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -21438,7 +21579,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -21447,13 +21588,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -21473,7 +21614,7 @@
     "yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "requires": {
         "cliui": "^3.2.0",
         "decamelize": "^1.1.1",
@@ -21494,7 +21635,7 @@
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"

--- a/build/testdata/npm/project4/npmv8/windows/excpected_dependencies_list.json
+++ b/build/testdata/npm/project4/npmv8/windows/excpected_dependencies_list.json
@@ -1,12115 +1,12341 @@
 [
     {
-        "id": "fast-levenshtein:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
-        "md5": "443a739d106c51a33470c9f018d82e85",
-        "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
-    },
-    {
-        "id": "chalk:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.8.0",
-                "babel-traverse:6.8.0",
-                "babel-plugin-transform-es2015-block-scoping:6.8.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-code-frame:6.7.7",
-                "babel-traverse:6.7.6",
-                "babel-eslint:6.0.4",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fancy-log:1.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "run-sequence:1.1.5",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
-        "md5": "d7e0f89d6888d5d9ced994c205926555",
-        "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d"
-    },
-    {
-        "id": "lodash._arrayeach:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
-        "md5": "2500bac4195ee774f346d80500ad77ef",
-        "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
-    },
-    {
-        "id": "brace-expansion:1.1.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
-        "md5": "02822e3db48e8c5b844fa309fa2cc56b",
-        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
-    },
-    {
-        "id": "source-map-resolve:0.5.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
-        "md5": "88b0cf532783413eb92e171554ddd28d",
-        "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
-    },
-    {
-        "id": "is-shared-array-buffer:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6",
-        "md5": "262a0c4a277cb35dc227ce4a0f552be1",
-        "sha256": "14b35068e9505161afce57efbd849b33c519d4524f4b2548587d017e51d25897"
-    },
-    {
-        "id": "eslint-plugin-mocha:4.12.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
-        "md5": "3e429cc644ee80c1c60c86478eee616b",
-        "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
-    },
-    {
-        "id": "require-uncached:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
-        "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
-        "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
-    },
-    {
-        "id": "figures:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
-        "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
-        "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
-    },
-    {
-        "id": "cliui:3.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "120601537a916d29940f934da3b48d585a39213d",
-        "md5": "3a83794ba283c15042e429b11802766d",
-        "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
-    },
-    {
-        "id": "is-plain-object:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-extendable:1.0.1",
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
-        "md5": "335972afae19ad1eccb8eee9aad94747",
-        "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
-    },
-    {
-        "id": "is-callable:1.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "47301d58dd0259407865547853df6d61fe471945",
-        "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
-        "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
-    },
-    {
-        "id": "chokidar:1.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
-        "md5": "3b76ca6e8ebf196645910f2985f77385",
-        "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
-    },
-    {
-        "id": "cache-base:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
-        "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
-        "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
-    },
-    {
-        "id": "core-js:2.6.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-runtime:6.26.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
-        "md5": "a1881352eef45832b331dc025db1b72c",
-        "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
-    },
-    {
-        "id": "use:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
-        "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
-        "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
-    },
-    {
-        "id": "path-exists:2.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "md5": "4cc32b19e220e3ca0f4d14844996dc56",
-        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
-    },
-    {
-        "id": "string.prototype.trimend:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e75ae90c2942c63504686c18b287b4a0b1a45f80",
-        "md5": "88b629f9cb3e49990b0fbd7c2c06a4f9",
-        "sha256": "984cce7dab0d22dfe19301aeedfca180c9243c97d16cdd7c0f31c7be744e6710"
-    },
-    {
-        "id": "slice-ansi:0.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
-        "md5": "c6a421b62848c96d57d4394964a89162",
-        "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
-    },
-    {
-        "id": "isexe:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which:1.3.1",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
-        "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
-        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
-    },
-    {
-        "id": "type:2.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ext:1.6.0",
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
-        "md5": "b06b1e937cd3671d147ef4f040fa297d",
-        "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
-    },
-    {
-        "id": "babylon:6.18.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
-        "md5": "c0f769098a62e7881847657d146d9cbe",
-        "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
-    },
-    {
-        "id": "colors:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-table:0.3.11",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
-        "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
-        "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
-    },
-    {
-        "id": "eslint-config-canonical:1.15.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
-        "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
-        "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
-    },
-    {
-        "id": "require-main-filename:1.0.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
-        "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
-        "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
-    },
-    {
-        "id": "parse-glob:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
-        "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
-        "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
-    },
-    {
-        "id": "to-regex:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
-        "md5": "8a6359bf8c570483aad2a767191e87bb",
-        "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
-    },
-    {
-        "id": "decode-uri-component:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
-        "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
-        "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
-    },
-    {
-        "id": "which:1.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
-        "md5": "3077f0c321098e78b78ddd6b4b2789e5",
-        "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
-    },
-    {
-        "id": "is-boolean-object:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
-        "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
-        "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
-    },
-    {
-        "id": "ansi-escapes:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
-        "md5": "7431226bb3f179e8cd7eddf297b904ec",
-        "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
-    },
-    {
-        "id": "object-assign:4.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
-        "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
-        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
-    },
-    {
-        "id": "is-posix-bracket:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:0.1.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
-        "md5": "cd1bc456317e6cf7357683e79b8354c5",
-        "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
-    },
-    {
-        "id": "has-values:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
-        "md5": "b22e4bd0ee56cd167cb12437533618b1",
-        "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
-    },
-    {
-        "id": "es6-set:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
-        "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
-        "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
-    },
-    {
-        "id": "table:3.8.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
-        "md5": "caa5899fd31138fdbe11b2944fdf16e4",
-        "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
-    },
-    {
-        "id": "path-type:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "md5": "e14c138690b623db36532ff609b81b08",
-        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
-    },
-    {
-        "id": "supports-color:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
-        "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
-        "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
-    },
-    {
-        "id": "esprima:4.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "redeyed:2.1.1",
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
-        "md5": "c9d44a818c324d707a81b08dd36cd079",
-        "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
-    },
-    {
-        "id": "word-wrap:1.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
-        "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
-        "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
-    },
-    {
-        "id": "source-map-url:0.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
-        "md5": "db54d6dc84c3bfa7f420da51c493023c",
-        "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
-    },
-    {
-        "id": "ajv:4.11.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv-keywords:1.5.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
-        "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
-        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
-    },
-    {
-        "id": "braces:2.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
-        "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
-        "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
-    },
-    {
-        "id": "map-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
-        "md5": "1911d8539476d5e5b03c42e63a87b49a",
-        "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
-    },
-    {
-        "id": "ansi-regex:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "has-ansi:2.0.0",
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-ansi:3.0.1",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
-        "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
-        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
-    },
-    {
-        "id": "invert-kv:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lcid:1.0.0",
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
-        "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
-        "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
-    },
-    {
-        "id": "os-locale:1.4.0",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "md5": "fdb77de7d9374b72e7f466c27908a730",
-        "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
-    },
-    {
-        "id": "is-number:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
-        "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
-        "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
-    },
-    {
-        "id": "isobject:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-plain-object:2.0.4",
-                "is-extendable:1.0.1",
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.pick:1.3.0",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-visit:1.0.1",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
-        "md5": "9e7647515c0885e809f9aeb22de293f3",
-        "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
-    },
-    {
-        "id": "regenerator-runtime:0.11.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-runtime:6.26.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
-        "md5": "728ac808fb5276bf420fab33620d0c39",
-        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
-    },
-    {
-        "id": "cli-width:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
-        "md5": "c9cf40c64a983c42f8fd91a97542f25e",
-        "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
-    },
-    {
-        "id": "cardinal:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
-        "md5": "876b0338412efe635c487c4bf31a55b1",
-        "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
-    },
-    {
-        "id": "set-blocking:2.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
-        "md5": "ff057cf430b35ecb25780f94cd051ab3",
-        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
-    },
-    {
-        "id": "snapdragon:0.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
-        "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
-        "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
-    },
-    {
-        "id": "is-get-set-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
-        "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
-        "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
-    },
-    {
-        "id": "string-width:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
-        "md5": "b8aa95585646db49430dbaf185daec5d",
-        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
-    },
-    {
-        "id": "is-extendable:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
-        "md5": "61392549d95a063512f916897d7069b7",
-        "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
-    },
-    {
-        "id": "static-extend:0.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
-        "md5": "685c7b45bd48268f9eeffbccecb2d313",
-        "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
-    },
-    {
-        "id": "babel-messages:6.23.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
-        "md5": "f7a22e78d59c180af1175172a3abee40",
-        "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
-    },
-    {
-        "id": "tsconfig-paths:3.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19769aca6ee8f6a1a341e38c8fa45dd9fb18899b",
-        "md5": "864704be71309d70ae4a2045ce17e2e0",
-        "sha256": "99c2bb5ac67ade10dc163b295eabb1b2a827e7857cdfeeccf5c9f8e496af3f81"
-    },
-    {
-        "id": "es6-iterator:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
-        "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
-        "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
-    },
-    {
-        "id": "is-accessor-descriptor:0.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
-        "md5": "988cec0d99237747735bc5d84953a207",
-        "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
-    },
-    {
-        "id": "ignore:3.3.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
-        "md5": "623073ae841f6a00f1d93c50f97065ad",
-        "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
-    },
-    {
-        "id": "micromatch:2.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
-        "md5": "0c6949145be8bb09e5aa63fdebea9c24",
-        "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
-    },
-    {
-        "id": "through:2.3.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
-        "md5": "615296782d4936bd53ebe4e5baa57db7",
-        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
-    },
-    {
-        "id": "debug:3.2.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
-        "md5": "0f887df93ceeaa5784063eb8733a6778",
-        "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
-    },
-    {
-        "id": "js-yaml:3.14.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
-        "md5": "2a522c3e23f7999abd8f852c012c20dd",
-        "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
-    },
-    {
-        "id": "component-emitter:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
-        "md5": "6b8517f3d7ad46e95c97b6d453f82189",
-        "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
-    },
-    {
-        "id": "source-map:0.5.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
-        "md5": "3773f963d18f1aca320fae40b04aded2",
-        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
-    },
-    {
-        "id": "inflight:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
-        "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
-        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
-    },
-    {
-        "id": "lodash._arraycopy:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
-        "md5": "6de9a4e0d113c056078d1db4e75c748b",
-        "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
-    },
-    {
-        "id": "object-inspect:1.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6e2c120e868fd1fd18cb4f18c31741d0d6e776f0",
-        "md5": "3b663a84af220988fe04b4a283676fb0",
-        "sha256": "c172809067d5c1e1a9d02dbef2abbe8e602676c3b78dbe7effd3274dee7d7646"
-    },
-    {
-        "id": "generate-object-property:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
-        "md5": "275dde8134c99f03d9ff31a8fa861f19",
-        "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
-    },
-    {
-        "id": "is-fullwidth-code-point:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
-        "md5": "edbd4281a6ac4fb8d1082592c411f250",
-        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
-    },
-    {
-        "id": "es5-ext:0.10.53",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.1",
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "event-emitter:0.3.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "93c5a3acfdbef275220ad72644ad02ee18368de1",
-        "md5": "fae9645d4e605a9cda5974baa7dc1733",
-        "sha256": "03e3c58089f1bcc66467ee24b4625d39b3279fccf2d937121289f3145e7b6ec2"
-    },
-    {
-        "id": "ms:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:2.6.9",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
-        "md5": "9615634070dd7751f127b2a0fb362484",
-        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
-    },
-    {
-        "id": "es6-weak-map:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
-        "md5": "edb82ccad9f34520dc736bfbc67dc4be",
-        "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
-    },
-    {
-        "id": "lodash._baseclone:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.clonedeep:3.0.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "303519bf6393fe7e42f34d8b630ef7794e3542b7",
-        "md5": "553b734a6902f3363cf41de744286bab",
-        "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549"
-    },
-    {
-        "id": "parse-json:2.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "md5": "9b98b48019fa25c226348737831cf130",
-        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
-    },
-    {
-        "id": "map-cache:0.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fragment-cache:0.2.1",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
-        "md5": "7ed5e46ed67d87ec937cedc485559cb6",
-        "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
-    },
-    {
-        "id": "nanomatch:1.2.13",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
-        "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
-        "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
-    },
-    {
-        "id": "function-bind:1.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has:1.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
-        "md5": "ee976e75439af2b82e707f3a64c69684",
-        "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
-    },
-    {
-        "id": "is-data-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
-        "md5": "d4fe7614279e3f4718d383035209c33e",
-        "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
-    },
-    {
-        "id": "is-glob:4.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-        "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
-        "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
-    },
-    {
-        "id": "color-convert:1.9.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
-        "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
-        "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
-    },
-    {
-        "id": "write:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
-        "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
-        "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
-    },
-    {
-        "id": "ansi-regex:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "strip-ansi:4.0.0",
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
-        "md5": "1cc176457cc56d720f68eaf26b2afe8b",
-        "sha256": "bdadb0d036d35d54a71c47d94b2abfedb595775f41b8137bec044dc5efe43d35"
-    },
-    {
-        "id": "micromatch:3.1.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
-        "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
-        "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
-    },
-    {
-        "id": "es6-symbol:3.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
-        "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
-        "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
-    },
-    {
-        "id": "is-windows:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "md5": "bcc9525ed3558792d281951c90ad366e",
-        "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
-    },
-    {
-        "id": "kind-of:6.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:1.0.0",
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
-        "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
-        "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
-    },
-    {
-        "id": "eslint:3.19.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-babel:3.3.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-flowtype:2.50.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-lodash:2.7.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
-        "md5": "2b28bed1fe16d31f22178145baa90d7a",
-        "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
-    },
-    {
-        "id": "shellwords:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
-        "md5": "406c4d51a834f3ddddfaf96b9303af36",
-        "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
-    },
-    {
-        "id": "find-up:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
-        "md5": "cb9da6343737d03323119847685addf1",
-        "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
-    },
-    {
-        "id": "mute-stream:0.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
-        "md5": "597b34af22c4237293f5c05cd5f74214",
-        "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
-    },
-    {
-        "id": "supports-hyperlinks:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
-        "md5": "ac43da5665ec45c28303793339d60e5f",
-        "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
-    },
-    {
-        "id": "assign-symbols:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extend-shallow:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
-        "md5": "e9bb66200b728da39a79c2f235780331",
-        "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
-    },
-    {
-        "id": "is-data-descriptor:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
-        "md5": "f8d653ce6e504d83c985de8d182f1ae5",
-        "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
-    },
-    {
-        "id": "ramda:0.25.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-mocha:4.12.1",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
-        "md5": "f86f2a632aa11bb7af129304fbe22a67",
-        "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
-    },
-    {
-        "id": "is-extglob:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:0.3.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-glob:2.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
-        "md5": "2abcdb854a7d2b4446afc7b636916db7",
-        "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
-    },
-    {
-        "id": "lowercase-keys:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
-        "md5": "de9b080b5e473d21200e69b8bfc7c204",
-        "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
-    },
-    {
-        "id": "once:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "run-async:0.1.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
-        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
-        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
-    },
-    {
-        "id": "babel-eslint:7.2.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
-        "md5": "85d7580cf18c64e2b1cd165832032bbc",
-        "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
-    },
-    {
-        "id": "esquery:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
-        "md5": "67c3703f159c91ae9bd06b896a863b19",
-        "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
-    },
-    {
-        "id": "array-unique:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
-        "md5": "7b3ac4760380d655957c68e59748f438",
-        "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
-    },
-    {
-        "id": "readdirp:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
-        "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
-        "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
-    },
-    {
-        "id": "lodash.clonedeep:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
-        "md5": "dfef3b8bee7adea034e7224d909d92f5",
-        "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
-    },
-    {
-        "id": "globals:9.18.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
-        "md5": "746bb222029d9fd52336a7503c6e110b",
-        "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
-    },
-    {
-        "id": "buffer-from:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
-        "md5": "5fe5f473dc3263473041a56654581058",
-        "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
-    },
-    {
-        "id": "event-emitter:0.3.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
-        "md5": "5e969bf0d73326a36ab0eede156d48e3",
-        "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
-    },
-    {
-        "id": "is-buffer:1.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "kind-of:3.2.2",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:3.2.2",
-                "is-number:3.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "kind-of:4.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
-        "md5": "374af5d9a1a7e4d3e686419412fa6b72",
-        "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
-    },
-    {
-        "id": "user-home:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
-        "md5": "221f00361d182f5dfd195a7d867307c7",
-        "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
-    },
-    {
-        "id": "binary-extensions:1.13.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-binary-path:1.0.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
-        "md5": "013fed37056567a27186a86285f28efd",
-        "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
-    },
-    {
-        "id": "cli-cursor:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
-        "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
-        "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
-    },
-    {
-        "id": "type:1.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "d:1.0.1",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
-        "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
-        "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
-    },
-    {
-        "id": "string_decoder:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
-        "md5": "7b93eea8153258fea64c3192922effaa",
-        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
-    },
-    {
-        "id": "ansi-styles:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
-        "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
-        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
-    },
-    {
-        "id": "unbox-primitive:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "085e215625ec3162574dc8859abee78a59b14471",
-        "md5": "23d12db3c5ca7db2738571b3e610d09d",
-        "sha256": "dccea4f58520131a5e103a44a7f45e734a0161d7ef7490ba93008afe707eed3e"
-    },
-    {
-        "id": "glob-base:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
-        "md5": "ea2fd4074a1f129431de415f1c5387aa",
-        "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
-    },
-    {
-        "id": "urix:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "source-map-resolve:0.3.1",
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
-        "md5": "dd3921f317a15657fad465fd215fe38d",
-        "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
-    },
-    {
-        "id": "y18n:3.2.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
-        "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
-        "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
-    },
-    {
-        "id": "pragmatist:3.0.24",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
-        "md5": "282125ff6b702db1e05de93b7b866982",
-        "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
-    },
-    {
-        "id": "co:4.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "ajv:4.11.8",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
-        "md5": "b6f068b290c84d37007997c45148ad18",
-        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
-    },
-    {
-        "id": "math-random:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "randomatic:3.1.1",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5dd6943c938548267016d4e34f057583080c514c",
-        "md5": "029796aed5b40e10d30518bc21ad436a",
-        "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
-    },
-    {
-        "id": "is-descriptor:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-property:1.0.0",
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:1.0.0",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:1.0.0",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3b159746a66604b04f8c81524ba365c5f14d86ec",
-        "md5": "7cd33adcb4ca927942b08b261badd3ed",
-        "sha256": "fe5ee7a359c2ae4ec7c12a075d903150c23365bf55c0c471b8d34fade96c6ead"
-    },
-    {
-        "id": "get-intrinsic:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "call-bind:1.0.2",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "15f59f376f855c446963948f0d24cd3637b4abc6",
-        "md5": "dcf91ab5448081811d382dfabad32bb6",
-        "sha256": "5a1b968faf5a6c2c3833e40321641651cbee32e41296e573d84b88ed2fe07b1b"
-    },
-    {
-        "id": "is-arrayish:0.2.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.0",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "error-ex:1.3.2",
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
-        "md5": "4bbbacda455ab73d86f5eda908989f24",
-        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
-    },
-    {
-        "id": "ansicolors:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979",
-        "md5": "9a8ff703d6072578025a1a324c9005d1",
-        "sha256": "b8e260ab45c01049f6a58029b723935bcef0cb28e62888e412f217bfd4e228ef"
-    },
-    {
-        "id": "arr-diff:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
-        "md5": "42ec151186ae4bd9980a212083d98bbe",
-        "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
-    },
-    {
-        "id": "kind-of:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20813df3d712928b207378691a45066fae72dd57",
-        "md5": "e24d0d555965b239fb2b6435b0724853",
-        "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
-    },
-    {
-        "id": "text-table:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
-        "md5": "4e595139988957453229d6ccd229f626",
-        "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
-    },
-    {
-        "id": "lodash._bindcallback:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.clonedeep:3.0.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createassigner:3.1.1",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
-        "md5": "20bfe15e77fe081ff95fa92c73f0699e",
-        "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
-    },
-    {
-        "id": "ajv-keywords:1.5.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
-        "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
-        "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
-    },
-    {
-        "id": "for-in:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "for-own:0.1.5",
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mixin-deep:1.3.2",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
-        "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
-        "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
-    },
-    {
-        "id": "eslint-import-resolver-node:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
-        "md5": "bf0a201e44f3e437813f10b97923f452",
-        "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
-    },
-    {
-        "id": "lodash._basefor:3.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.isplainobject:3.2.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._pickbycallback:3.0.0",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
-        "md5": "e0118d593252e3902b3769f0ff775d04",
-        "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
-    },
-    {
-        "id": "supports-preserve-symlinks-flag:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
-        "md5": "2ecf7c03c814ab155c5278d61f65583f",
-        "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
-    },
-    {
-        "id": "fill-range:2.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
-        "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
-        "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
-    },
-    {
-        "id": "jsx-ast-utils:1.4.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
-        "md5": "704aebceee728c9e0120486622b35790",
-        "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
-    },
-    {
-        "id": "onetime:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
-        "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
-        "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
-    },
-    {
-        "id": "proto-props:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-proto-prop:1.0.1",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
-        "md5": "43c4cc31101ee8f37df9b66ff8353003",
-        "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
-    },
-    {
-        "id": "arr-diff:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
-        "md5": "5aa32e7c03b612d64d433306ecfcd392",
-        "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
-    },
-    {
-        "id": "is-equal-shallow:0.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
-        "md5": "79abafbc68151c75a7242adf69c9b7c5",
-        "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
-    },
-    {
-        "id": "mixin-deep:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
-        "md5": "53fb379c1187b97eecfcf06399958566",
-        "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
-    },
-    {
-        "id": "pify:2.3.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
-        "md5": "475310192b9d153240ac82eb66b827e8",
-        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
-    },
-    {
-        "id": "xtend:4.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
-        "md5": "183e6eef1df0529fd39bd932447ba547",
-        "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
-    },
-    {
-        "id": "is-binary-path:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
-        "md5": "a989667cf8d696127090b72fe8a674b3",
-        "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
-    },
-    {
-        "id": "fill-range:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
-        "md5": "35483acae8b070dad60c41a99afe6b4d",
-        "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
-    },
-    {
-        "id": "comment-parser:0.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
-        "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
-        "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
-    },
-    {
-        "id": "normalize-path:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
-        "md5": "b2f3932160dc03a5604dbac60ef59c34",
-        "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
-    },
-    {
-        "id": "exit-hook:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "restore-cursor:1.0.1",
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
-        "md5": "d6ad3b683bee91b5a117990d68a097dd",
-        "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
-    },
-    {
-        "id": "number-is-nan:1.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "is-fullwidth-code-point:1.0.0",
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "097b602b53422a522c1afb8790318336941a011d",
-        "md5": "1c192095065e6b72a7e20a747b110469",
-        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
-    },
-    {
-        "id": "strip-bom:2.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "md5": "3fa008815fc843fd20aa6f15330ebcfb",
-        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
-    },
-    {
-        "id": "deep-is:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
-        "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
-        "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
-    },
-    {
-        "id": "is-date-object:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
-        "md5": "3b3393d413d848d50129f3f80d37e86a",
-        "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
-    },
-    {
-        "id": "resolve:1.22.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "rechoir:0.6.2",
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5e0b8c67c15df57a89bdbabe603a002f21731198",
-        "md5": "aaf15861cf0f8af2222bd383a475bc28",
-        "sha256": "06536fa0cbfbf8d6b2d5e6971437f4eb02110c84961b698d1b8ba5c6ae8f760d"
-    },
-    {
-        "id": "extglob:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
-        "md5": "c8be79678101bbc03ea2018b80a8ac0a",
-        "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
-    },
-    {
-        "id": "arr-union:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
-        "md5": "f3cf2ebd1f4051917051f0c2b9287954",
-        "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
-    },
-    {
-        "id": "cli-table:0.3.11",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
-        "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
-        "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
-    },
-    {
-        "id": "ansi-escapes:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
-        "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
-        "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
-    },
-    {
-        "id": "prelude-ls:1.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "levn:0.2.5",
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "type-check:0.3.2",
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "type-check:0.3.2",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
-        "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
-        "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
-    },
-    {
-        "id": "get-value:2.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
-        "md5": "b45bf08107e22e624dade29284abd265",
-        "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
-    },
-    {
-        "id": "eslint-plugin-lodash:2.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
-        "md5": "7673c712d2af4c5fdc07ae78775670d6",
-        "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
-    },
-    {
-        "id": "has-value:0.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
-        "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
-        "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
-    },
-    {
-        "id": "os-homedir:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "user-home:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
-        "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
-        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
-    },
-    {
-        "id": "read-pkg:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "md5": "c35de6ee14fc66999d84a2e20bdd478b",
-        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
-    },
-    {
-        "id": "cli-usage:0.1.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
-        "md5": "9f20b9678f9a13b909660a21fee052a4",
-        "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
-    },
-    {
-        "id": "canonical:3.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
-        "md5": "a92c480423bdf2a2773e91c283b74ad8",
-        "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
-    },
-    {
-        "id": "lodash.keys:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
-        "md5": "d2aa104b88db88e2c0f1ed627031ed03",
-        "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
-    },
-    {
-        "id": "has-flag:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
-        "md5": "7ba03f6b47769f2acdc743ac0b23e339",
-        "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
-    },
-    {
-        "id": "caller-path:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
-        "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
-        "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
-    },
-    {
-        "id": "circular-json:0.3.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
-        "md5": "5569f191dea3cd5f952867196e41e050",
-        "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
-    },
-    {
-        "id": "is-regex:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
-        "md5": "13a02d0abc63ff0093ca592e999f713c",
-        "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
-    },
-    {
-        "id": "error-ex:1.3.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "parse-json:2.2.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
-        "md5": "5d2c673565060037f9e04d7975d04feb",
-        "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
-    },
-    {
-        "id": "es-abstract:1.19.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d4885796876916959de78edaa0df456627115ec3",
-        "md5": "11444142629b2eb1c6cc47907ca74f1f",
-        "sha256": "10fd94f8d892b32a91429bb7be44e1256d891c69467ae522e79bd6400f8946bc"
-    },
-    {
-        "id": "extend-shallow:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "split-string:3.1.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
-        "md5": "194095206e18756d832f5e0ad3d71cb8",
-        "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
-    },
-    {
-        "id": "internal-slot:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
-        "md5": "01f7b7499f71622547496b12f902bec8",
-        "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
-    },
-    {
-        "id": "doctrine:1.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
-        "md5": "8628b3ac690236d809939b9c3ec2531c",
-        "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
-    },
-    {
-        "id": "escape-string-regexp:1.0.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "figures:1.7.0",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
-        "md5": "02440084832abe665260d5db1da1dd9e",
-        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
-    },
-    {
-        "id": "path-is-inside:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "365417dede44430d1c11af61027facf074bdfc53",
-        "md5": "8f27701be0f4d4da9534227663ae61ed",
-        "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d"
-    },
-    {
-        "id": "chalk:2.4.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
-        "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
-        "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
-    },
-    {
-        "id": "define-properties:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
-        "md5": "d06819a7b947f1b335da2f41519994ac",
-        "sha256": "5524f4db15bb95af92c791ba208e2fc774bd8ae17eb347865492d444f95a70a5"
-    },
-    {
-        "id": "restore-cursor:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cli-cursor:1.0.2",
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34661f46886327fed2991479152252df92daa541",
-        "md5": "99b769f599ac64ecf9027f8717f01bb0",
-        "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
-    },
-    {
-        "id": "file-entry-cache:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
-        "md5": "329f8f032842d7a2c711bd18423e5226",
-        "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
-    },
-    {
-        "id": "kind-of:3.2.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-number:2.1.0",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon-util:3.0.1",
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number:3.0.0",
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-object-path:0.3.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-accessor-descriptor:0.1.6",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-data-descriptor:0.1.4",
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
-        "md5": "c46cdfc40c94b44938f30b7254194d92",
-        "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47"
-    },
-    {
-        "id": "p-locate:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "20a0103b222a70c8fd39cc2e580680f3dde5ec43",
-        "md5": "1dd1c9d3ebad6ad80815da62a0d3cf43",
-        "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46"
-    },
-    {
-        "id": "natural-compare:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
-        "md5": "210787ea3f1a715dd963317ebfc5193f",
-        "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
-    },
-    {
-        "id": "escope:3.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
-        "md5": "9390f529580d458bc659af81607d7114",
-        "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
-    },
-    {
-        "id": "run-async:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
-        "md5": "05b4c27dcef5296aff906af32f377494",
-        "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
-    },
-    {
-        "id": "class-utils:0.3.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
-        "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
-        "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
-    },
-    {
-        "id": "has-ansi:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
-        "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
-        "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
-    },
-    {
-        "id": "loose-envify:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "invariant:2.2.4",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
-        "md5": "5e78d5f6b1ad3ecce9605936059d087e",
-        "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
-    },
-    {
-        "id": "levn:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
-        "md5": "824680de0ed2dabe2745e88737723963",
-        "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
-    },
-    {
-        "id": "babel-types:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
-        "md5": "d12869e767169377af311247a2d247e9",
-        "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
-    },
-    {
-        "id": "define-property:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
-        "md5": "2751868d9fa31ebbbe851fdcb729115d",
-        "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
-    },
-    {
-        "id": "object.assign:4.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
-        "md5": "87b8da296ced17d6e062b791d48ed38b",
-        "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
-    },
-    {
-        "id": "acorn:5.7.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
-        "md5": "861b7e390cd4b067b90229f4b9eec0c9",
-        "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
-    },
-    {
-        "id": "mkdirp:0.5.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "write:0.2.1",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d91cefd62d1436ca0f41620e251288d420099def",
-        "md5": "7e445b65cc532ae036e685117d5fe44d",
-        "sha256": "4e5ab01a61e329dd14d4020ce846e3abd93ee79b0f788f22fd5d5b4a61b1bb0a"
-    },
-    {
-        "id": "safe-regex:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
-        "md5": "6729d2a26cdabb856b9506e567bd8a57",
-        "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
-    },
-    {
-        "id": "lodash._baseassign:3.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
-        "md5": "2438792bc711256968416ae0164b5dd9",
-        "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
-    },
-    {
-        "id": "fragment-cache:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
-        "md5": "14306688d4947a100f6cce5b00d07afd",
-        "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
-    },
-    {
-        "id": "has:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-core-module:2.8.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
-        "md5": "b765203b0d733534ee6a58d84767223a",
-        "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
-    },
-    {
-        "id": "glob-parent:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
-        "md5": "7dc0b2d10ed856934e289df5e1f12c59",
-        "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
-    },
-    {
-        "id": "hosted-git-info:2.8.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
-        "md5": "e50583bc39341b531466e5de5b6aef94",
-        "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
-    },
-    {
-        "id": "invariant:2.2.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
-        "md5": "445e70b75ab7215bc0da1fbaa36113cd",
-        "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
-    },
-    {
-        "id": "code-point-at:1.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "readline2:1.0.1",
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
-        "md5": "c214d9956b6b675ad837e76eecfc2d4b",
-        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
-    },
-    {
-        "id": "split-string:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
-        "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
-        "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
-    },
-    {
-        "id": "lodash.assign:4.2.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
-        "md5": "5a92447d4e8669abba120d5164892902",
-        "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
-    },
-    {
-        "id": "is-number-object:1.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a7aaf838c7f0686a50b4553f7e54a96494e89f0",
-        "md5": "b9541523302c3dcfc0ed3f819496057c",
-        "sha256": "0d6833a8c4f62895368ccb95fbd08ba8a6ff9124974aba410a58ad9104cc6683"
-    },
-    {
-        "id": "randomatic:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
-        "md5": "da226719644d2e64d1127424e028f827",
-        "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
-    },
-    {
-        "id": "ansi-styles:2.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
-        "md5": "deb5e5008ca69027719588d723cf9f91",
-        "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
-    },
-    {
-        "id": "lodash.isarray:3.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.isplainobject:3.2.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.toplainobject:3.0.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseflatten:3.1.4",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash._pickbycallback:3.0.0",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keysin:3.0.8",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
-        "md5": "ac707272f6b31e82622b1d581110aec2",
-        "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd"
-    },
-    {
-        "id": "string.prototype.trimstart:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b36399af4ab2999b4c9c648bd7a3fb2bb26feeed",
-        "md5": "ad7c83cedfcdcafa713e957c027893c6",
-        "sha256": "8f5bffcc06a218d0106e9aba6216621e4f7e12667470e9b25d1ae3d4b13be75a"
-    },
-    {
-        "id": "generate-function:2.3.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f069617690c10c868e73b8465746764f97c3479f",
-        "md5": "b4fd862f79a3a0a097ea8818a5858d22",
-        "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
-    },
-    {
-        "id": "callsites:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "caller-path:0.1.0",
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
-        "md5": "b6e9bfb992503522ddaee4e965423faa",
-        "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
-    },
-    {
-        "id": "find-up:1.1.2",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
-        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
-    },
-    {
-        "id": "node-emoji:1.11.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
-        "md5": "40310f4209362a8df02af58dac079c7d",
-        "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
-    },
-    {
-        "id": "decamelize:1.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:3.10.0",
-                "uglify-js:2.6.2",
-                "handlebars:4.0.5",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "meow:3.7.0",
-                "dateformat:1.0.12",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
-        "md5": "330932e4de0e60c36114facb6d3dfafa",
-        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
-    },
-    {
-        "id": "has-flag:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "supports-color:5.5.0",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "supports-color:5.5.0",
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
-        "md5": "1fa1fa951639c7058277abcecca86922",
-        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
-    },
-    {
-        "id": "lodash.isarguments:3.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
-        "md5": "5aee2d8dc451d10cdc97666d9964074d",
-        "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
-    },
-    {
-        "id": "is-primitive:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-equal-shallow:0.1.3",
-                "regex-cache:0.4.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "207bab91638499c07b2adf240a41a87210034575",
-        "md5": "73402009e3936aeaa7b5c473d090b017",
-        "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
-    },
-    {
-        "id": "is-string:1.0.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
-        "md5": "a7cc7f159a13b20e5fa93015d6124705",
-        "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
-    },
-    {
-        "id": "object-keys:1.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-properties:1.1.3",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
-        "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
-        "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
-    },
-    {
-        "id": "pinkie:2.0.4",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pinkie-promise:2.0.1",
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pinkie-promise:2.0.1",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
-        "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
-        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
-    },
-    {
-        "id": "has-symbols:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-symbol:1.0.4",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-intrinsic:1.1.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-tostringtag:1.0.0",
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "165d3070c00309752a1236a479331e3ac56f1423",
-        "md5": "6fa03a33b382263eedbbdc38c48cd24b",
-        "sha256": "005c4ea47993c807c8a535827b56db30dde39400e918c424fc3de1cc3eb165dd"
-    },
-    {
-        "id": "path-is-absolute:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
-        "md5": "18bfccb10294ae19e7eb616ed1c05176",
-        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
-    },
-    {
-        "id": "for-own:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
-        "md5": "6b95dc29fcffc91036164869c724d05b",
-        "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
-    },
-    {
-        "id": "snapdragon-node:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
-        "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
-        "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
-    },
-    {
-        "id": "set-value:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
-        "md5": "b1e945fff7d8430e86066db678ca6390",
-        "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
-    },
-    {
-        "id": "rechoir:0.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "liftoff:2.2.1",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
-        "md5": "9a0aa4db2a887a452ef08921160c7eb4",
-        "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
-    },
-    {
-        "id": "color-name:1.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "color-convert:1.9.3",
-                "ansi-styles:3.2.1",
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
-        "md5": "b45186c4fe76a2450ec484149ade0066",
-        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
-    },
-    {
-        "id": "typedarray:0.0.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
-        "md5": "54a18bcd7fd55c812993e9ce90a0709d",
-        "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
-    },
-    {
-        "id": "resolve-url:0.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "source-map-resolve:0.3.1",
-                "css:2.2.1",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
-        "md5": "b515d6d96cd554cb0cda158563e82e00",
-        "sha256": "88e9cb578b6373125c416cacb9f42c4896fe3e072e4b94ba6948cba70e551824"
-    },
-    {
-        "id": "@types/json5:0.0.29",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
-        "md5": "b2b856287e2f65c5298b7747332bb633",
-        "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
-    },
-    {
-        "id": "esutils:2.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:2.1.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
-        "md5": "fbea0e3ececd72f8135013e599bb44b3",
-        "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
-    },
-    {
-        "id": "optionator:0.8.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
-        "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
-        "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
-    },
-    {
-        "id": "eslint-plugin-import:2.25.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "322f3f916a4e9e991ac7af32032c25ce313209f1",
-        "md5": "441bc6892fc8ba6a5b335b241d27954b",
-        "sha256": "96d40d97f89261c792a276dc515c20fafbbc4c2e24d6e51d34a53b700957021d"
-    },
-    {
-        "id": "is-number:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
-        "md5": "16a0b10f0dab47199d6536d319c0c6d5",
-        "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
-    },
-    {
-        "id": "eslint-plugin-promise:3.8.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
-        "md5": "ba6f09078795c4b8612de3a95a483603",
-        "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
-    },
-    {
-        "id": "load-json-file:1.1.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
-        "md5": "939784db9c3c72c26262cebef2f9b631",
-        "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
-    },
-    {
-        "id": "core-util-is:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
-        "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
-        "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
-    },
-    {
-        "id": "json-stable-stringify:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "ajv:4.11.8",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
-        "md5": "7712931a8d538cad6e4beaccd491cbb2",
-        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
-    },
-    {
-        "id": "fs.realpath:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
-        "md5": "9f790d7180667e1d8d1110f2cf321b62",
-        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
-    },
-    {
-        "id": "graceful-fs:4.2.9",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "041b05df45755e587a24942279b9d113146e1c96",
-        "md5": "e387a6dfac11fd5d79bd2718100e08b6",
-        "sha256": "16677911bf936576c5c73447657a30b4c535ddf8dc2fa0c8109ae93fa9319f0a"
-    },
-    {
-        "id": "is-glob:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-base:0.3.0",
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob-parent:2.0.0",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
-        "md5": "094686a7618e52db5f126af328da6aff",
-        "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
-    },
-    {
-        "id": "normalize-package-data:2.5.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
-        "md5": "b46c083aa373a30b8d2421e9f269d543",
-        "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
-    },
-    {
-        "id": "rx-lite:3.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
-        "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
-        "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
-    },
-    {
-        "id": "has-tostringtag:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-date-object:1.0.5",
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-number-object:1.0.6",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-string:1.0.7",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
-        "md5": "25e5a30ea25da9a3e5cf67924512233a",
-        "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
-    },
-    {
-        "id": "string-width:1.0.2",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
-        "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
-        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
-    },
-    {
-        "id": "isobject:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
-        "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
-        "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
-    },
-    {
-        "id": "get-caller-file:1.0.3",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
-        "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
-        "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
-    },
-    {
-        "id": "side-channel:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
-        "md5": "abcc258cdccfd0db4007c7be3888d7df",
-        "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
-    },
-    {
-        "id": "which-boxed-primitive:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "13757bc89b209b049fe5d86430e21cf40a89a8e6",
-        "md5": "2d84f8bed229309416dffff93d5028cd",
-        "sha256": "4a4017ba9103fed80bc3ec67c529ed43b38066a626dd9595d91a57cf0c5e089d"
-    },
-    {
-        "id": "util-deprecate:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
-        "md5": "280e304a953ba3a89f52cc6ad616b284",
-        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
-    },
-    {
-        "id": "braces:1.8.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
-        "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
-        "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
-    },
-    {
-        "id": "lodash._getnative:3.9.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._createcache:3.1.2",
-                "lodash._basedifference:3.0.3",
-                "lodash.omit:3.1.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseisequal:3.0.7",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.pairs:3.0.1",
-                "lodash._basecallback:3.3.1",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseeach:3.0.4",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.sortby:3.1.5",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.keys:3.1.2",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
-        "md5": "a311ce03b077bd8a3b4bfe46776f9035",
-        "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
-    },
-    {
-        "id": "eslint-module-utils:2.7.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
-        "md5": "b209efc416d3e5b3f9b15c9177a19fec",
-        "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
-    },
-    {
-        "id": "spdx-expression-parse:3.0.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
-        "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
-        "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
-    },
-    {
-        "id": "glob:7.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "rimraf:2.6.3",
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d15535af7732e02e948f4c41628bd910293f6023",
-        "md5": "05f5ea4a12aecafd90fe04c32385ce80",
-        "sha256": "f6ee73de2fedc6931cbe3df9f8a7d8fd34e8a869ca2e8c8b624e9ea2647a051b"
-    },
-    {
-        "id": "require-directory:2.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
-        "md5": "f3a9010155b6a46066afbe2d07f624bd",
-        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
-    },
-    {
-        "id": "get-set-props:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-get-set-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
-        "md5": "ae71d26ef14801348a804a1b2e987ed9",
-        "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
-    },
-    {
-        "id": "is-proto-prop:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
-        "md5": "78443d3b543426fda71dfcb27111473b",
-        "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
-    },
-    {
-        "id": "inherits:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
-        "md5": "bf725b87e6485c1d9db0279cce76a4a7",
-        "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
-    },
-    {
-        "id": "extglob:2.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
-        "md5": "5e368678ebf35fe8dbaa173517e7adc1",
-        "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
-    },
-    {
-        "id": "to-object-path:0.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
-        "md5": "ed213d48acc6db7b01883673013ba398",
-        "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
-    },
-    {
-        "id": "spdx-correct:3.1.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
-        "md5": "bd668e9b71960e76e867c11ec3ec2982",
-        "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
-    },
-    {
-        "id": "is-js-type:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
-        "md5": "89c1378f5a53fec687827f000e40d29b",
-        "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
-    },
-    {
-        "id": "eslint-plugin-babel:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
-        "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
-        "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
-    },
-    {
-        "id": "d:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-iterator:2.0.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.1",
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "event-emitter:0.3.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es6-weak-map:2.0.3",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8698095372d58dbee346ffd0c7093f99f8f9eb5a",
-        "md5": "34f0b6b6c919df899c7c240deb36deed",
-        "sha256": "e7fb647f7a114c2f5bc547454b043c29dd13de095dc6f476b883b266993918a9"
-    },
-    {
-        "id": "to-regex-range:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
-        "md5": "5ad83eab061e092ad457387b4317ed45",
-        "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
-    },
-    {
-        "id": "expand-brackets:2.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
-        "md5": "a49099d108479157c6efcc4b739a00b2",
-        "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
-    },
-    {
-        "id": "posix-character-classes:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
-        "md5": "1fc17a88bddf7099b36179e8acbb68e9",
-        "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
-    },
-    {
-        "id": "is-core-module:2.8.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f59fdfca701d5879d0a6b100a40aa1560ce27211",
-        "md5": "b7203baea21d3312e5c49f374855b4b3",
-        "sha256": "a5476c788ef83b7ff627631136a2dfefe49e0f3c6ed00bee6ec426223c751e20"
-    },
-    {
-        "id": "readable-stream:2.3.7",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "comment-parser:0.4.2",
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "concat-stream:1.6.2",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
-        "md5": "f060c259b513e887f551d073950f12f9",
-        "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
-    },
-    {
-        "id": "is-resolvable:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
-        "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
-        "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
-    },
-    {
-        "id": "filename-regex:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
-        "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
-        "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
-    },
-    {
-        "id": "semver:5.7.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
-        "md5": "99453010ab0aad4c49dba769e6193c35",
-        "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
-    },
-    {
-        "id": "is-weakref:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
-        "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
-        "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
-    },
-    {
-        "id": "expand-range:1.8.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
-        "md5": "b9375c64d875584bb5bf5a4829007f32",
-        "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
-    },
-    {
-        "id": "array.prototype.flat:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "07e0975d84bbc7c48cd1879d609e682598d33e13",
-        "md5": "97648174e504c24169cf0eda8f034788",
-        "sha256": "846fec18a5be9e6f972b366954db8b98812ee8b8873592b364a7a3e54dcb19bb"
-    },
-    {
-        "id": "window-size:0.2.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
-        "md5": "250499d281e44d2783aec6cfc458e96a",
-        "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
-    },
-    {
-        "id": "is-number:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "has-values:1.0.0",
-                "has-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
-        "md5": "fb4c6b1ce591089d5da379104d9455b8",
-        "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
-    },
-    {
-        "id": "readline2:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
-        "md5": "4e61bfb7db0673cc96401d5c3eea081c",
-        "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
-    },
-    {
-        "id": "remove-trailing-separator:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "normalize-path:2.1.1",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
-        "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
-        "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
-    },
-    {
-        "id": "async-each:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
-        "md5": "c1130142d7ed405602b1fc38d811e360",
-        "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
-    },
-    {
-        "id": "concat-stream:1.6.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
-        "md5": "f3d719f26732b5206541e52972316e84",
-        "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
-    },
-    {
-        "id": "snapdragon-util:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
-        "md5": "17c194e41dd12d561800985ef5b4ffdf",
-        "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
-    },
-    {
-        "id": "define-property:0.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
-        "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
-        "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
-    },
-    {
-        "id": "is-negative-zero:2.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
-        "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
-        "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
-    },
-    {
-        "id": "has-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
-        "md5": "0f5d46e9619fa36d9930f590ef96844b",
-        "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
-    },
-    {
-        "id": "spdx-license-ids:3.0.11",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-correct:3.1.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
-        "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
-        "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
-    },
-    {
-        "id": "anymatch:1.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
-        "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
-        "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
-    },
-    {
-        "id": "yargs:4.8.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
-        "md5": "964f012a6509b1b431de5f58a11e061a",
-        "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
-    },
-    {
-        "id": "shelljs:0.7.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
-        "md5": "476ea3b109ecf2179be8b78b444245d0",
-        "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
-    },
-    {
-        "id": "doctrine:2.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
-        "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
-        "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
-    },
-    {
-        "id": "is-extglob:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-glob:4.0.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-        "md5": "f84c2f17059e807664dd8e3acc0c34c5",
-        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
-    },
-    {
-        "id": "object.values:1.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
-        "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
-        "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
-    },
-    {
-        "id": "path-parse:1.0.7",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "resolve:1.22.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
-        "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
-        "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
-    },
-    {
-        "id": "is-accessor-descriptor:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:1.0.2",
-                "define-property:2.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
-        "md5": "71d1d01f8028c245544a9a1217fb2bce",
-        "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
-    },
-    {
-        "id": "jsonpointer:5.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f802669a524ec4805fa7389eadbc9921d5dc8072",
-        "md5": "463322a0a00674acd3366d4c3bfd152f",
-        "sha256": "5d92ea00b9af9a6eadf29006039b37c7612d1c02ca17fcc142b4ceb30be75f4c"
-    },
-    {
-        "id": "interpret:1.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "shelljs:0.7.8",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
-        "md5": "9d7dec2c46613400992e6b9ed13175c1",
-        "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
-    },
-    {
-        "id": "lcid:1.0.0",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "os-locale:1.4.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "os-locale:1.4.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "md5": "33e24746875ebbcc37c40c7297388609",
-        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
-    },
-    {
-        "id": "rimraf:2.6.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "flat-cache:1.3.4",
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
-        "md5": "bd58522df35ee7b727430b41720e912d",
-        "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
-    },
-    {
-        "id": "yargs-parser:2.4.1",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
-        "md5": "3ed28206e170b6c0cf902511c2d0534b",
-        "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
-    },
-    {
-        "id": "get-symbol-description:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
-        "md5": "e14a4c666fa15e9f9173046700ead218",
-        "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
-    },
-    {
-        "id": "array.prototype.find:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6abbd0c2573925d8094f7d23112306af8c16d534",
-        "md5": "bd2ad5f97c8a124851aa316833fb8dd7",
-        "sha256": "f35b78cc51239d0c6edcc59872e03487a401d2ea995065a0526386e38a80baea"
-    },
-    {
-        "id": "babel-runtime:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-messages:6.23.0",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
-        "md5": "f791f7898733e02f7216de5d6d6a1602",
-        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
-    },
-    {
-        "id": "camelcase:3.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs-parser:2.4.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
-        "md5": "d9d2d730959290cbbb9ef3900cd6126c",
-        "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
-    },
-    {
-        "id": "es6-map:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
-        "md5": "98c9ef67294b8213745a30395f4a62b5",
-        "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
-    },
-    {
-        "id": "ms:2.1.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "debug:3.2.7",
-                "eslint-import-resolver-node:0.3.6",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "debug:3.2.7",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
-        "md5": "a50e4bf82f754914316bfca3dfbcf352",
-        "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
-    },
-    {
-        "id": "define-property:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon-node:2.1.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
-        "md5": "8a6929a07bffc6c4c16bb506e31834c1",
-        "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
-    },
-    {
-        "id": "expand-brackets:0.1.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
-        "md5": "15d774bbd64fa32c2c427854bf58143b",
-        "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
-    },
-    {
-        "id": "type-check:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "levn:0.2.5",
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.6.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "levn:0.3.0",
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "optionator:0.8.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
-        "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
-        "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
-    },
-    {
-        "id": "spdx-exceptions:2.3.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "spdx-expression-parse:3.0.1",
-                "validate-npm-package-license:3.0.4",
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
-        "md5": "acbb50a4dc418357a51310b852eb2e38",
-        "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
-    },
-    {
-        "id": "node-notifier:4.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
-        "md5": "0f04f7a88ceff67961e4277485727ce9",
-        "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
-    },
-    {
-        "id": "js-types:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-js-type:2.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
-        "md5": "60cccf96110592ca167c2c9b98155a45",
-        "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
-    },
-    {
-        "id": "is-my-ip-valid:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7b351b8e8edd4d3995d4d066680e664d94696824",
-        "md5": "933f3e907a361ef18be30c70737b7808",
-        "sha256": "5ffa08e4ea7c36daf2ab805d31f678457823c347262856f9d819b5d99ee53e24"
-    },
-    {
-        "id": "which-module:1.0.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
-        "md5": "004cd541632e781023b01a91b2d4b851",
-        "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
-    },
-    {
-        "id": "argparse:1.0.10",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
-        "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
-        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
-    },
-    {
-        "id": "debug:2.6.9",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
-        "md5": "cb6cb63ab5843aee3af94d27c60ea476",
-        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
-    },
-    {
-        "id": "is-my-json-valid:2.20.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
-        "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
-        "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
-    },
-    {
-        "id": "to-fast-properties:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
-        "md5": "eb323816b9903f0e6877898c3065da5b",
-        "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
-    },
-    {
-        "id": "is-descriptor:0.1.6",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "366d8240dde487ca51823b1ab9f07a10a78251ca",
-        "md5": "8e793e2a6d3bef3145c7bfae02099c0a",
-        "sha256": "b0d542e7aa38610efea55af9bf42c812a73d93ae522b1ceaa106f831900bb06a"
-    },
-    {
-        "id": "has-values:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
-        "md5": "59bfd41b8b69c52c77823af62b7bada7",
-        "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
-    },
-    {
-        "id": "pluralize:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
-        "md5": "10ffc865fc0a65a38893463e1ab77403",
-        "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
-    },
-    {
-        "id": "repeat-element:1.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
-        "md5": "bf964c7d487f69452bf2196b93908917",
-        "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
-    },
-    {
-        "id": "safe-buffer:5.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string_decoder:1.1.1",
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
-        "md5": "dc7142b470e0957c5c34098b6fced0ab",
-        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
-    },
-    {
-        "id": "imurmurhash:0.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
-        "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
-        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
-    },
-    {
-        "id": "locate-path:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
-        "md5": "3241773d42e4709beacb91d0e7d92331",
-        "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
-    },
-    {
-        "id": "js-tokens:3.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-code-frame:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "loose-envify:1.4.0",
-                "invariant:2.2.4",
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9866df395102130e38f7f996bceb65443209c25b",
-        "md5": "969180644218c18794b6df26d42accd5",
-        "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
-    },
-    {
-        "id": "strip-ansi:4.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
-        "md5": "f0aa5746513c46c807ea71744ec2bc5c",
-        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
-    },
-    {
-        "id": "is-fullwidth-code-point:2.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "string-width:2.1.1",
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
-        "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
-        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
-    },
-    {
-        "id": "is-utf8:0.2.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "gulp-sourcemaps:2.0.0-alpha",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:1.0.0",
-                "vinyl-fs:0.3.14",
-                "gulp:3.9.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "strip-bom:2.0.0",
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
-        "md5": "7c483523b33b0640efedcc6561c545e2",
-        "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
-    },
-    {
-        "id": "next-tick:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es5-ext:0.10.53",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ca86d1fe8828169b0120208e3dc8424b9db8342c",
-        "md5": "e199ee5dd3885bfecd2d3c8856fcc85f",
-        "sha256": "589acf7512a9bef481eec81eeb8aef056e638f26257e572a0cb3e3baccbc7863"
-    },
-    {
-        "id": "jsonify:0.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json-stable-stringify:1.0.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "json-stable-stringify:1.0.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
-        "md5": "78cc678249f2a175db1cffbd5bb25a14",
-        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
-    },
-    {
-        "id": "array-unique:0.3.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
-        "md5": "c7fa44b0117a3ed0d161f876c68633f7",
-        "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
-    },
-    {
-        "id": "concat-map:0.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.4",
-                "minimatch:2.0.10",
-                "babel-core:6.8.0",
-                "babel-plugin-transform-regenerator:6.8.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.3",
-                "minimatch:3.0.0",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
-        "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
-        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
-    },
-    {
-        "id": "strip-json-comments:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
-        "md5": "af7d37e88560f64851d5c27b0abc617e",
-        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
-    },
-    {
-        "id": "balanced-match:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "brace-expansion:1.1.11",
-                "minimatch:3.1.1",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
-        "md5": "eaa5cad5807df26bd8eb05ea4af19001",
-        "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
-    },
-    {
-        "id": "ext:1.6.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-symbol:3.1.3",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
-        "md5": "9cf67c9330abea4cd40a86724154f246",
-        "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
-    },
-    {
-        "id": "p-try:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-limit:1.3.0",
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
-        "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
-        "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
-    },
-    {
-        "id": "minimatch:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "879ad447200773912898b46cd516a7abbb5e50b0",
-        "md5": "22992838af1452c5cccc92cdf6c21025",
-        "sha256": "2b4e6fc003c29d58cb6f21c9b235ffa6ad29c7e94eba24c60d42973113629280"
-    },
-    {
-        "id": "object.pick:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
-        "md5": "40633da6e17a372e353e73ae28beb843",
-        "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
-    },
-    {
-        "id": "atob:2.1.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "source-map-resolve:0.5.3",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
-        "md5": "45eb23f9eb24b3ff24e18466deeaa887",
-        "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
-    },
-    {
-        "id": "growly:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
-        "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
-        "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
-    },
-    {
-        "id": "babel-traverse:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
-        "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
-        "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
-    },
-    {
-        "id": "p-limit:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "p-locate:2.0.0",
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
-        "md5": "f674d1283c8ac4d11ec813efc2b5934a",
-        "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
-    },
-    {
-        "id": "union-value:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
-        "md5": "5438ca0bb737dc01e85a61121dcc3626",
-        "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
-    },
-    {
-        "id": "es6-symbol:3.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es6-set:0.1.5",
-                "es6-map:0.1.5",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
-        "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
-        "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
-    },
-    {
-        "id": "estraverse:5.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "esrecurse:4.3.0",
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "esquery:1.4.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
-        "md5": "ac5d5752d7928d448689899477f994b0",
-        "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
-    },
-    {
-        "id": "espree:3.5.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
-        "md5": "84b02c58a8ae5ce3da5886773141518b",
-        "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
-    },
-    {
-        "id": "inquirer:0.12.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
-        "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
-        "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
-    },
-    {
-        "id": "es-to-primitive:1.2.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
-        "md5": "a32f26c478b76efa377601b8d17268a9",
-        "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
-    },
-    {
-        "id": "eslint-plugin-react:6.10.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
-        "md5": "fabc99b1e4722b4e10fe41f348940da3",
-        "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
-    },
-    {
-        "id": "acorn-jsx:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
-        "md5": "4b90c954f940a0891370c7d265ce0fc6",
-        "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
-    },
-    {
-        "id": "supports-color:5.5.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:2.4.2",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "supports-hyperlinks:1.0.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
-        "md5": "17b1003344e0e0d2719205be85946698",
-        "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
-    },
-    {
-        "id": "eslint-plugin-jsdoc:2.4.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
-        "md5": "faf67209cc82f0fc3b0717ea662bbdab",
-        "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
-    },
-    {
-        "id": "minimist:1.2.5",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "json5:1.0.1",
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "mkdirp:0.5.5",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
-        "md5": "522d37fe79e519d03574fd979abd7e4f",
-        "sha256": "a1800ce4d39356e96497bd09a41fad0033a13dd8eeb469008333547505ce4350"
-    },
-    {
-        "id": "estraverse:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
-        "md5": "fe475b154e52864c56c3fc8f4b4af81b",
-        "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
-    },
-    {
-        "id": "preserve:0.2.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
-        "md5": "bca875c4e8d238ef216dc9d1bcabf976",
-        "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
-    },
-    {
-        "id": "is-extendable:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object.omit:2.0.1",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "union-value:1.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extend-shallow:2.0.1",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
-        "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
-        "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
-    },
-    {
-        "id": "babel-code-frame:6.26.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
-        "md5": "fdca204ce9b0158bcc65745baa896e4c",
-        "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
-    },
-    {
-        "id": "pinkie-promise:2.0.1",
-        "scopes": [
-            "dev",
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "del:2.2.0",
-                "flat-cache:1.0.10",
-                "file-entry-cache:1.2.4",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "del:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "globby:4.0.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "pkg-conf:1.1.2",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "path-exists:2.1.0",
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "find-up:1.1.2",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "load-json-file:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "path-type:1.1.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
-        "md5": "d6cf74027e88ca54043e91d59629a656",
-        "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
-    },
-    {
-        "id": "pascalcase:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
-        "md5": "0c6e0012f1d98450a08a7b76b55a3296",
-        "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
-    },
-    {
-        "id": "acorn:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "acorn-jsx:3.0.1",
-                "espree:3.5.4",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
-        "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
-        "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
-    },
-    {
-        "id": "arr-flatten:1.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "arr-diff:2.0.0",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "36048bbff4e7b47e136644316c99669ea5ae91f1",
-        "md5": "1b469d538f9b387d83b3cb7e5994f7a5",
-        "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a"
-    },
-    {
-        "id": "object.omit:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
-        "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
-        "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
-    },
-    {
-        "id": "esrecurse:4.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "escope:3.6.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
-        "md5": "a39f104614e3543dd4522ac4afdace00",
-        "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
-    },
-    {
-        "id": "is-property:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "generate-function:2.3.1",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.20.6",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "generate-object-property:1.2.0",
-                "is-my-json-valid:2.13.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
-        "md5": "29d8709ba7392da7846b05c30cb83832",
-        "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
-    },
-    {
-        "id": "copy-descriptor:0.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
-        "md5": "d6e57e9597c6af638adc414e74c3d516",
-        "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
-    },
-    {
-        "id": "isarray:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "doctrine:1.5.0",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "concat-stream:1.5.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "doctrine:1.2.1",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "isobject:2.1.0",
-                "has-value:0.3.1",
-                "unset-value:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "readable-stream:2.0.6",
-                "through2:2.0.1",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
-        "md5": "c24471c617803171eed93b3516624c97",
-        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
-    },
-    {
-        "id": "kind-of:5.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "object-copy:0.1.0",
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-descriptor:0.1.6",
-                "define-property:0.2.5",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
-        "md5": "378018a0079fc3bc94e8ec2812d86fe6",
-        "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
-    },
-    {
-        "id": "lodash._basecopy:3.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "lodash.toplainobject:3.0.0",
-                "lodash.merge:3.3.2",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clone:3.0.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash.template:3.6.2",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "lodash._baseassign:3.2.0",
-                "lodash._baseclone:3.3.0",
-                "lodash.clonedeep:3.0.2",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
-        "md5": "34a2be5e888808f5239e85ae528752bf",
-        "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
-    },
-    {
-        "id": "validate-npm-package-license:3.0.4",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "normalize-package-data:2.5.0",
-                "read-pkg:1.1.0",
-                "read-pkg-up:1.0.1",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
-        "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
-        "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
-    },
-    {
-        "id": "is-bigint:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
-        "md5": "54f51f1529d609a8762b6f18a9fc5f39",
-        "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
-    },
-    {
-        "id": "call-bind:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "get-symbol-description:1.0.0",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "side-channel:1.0.4",
-                "internal-slot:1.0.3",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-regex:1.1.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-weakref:1.0.2",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimend:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string.prototype.trimstart:1.0.4",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-boolean-object:1.1.2",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.flat:1.2.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.values:1.1.5",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "array.prototype.find:2.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "object.assign:4.1.2",
-                "eslint-plugin-react:6.10.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
-        "md5": "d244c20a7b3f2c607030df6337a4e68d",
-        "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
-    },
-    {
-        "id": "eslint-plugin-no-use-extend-native:0.3.12",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
-        "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
-        "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
-    },
-    {
-        "id": "array-includes:3.1.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f5b493162c760f3539631f005ba2bb46acb45ba9",
-        "md5": "9d752dc8689c23a402be29863f5c1079",
-        "sha256": "9cdcf83ee2d54701efc89e0a73785538d154bd0d7db7218bdaab94047801b95c"
-    },
-    {
-        "id": "ret:0.1.15",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "safe-regex:1.1.0",
-                "regex-not:1.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
-        "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
-        "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
-    },
-    {
-        "id": "collection-visit:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
-        "md5": "735947ef7cec034327b0f2b0144b8256",
-        "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
-    },
-    {
-        "id": "object-visit:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "map-visit:1.0.0",
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "collection-visit:1.0.0",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
-        "md5": "0c309d8c43bc9546676100500c1db1c4",
-        "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
-    },
-    {
-        "id": "process-nextick-args:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "readable-stream:2.3.7",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
-        "md5": "09e1b13837638717ed3f2aae7bc700db",
-        "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
-    },
-    {
-        "id": "eslint-plugin-flowtype:2.50.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
-        "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
-        "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
-    },
-    {
-        "id": "strip-ansi:3.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "chalk:1.1.3",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.11.4",
-                "eslint:1.10.3",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.7.8",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "chalk:1.1.3",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.1",
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "wrap-ansi:2.1.0",
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ],
-            [
-                "string-width:1.0.2",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
-        "md5": "823f58e5d7b03f4e924b2be7157f4f43",
-        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
-    },
-    {
-        "id": "unset-value:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
-        "md5": "d69bb4d1f65e08acd32debce863b513e",
-        "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
-    },
-    {
-        "id": "regex-cache:0.4.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
-        "md5": "c08a04a26436892d55f3d2fb294d8b73",
-        "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
-    },
-    {
-        "id": "regex-not:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "nanomatch:1.2.13",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex:3.0.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
-        "md5": "e54f51e5d23c17edae9f9d199b337531",
-        "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
-    },
-    {
-        "id": "marked-terminal:3.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
-        "md5": "3fc3251d4faab2d1df0155b08258bd34",
-        "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
-    },
-    {
-        "id": "has-bigints:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "is-bigint:1.0.4",
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "64fe6acb020673e3b78db035a5af69aa9d07b113",
-        "md5": "3d1a6fa2571c73144e864272fd5e2e75",
-        "sha256": "7bd053a7d11cfd00367859ca9d06020f643cb6b305a400e424dfd872ebcc223a"
-    },
-    {
-        "id": "lodash:4.17.21",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "babel-traverse:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "babel-types:6.26.0",
-                "babel-eslint:7.2.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-flowtype:2.50.3",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-jsdoc:2.4.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint-plugin-lodash:2.7.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "inquirer:0.12.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "table:3.8.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "node-emoji:1.11.0",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
-        "md5": "25247d3dd7029d08a6ac99adab09086b",
-        "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
-    },
-    {
-        "id": "is-obj-prop:1.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
-        "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
-        "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
-    },
-    {
-        "id": "resolve-from:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "require-uncached:1.0.3",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "require-uncached:1.0.2",
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "gulp-mocha:2.2.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
-        "md5": "e19abe316d7d524402ff940ff923406c",
-        "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
-    },
-    {
-        "id": "flat-cache:1.3.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "file-entry-cache:2.0.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
-        "md5": "7f7fe842b74285784727aedf7cf81c4b",
-        "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
-    },
-    {
-        "id": "progress:1.1.8",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:2.9.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
-        "md5": "06556528b7598e755a84c9c8f75c2622",
-        "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
-    },
-    {
-        "id": "base:0.11.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
-        "md5": "b457a16eb8603bc0d84d252716f5b0d5",
-        "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
-    },
-    {
-        "id": "marked:0.7.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
-        "md5": "2981b17fa46348526d23658960663d88",
-        "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
-    },
-    {
-        "id": "is-symbol:1.0.4",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "es-to-primitive:1.2.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "which-boxed-primitive:1.0.2",
-                "unbox-primitive:1.0.1",
-                "es-abstract:1.19.1",
-                "array-includes:3.1.4",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
-        "md5": "1d481161785d0b7c5a729e39edb86e9a",
-        "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
-    },
-    {
-        "id": "json5:1.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
-        "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
-        "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
-    },
-    {
-        "id": "is-dotfile:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "parse-glob:3.0.4",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
-        "md5": "9c1b18df01884a55636db529eca19fe2",
-        "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
-    },
-    {
-        "id": "object-copy:0.1.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "static-extend:0.1.2",
-                "class-utils:0.3.6",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
-        "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
-        "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
-    },
-    {
-        "id": "redeyed:2.1.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "cardinal:2.1.1",
-                "marked-terminal:3.3.0",
-                "cli-usage:0.1.10",
-                "node-notifier:4.6.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
-        "md5": "b143ff11e6aece5ad2722daebb73c708",
-        "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
-    },
-    {
-        "id": "wrap-ansi:2.1.0",
-        "scopes": [
-            "prod"
-        ],
-        "requestedBy": [
-            [
-                "cliui:3.2.0",
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
-        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
-    },
-    {
-        "id": "sprintf-js:1.0.3",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "argparse:1.0.7",
-                "js-yaml:3.6.0",
-                "css-lint:1.0.1",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "argparse:1.0.10",
-                "js-yaml:3.14.1",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
-        "md5": "8e6b31a052754055683e4a35a317feab",
-        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
-    },
-    {
-        "id": "wrappy:1.0.2",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "inflight:1.0.6",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "once:1.4.0",
-                "glob:7.2.0",
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
-        "md5": "567b1699cfae49cb20f598571a6c90c7",
-        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
-    },
-    {
-        "id": "extend-shallow:2.0.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "expand-brackets:2.1.4",
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "extglob:2.0.4",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "set-value:2.0.1",
-                "cache-base:1.0.1",
-                "base:0.11.2",
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "snapdragon:0.8.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
-        "md5": "5c9316b33e9363368f4468595c700044",
-        "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
-    },
-    {
-        "id": "strip-bom:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "tsconfig-paths:3.12.0",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "eslint:3.19.0",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
-        "md5": "a2045f7f89506a0f8301822998d1daf7",
-        "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
-    },
-    {
-        "id": "read-pkg-up:1.0.1",
-        "scopes": [
-            "prod",
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "yargs:4.6.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "meow:3.7.0",
-                "dateformat:1.0.12",
-                "gulp-util:3.0.7",
-                "gulp-babel:6.1.2",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "yargs:4.8.1",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
-        "md5": "02cc53c7512931912dcbdcd9c1d55265",
-        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
-    },
-    {
-        "id": "obj-props:1.3.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "is-obj-prop:1.0.0",
-                "eslint-plugin-no-use-extend-native:0.3.12",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8884ab21c8d8496c4a7f696c78bf82289c51680b",
-        "md5": "ab45790d12ef25b271e0705f15cbdc4e",
-        "sha256": "ca7dad5516740c0db50ebeec237f934b90afcdc2cab6f4faae7774c08c2ca14e"
-    },
-    {
-        "id": "path-exists:3.0.0",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "locate-path:2.0.0",
-                "find-up:2.1.0",
-                "eslint-module-utils:2.7.3",
-                "eslint-plugin-import:2.25.4",
-                "eslint-config-canonical:1.15.0",
-                "canonical:3.2.1",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
-        "md5": "7c2676f4502f776524cefe6e0b877136",
-        "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
-    },
-    {
-        "id": "repeat-string:1.6.1",
-        "scopes": [
-            "dev"
-        ],
-        "requestedBy": [
-            [
-                "fill-range:2.2.4",
-                "expand-range:1.8.2",
-                "braces:1.8.5",
-                "micromatch:2.3.11",
-                "anymatch:1.3.2",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ],
-            [
-                "to-regex-range:2.1.1",
-                "fill-range:4.0.0",
-                "braces:2.3.2",
-                "micromatch:3.1.10",
-                "readdirp:2.2.1",
-                "chokidar:1.7.0",
-                "pragmatist:3.0.24",
-                "bundle-dependencies"
-            ]
-        ],
-        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
-        "md5": "ed49a5a26c9110a28411da1cded28e3a",
-        "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+    "id": "nanomatch:1.2.13",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+    "md5": "0b72aaedbb1190ac84d5d5e3f232d58f",
+    "sha256": "1fbce3643fc3ba1fef4a7e80ad4e3476b41b12ac7d2ef74cf4f4edafceec8eb8"
+    },
+    {
+    "id": "unset-value:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+    "md5": "d69bb4d1f65e08acd32debce863b513e",
+    "sha256": "53638214a6c65f1d8fcf8b7b718a7c2526b4b9a51cfb0f9c2685a13fdf435286"
+    },
+    {
+    "id": "ansi-styles:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "41fbb20243e50b12be0f04b8dedbf07520ce841d",
+    "md5": "32f5aaf7b10b2d222566c733fb1cab0a",
+    "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3"
+    },
+    {
+    "id": "split-string:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7cb09dda3a86585705c64b39a6466038682e8fe2",
+    "md5": "28a2b30b3b5d7a8022e2ddee6bdc0e4f",
+    "sha256": "ca1a04195a16c5113ba19dfa474499d8a4ce0df08713805a694b10f5d6b1a5af"
+    },
+    {
+    "id": "invariant:2.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610f3c92c9359ce1db616e538008d23ff35158e6",
+    "md5": "445e70b75ab7215bc0da1fbaa36113cd",
+    "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81"
+    },
+    {
+    "id": "to-fast-properties:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
+    "md5": "eb323816b9903f0e6877898c3065da5b",
+    "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21"
+    },
+    {
+    "id": "xtend:4.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb72779f5fa465186b1f438f674fa347fdb5db54",
+    "md5": "183e6eef1df0529fd39bd932447ba547",
+    "sha256": "bd22a01d43c799be7bb53dfa9e775b132045e39525e51efb977528a00041ba48"
+    },
+    {
+    "id": "circular-json:0.3.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "815c99ea84f6809529d2f45791bdf82711352d66",
+    "md5": "5569f191dea3cd5f952867196e41e050",
+    "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18"
+    },
+    {
+    "id": "resolve:1.22.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "rechoir:0.6.2",
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "27cb2ebb53f91abb49470a928bba7558066ac177",
+    "md5": "67a0957a5180922a45e1b1d326a15508",
+    "sha256": "b556a5d48802ed4d038cfe8804596e1cca2176599a776f12daf686dee92d12ea"
+    },
+    {
+    "id": "array-unique:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
+    "md5": "7b3ac4760380d655957c68e59748f438",
+    "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a"
+    },
+    {
+    "id": "regex-not:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+    "md5": "e54f51e5d23c17edae9f9d199b337531",
+    "sha256": "fa4448bb964e8f97905f8e557d529884f08dea1a5e61e88d7589819967bef276"
+    },
+    {
+    "id": "is-extglob:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:0.3.2",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-glob:2.0.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ac468177c4943405a092fc8f29760c6ffc6206c0",
+    "md5": "2abcdb854a7d2b4446afc7b636916db7",
+    "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d"
+    },
+    {
+    "id": "object.pick:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+    "md5": "40633da6e17a372e353e73ae28beb843",
+    "sha256": "8000226024d4532fbe482d4b9631e9562ecbcc496d7869d52eebc7b9d3f3ee0b"
+    },
+    {
+    "id": "spdx-correct:3.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9",
+    "md5": "bd668e9b71960e76e867c11ec3ec2982",
+    "sha256": "5fdfb05593e31709e10690fa2acc8ca921bf67f36b8e7968b018eabdb19682ef"
+    },
+    {
+    "id": "path-is-absolute:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+    "md5": "18bfccb10294ae19e7eb616ed1c05176",
+    "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c"
+    },
+    {
+    "id": "event-emitter:0.3.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "df8c69eef1647923c7157b9ce83840610b02cc39",
+    "md5": "5e969bf0d73326a36ab0eede156d48e3",
+    "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1"
+    },
+    {
+    "id": "set-value:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a18d40530e6f07de4228c7defe4227af8cad005b",
+    "md5": "b1e945fff7d8430e86066db678ca6390",
+    "sha256": "80e6254de6a2f04793c034edfbccd82c1da9249a54247fa2b1b562d19b157761"
+    },
+    {
+    "id": "is-number-object:1.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59d50ada4c45251784e9904f5246c742f07a42fc",
+    "md5": "01e99c61d94d3ac9cffd17b6a666c860",
+    "sha256": "ab356b0a4c4dedc7ac45456826ec5caa14aa1051402516dc86f9bd75ba0a9b75"
+    },
+    {
+    "id": "es6-set:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d2b3ec5d4d800ced818db538d28974db0a73ccb1",
+    "md5": "77d9d782bcaec16287acfb2bdf3a00a2",
+    "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1"
+    },
+    {
+    "id": "chokidar:1.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "798e689778151c8076b4b360e5edd28cda2bb468",
+    "md5": "3b76ca6e8ebf196645910f2985f77385",
+    "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337"
+    },
+    {
+    "id": "is-callable:1.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "47301d58dd0259407865547853df6d61fe471945",
+    "md5": "c34435f9cd64c1bbc3f762a7ec3bc6b0",
+    "sha256": "789483e71bc10b4bc9d5013885d7e4ca6b986bb39356edddb9ef987cd151f3e5"
+    },
+    {
+    "id": "growly:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
+    "md5": "193788212c3a6fd9c5f1ae9bb98d06bb",
+    "sha256": "3aa80441ba0ab2c8ad55d23f30766e134560e096b44c26a32c235604977a6207"
+    },
+    {
+    "id": "babylon:6.18.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
+    "md5": "c0f769098a62e7881847657d146d9cbe",
+    "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c"
+    },
+    {
+    "id": "eslint-plugin-jsdoc:2.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7c1eaa8e88fab04c807472c17b6ff9a1ac7e564d",
+    "md5": "faf67209cc82f0fc3b0717ea662bbdab",
+    "sha256": "3a8f9b7594e50db6247aa1e5e0a97bb491c4a41d6535c9967895c1af2ed3252c"
+    },
+    {
+    "id": "eslint-plugin-no-use-extend-native:0.3.12",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3ad9a00c2df23b5d7f7f6be91550985a4ab701ea",
+    "md5": "74ddbc2ff8ee8b9a300dedee5a0b1a93",
+    "sha256": "071b7ae8a4d3ae9586a1997a5aee2e2bf82f5d934dfc648f3c72239d13fefcff"
+    },
+    {
+    "id": "run-async:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8ad4a5e110661e402a7d21b530e009f25f8e389",
+    "md5": "05b4c27dcef5296aff906af32f377494",
+    "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84"
+    },
+    {
+    "id": "esutils:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:2.1.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:1.5.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "74d2eb4de0b8da1293711910d50775b9b710ef64",
+    "md5": "fbea0e3ececd72f8135013e599bb44b3",
+    "sha256": "c5adbd730a495a3c635bbae9ee5f693b95c7e13b395f7036efab8232c5f0640f"
+    },
+    {
+    "id": "minimist:1.2.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "json5:1.0.1",
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mkdirp:0.5.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8637a5b759ea0d6e98702cfb3a9283323c93af44",
+    "md5": "0d781b9eda1d585527fb8e1edcfce4c6",
+    "sha256": "49c9124665fc1900e589be610b8dc69d5e61a179e9ed8547c6d61d30a225e726"
+    },
+    {
+    "id": "component-emitter:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
+    "md5": "6b8517f3d7ad46e95c97b6d453f82189",
+    "sha256": "10643e76e9fcd23ea3bb4cde57f214cad74e3741a7013b2b4550ed6741c78161"
+    },
+    {
+    "id": "levn:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+    "md5": "824680de0ed2dabe2745e88737723963",
+    "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624"
+    },
+    {
+    "id": "jsx-ast-utils:1.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3867213e8dd79bf1e8f2300c0cfc1efb182c0df1",
+    "md5": "704aebceee728c9e0120486622b35790",
+    "sha256": "202906e1433e7c80535a49ba932e5547bcddeffbf15e6be351cb889e7faac2b2"
+    },
+    {
+    "id": "cli-width:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b0433d0b4e9c847ef18868a4ef16fd5fc8271c48",
+    "md5": "c9cf40c64a983c42f8fd91a97542f25e",
+    "sha256": "efe546517e03d46988675dcf2f640dcf1676f0fcffe8b132defa22a7e9c9716e"
+    },
+    {
+    "id": "glob-parent:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob-base:0.3.0",
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "81383d72db054fcccf5336daa902f182f6edbb28",
+    "md5": "7dc0b2d10ed856934e289df5e1f12c59",
+    "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d"
+    },
+    {
+    "id": "extend-shallow:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+    "md5": "5c9316b33e9363368f4468595c700044",
+    "sha256": "1b7c9a6b7c7a3d812460eaee0561d0b367ece710fcdc8a2b1e3c078ee8ed6a25"
+    },
+    {
+    "id": "lodash._baseassign:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
+    "md5": "2438792bc711256968416ae0164b5dd9",
+    "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81"
+    },
+    {
+    "id": "eslint:3.19.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-babel:3.3.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-flowtype:2.50.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-lodash:2.7.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-mocha:4.12.1",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8fc6201c7f40dd08941b87c085767386a679acc",
+    "md5": "2b28bed1fe16d31f22178145baa90d7a",
+    "sha256": "b8de28c1338aa961c44ccaba4f293bcc2e013478c143754c4826de6382265272"
+    },
+    {
+    "id": "argparse:1.0.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+    "md5": "d96ffb030eff598e8f3eb48b6257bdaf",
+    "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d"
+    },
+    {
+    "id": "read-pkg:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+    "md5": "c35de6ee14fc66999d84a2e20bdd478b",
+    "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2"
+    },
+    {
+    "id": "set-blocking:2.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+    "md5": "ff057cf430b35ecb25780f94cd051ab3",
+    "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d"
+    },
+    {
+    "id": "loose-envify:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "invariant:2.2.4",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "71ee51fa7be4caec1a63839f7e682d8132d30caf",
+    "md5": "5e78d5f6b1ad3ecce9605936059d087e",
+    "sha256": "1218830a93538a4f730d530138e945ea6a65b45e099ee7a9ea538a05141babdc"
+    },
+    {
+    "id": "wrap-ansi:2.1.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+    "md5": "8ab8bf0ee05c3136afa8bbb1d3698f1e",
+    "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490"
+    },
+    {
+    "id": "static-extend:0.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+    "md5": "685c7b45bd48268f9eeffbccecb2d313",
+    "sha256": "d49ef864ff022866341aa57a8a9bb3a67b61ca1044562fdac1e6cd81633b8fc3"
+    },
+    {
+    "id": "use:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+    "md5": "4ef3227be6e13466d0cc5505bf6b20d9",
+    "sha256": "36ca5dde378558108ca18fa19f2719feaeaad4602262a1aa05fa88b4f05719db"
+    },
+    {
+    "id": "is-glob:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob-base:0.3.0",
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob-parent:2.0.0",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
+    "md5": "094686a7618e52db5f126af328da6aff",
+    "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad"
+    },
+    {
+    "id": "copy-descriptor:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+    "md5": "d6e57e9597c6af638adc414e74c3d516",
+    "sha256": "e010f2a9224a6c270ff834d740ab7ea508b5c7a086d329eb0cd641029e79b4b6"
+    },
+    {
+    "id": "babel-types:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a3b073f94ab49eb6fa55cd65227a334380632497",
+    "md5": "d12869e767169377af311247a2d247e9",
+    "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9"
+    },
+    {
+    "id": "ansi-styles:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
+    "md5": "deb5e5008ca69027719588d723cf9f91",
+    "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f"
+    },
+    {
+    "id": "ms:2.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:3.2.7",
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "debug:3.2.7",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "574c8138ce1d2b5861f0b44579dbadd60c6615b2",
+    "md5": "a50e4bf82f754914316bfca3dfbcf352",
+    "sha256": "f6616e15e530ed552f9daa2d3ce71963947c6bc7c98c9b64fd3e673fd02622c6"
+    },
+    {
+    "id": "urix:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "source-map-resolve:0.3.1",
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+    "md5": "dd3921f317a15657fad465fd215fe38d",
+    "sha256": "75ddd09b350185294372b4334af8ceff2bfb9893943414e571cc249519c215a7"
+    },
+    {
+    "id": "inflight:1.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+    "md5": "dd31215ede2e0da80f8e31c9f93d8ace",
+    "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b"
+    },
+    {
+    "id": "is-string:1.0.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0dd12bf2006f255bb58f695110eff7491eebc0fd",
+    "md5": "a7cc7f159a13b20e5fa93015d6124705",
+    "sha256": "cdfa3603dca66033b15c75fb807605d1fba9eca08bdcffe7ed47de1958d7cef4"
+    },
+    {
+    "id": "arr-union:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
+    "md5": "f3cf2ebd1f4051917051f0c2b9287954",
+    "sha256": "77b44fdf330e520dee618cef90a37f6c8d2dd876ff267aed5e7474db0d762ccb"
+    },
+    {
+    "id": "callsites:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "caller-path:0.1.0",
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "caller-path:0.1.0",
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "afab96262910a7f33c19a5775825c69f34e350ca",
+    "md5": "b6e9bfb992503522ddaee4e965423faa",
+    "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c"
+    },
+    {
+    "id": "micromatch:2.3.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "86677c97d1720b363431d04d0d15293bd38c1565",
+    "md5": "0c6949145be8bb09e5aa63fdebea9c24",
+    "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf"
+    },
+    {
+    "id": "braces:1.8.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ba77962e12dff969d6b76711e914b737857bf6a7",
+    "md5": "de2a10fc73a3b353af9b808e75bb8d8f",
+    "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395"
+    },
+    {
+    "id": "ret:0.1.15",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "safe-regex:1.1.0",
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+    "md5": "f4e653f5e9d5d653db6c881b71e7ec0a",
+    "sha256": "4a7462b50b3184e14d3518cc0438624ad20aa21bafeb30568aede82f07ef69fe"
+    },
+    {
+    "id": "ansi-escapes:3.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b",
+    "md5": "7431226bb3f179e8cd7eddf297b904ec",
+    "sha256": "2eec913a6b90db772d212cd9393b84bde8c2ac71584905e79311293736d24f8d"
+    },
+    {
+    "id": "babel-traverse:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
+    "md5": "c94a6c3fdf4d11f0a3045c61038eabac",
+    "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9"
+    },
+    {
+    "id": "next-tick:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1836ee30ad56d67ef281b22bd199f709449b35eb",
+    "md5": "faaf65a0216bc6be06b5cf1139315f60",
+    "sha256": "f29d4d707449588c7200d1d4d05286fd3b8c0f63ad2e595f9bcd011c8d0ed755"
+    },
+    {
+    "id": "to-regex:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+    "md5": "8a6359bf8c570483aad2a767191e87bb",
+    "sha256": "86831805bd821f826f2c77fe1add74855b63801c95a52f41f032cbe73112340d"
+    },
+    {
+    "id": "canonical:3.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c41077a388780b511e87d0c54eb4568f1f89959e",
+    "md5": "a92c480423bdf2a2773e91c283b74ad8",
+    "sha256": "569fc46c6a3537c1a86e814dc9fb040b4e9a5cc2e92f96da9523c732dfc30ccc"
+    },
+    {
+    "id": "has-value:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
+    "md5": "0f5d46e9619fa36d9930f590ef96844b",
+    "sha256": "29f7c52387889aeef39b66c717db0d79a47b208f3ae17431b683d7189c5b77c6"
+    },
+    {
+    "id": "which-boxed-primitive:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13757bc89b209b049fe5d86430e21cf40a89a8e6",
+    "md5": "2d84f8bed229309416dffff93d5028cd",
+    "sha256": "4a4017ba9103fed80bc3ec67c529ed43b38066a626dd9595d91a57cf0c5e089d"
+    },
+    {
+    "id": "es-abstract:1.20.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "027292cd6ef44bd12b1913b828116f54787d1814",
+    "md5": "3f67e5a17520816ff5cc668928214ed6",
+    "sha256": "54b669ef739263ae77a541d63749d7865ea4ac80a4d8802c8b93b3901327d7bb"
+    },
+    {
+    "id": "lodash._bindcallback:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.clonedeep:3.0.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._createassigner:3.1.1",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e531c27644cf8b57a99e17ed95b35c748789392e",
+    "md5": "20bfe15e77fe081ff95fa92c73f0699e",
+    "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea"
+    },
+    {
+    "id": "ramda:0.25.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-mocha:4.12.1",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8fdf68231cffa90bc2f9460390a0cb74a29b29a9",
+    "md5": "f86f2a632aa11bb7af129304fbe22a67",
+    "sha256": "17623b4d66830453e7fc85a8a96ac239bffb81110064f14bd76dedebd95bfd52"
+    },
+    {
+    "id": "array.prototype.find:2.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "153b8a28ad8965cd86d3117b07e6596af6f2880d",
+    "md5": "ec713f547ad22ceb5cf77b1282059b4c",
+    "sha256": "132f73797a28c9f91511f20662cc43ee6a51473b191b4d7aa5987861c540513d"
+    },
+    {
+    "id": "es6-weak-map:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53",
+    "md5": "edb82ccad9f34520dc736bfbc67dc4be",
+    "sha256": "886b1c2f5dcd3715e7205f843e8cf66be2f6530b0f41c479ac9db8ce4b5f2e87"
+    },
+    {
+    "id": "snapdragon-node:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
+    "md5": "ce4ebdb9d8dc261df7793fd9cb38db07",
+    "sha256": "f2a498821f245af04015fa8c50afc5d4a3c3839d2e7487227e7c4be11611b545"
+    },
+    {
+    "id": "json5:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "779fb0018604fa854eacbf6252180d83543e3dbe",
+    "md5": "9a3ab848f9886b41500a2a2bfe0cbb3a",
+    "sha256": "8cd9f5a4d6d4c0388a5061be831e2c18364ae9dad535aaf1c332a6ab8e9b3b84"
+    },
+    {
+    "id": "path-parse:1.0.7",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
+    "md5": "0eb085db2ac7a62ab20dca9405fef1b0",
+    "sha256": "a07a198ca727816296616928237bfab6571f211750d798030b3b7a3f4a5473a3"
+    },
+    {
+    "id": "globals:9.18.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
+    "md5": "746bb222029d9fd52336a7503c6e110b",
+    "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a"
+    },
+    {
+    "id": "has-ansi:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+    "md5": "6c5e87ad63e866b41fc47eaddd3174b0",
+    "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed"
+    },
+    {
+    "id": "yargs-parser:2.4.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85568de3cf150ff49fa51825f03a8c880ddcc5c4",
+    "md5": "3ed28206e170b6c0cf902511c2d0534b",
+    "sha256": "75f75180a4f564247b4f438baf9e0d1b7ff113b4d27270a9d63446ce95eaadbc"
+    },
+    {
+    "id": "acorn-jsx:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
+    "md5": "4b90c954f940a0891370c7d265ce0fc6",
+    "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe"
+    },
+    {
+    "id": "define-property:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+    "md5": "8a6929a07bffc6c4c16bb506e31834c1",
+    "sha256": "a61a958973b476aec5401e5ceb5e3ef40ef2a24093ec2f91680f920336a98794"
+    },
+    {
+    "id": "has-value:0.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
+    "md5": "d65c8ea3ad1ccf067ab6e0ec189e7bdc",
+    "sha256": "de562805d0b419b653f2ca54cf89d71ebdc4424ea294001490f7eb9cf2b78dc0"
+    },
+    {
+    "id": "inquirer:0.12.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1ef2bfd63504df0bc75785fff8c2c41df12f077e",
+    "md5": "33d0a3ae6a225f8b08e941a8aa6a814f",
+    "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05"
+    },
+    {
+    "id": "to-object-path:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+    "md5": "ed213d48acc6db7b01883673013ba398",
+    "sha256": "c830bc5c3e8538866d41d5e4e952e52509c3af04df33737319a662dad106c406"
+    },
+    {
+    "id": "estraverse:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+    "md5": "fe475b154e52864c56c3fc8f4b4af81b",
+    "sha256": "7f262b147df8eeb209d0b7220b4dff6c70a5b1edba157bf335cee0bb71b9f1ae"
+    },
+    {
+    "id": "babel-messages:6.23.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
+    "md5": "f7a22e78d59c180af1175172a3abee40",
+    "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936"
+    },
+    {
+    "id": "inherits:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0fa2c64f932917c3433a0ded55363aae37416b7c",
+    "md5": "bf725b87e6485c1d9db0279cce76a4a7",
+    "sha256": "d94dbc6c1bb3c5ac0fb12a73ade187108fc60de273a1b754f55044eb5e24afaf"
+    },
+    {
+    "id": "interpret:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "665ab8bc4da27a774a40584e812e3e0fa45b1a1e",
+    "md5": "9d7dec2c46613400992e6b9ed13175c1",
+    "sha256": "f72923e40416525e4212eb40981a9126d79dfe15d00100070b4199393722087b"
+    },
+    {
+    "id": "rechoir:0.6.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "liftoff:2.2.1",
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85204b54dba82d5742e28c96756ef43af50e3384",
+    "md5": "9a0aa4db2a887a452ef08921160c7eb4",
+    "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635"
+    },
+    {
+    "id": "is-data-descriptor:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d84876321d0e7add03990406abbbbd36ba9268c7",
+    "md5": "d4fe7614279e3f4718d383035209c33e",
+    "sha256": "28c25461e29798d16795eadabe11cc5ced4904f9ca1761bc0463e403759ca12c"
+    },
+    {
+    "id": "is-accessor-descriptor:0.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+    "md5": "988cec0d99237747735bc5d84953a207",
+    "sha256": "2356586375dd98e696cdcec427de57d1796130c245c09bdb448287732a6133c9"
+    },
+    {
+    "id": "exit-hook:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f05ca233b48c05d54fff07765df8507e95c02ff8",
+    "md5": "d6ad3b683bee91b5a117990d68a097dd",
+    "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22"
+    },
+    {
+    "id": "object-inspect:1.12.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c0641f26394532f28ab8d796ab954e43c009a8ea",
+    "md5": "1193ad67b8d504446e7cb98275c5399b",
+    "sha256": "42e71d82a0209bda2995cae7e3d8802f631e5933646cae8cd000192dba74d65a"
+    },
+    {
+    "id": "tsconfig-paths:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ba0734599e8ea36c862798e920bcf163277b137a",
+    "md5": "4d77fe4a7d930f1ecb5942b37f359909",
+    "sha256": "9c764c11733958e34f461ca43b430f4c54edc9167cfbbb9088660f3431e9f401"
+    },
+    {
+    "id": "mkdirp:0.5.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "write:0.2.1",
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7def03d2432dcae4ba1d611445c48396062255f6",
+    "md5": "673b86d8669883c517b32b04886560f6",
+    "sha256": "1b29291a054b23ddc12f63cb0f563e486bc5866fb1855b5632d1a0ba88aab569"
+    },
+    {
+    "id": "require-directory:2.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+    "md5": "f3a9010155b6a46066afbe2d07f624bd",
+    "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8"
+    },
+    {
+    "id": "eslint-module-utils:2.7.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ad7e3a10552fdd0642e1e55292781bd6e34876ee",
+    "md5": "b209efc416d3e5b3f9b15c9177a19fec",
+    "sha256": "0f6c6dd2c1754ae39c8467748f67d10faad647ed4d10ea4a2b796b2ef853abe6"
+    },
+    {
+    "id": "object-copy:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+    "md5": "d745f2b80f9cb7f9f644b28f41e53c3e",
+    "sha256": "1cb8c20150d427b2fec17bd68d09632f950a60991e5e3e25fc6d822f06bea9ac"
+    },
+    {
+    "id": "array-includes:3.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb",
+    "md5": "3e1762231dcc1a9ca68d50da2e5935e5",
+    "sha256": "bf08768417abaaeb7f8caf6cc089ae4b3bcca6c9fe814bfede8556cdfeacae6d"
+    },
+    {
+    "id": "esquery:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2148ffc38b82e8c7057dfed48425b3e61f0f24a5",
+    "md5": "67c3703f159c91ae9bd06b896a863b19",
+    "sha256": "6e5add1c721480e6b9f2da07d6e14e706587649b84c565c56b8eb29c04cefa09"
+    },
+    {
+    "id": "fs.realpath:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+    "md5": "9f790d7180667e1d8d1110f2cf321b62",
+    "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c"
+    },
+    {
+    "id": "for-own:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5265c681a4f294dabbf17c9509b6763aa84510ce",
+    "md5": "6b95dc29fcffc91036164869c724d05b",
+    "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f"
+    },
+    {
+    "id": "esprima:4.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "redeyed:2.1.1",
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+    "md5": "c9d44a818c324d707a81b08dd36cd079",
+    "sha256": "d8a1910e9cbecc95b4c5df75376c46a7a9261859c294ef91505c1442e093cc74"
+    },
+    {
+    "id": "is-utf8:0.2.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "strip-bom:2.0.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:2.0.0",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:1.0.0",
+    "vinyl-fs:0.3.14",
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-bom:2.0.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
+    "md5": "7c483523b33b0640efedcc6561c545e2",
+    "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674"
+    },
+    {
+    "id": "source-map-resolve:0.5.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "190866bece7553e1f8f267a2ee82c606b5509a1a",
+    "md5": "88b0cf532783413eb92e171554ddd28d",
+    "sha256": "44b6cdf8ae8f4b6317508a633e5ce8fc4b866f7a40b81191b2b57f8bbd9b3ea9"
+    },
+    {
+    "id": "cli-cursor:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64da3f7d56a54412e59794bd62dc35295e8f2987",
+    "md5": "b5a4406dbe8b75b2a2f7495924a1d9fb",
+    "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505"
+    },
+    {
+    "id": "through:2.3.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-mocha:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+    "md5": "615296782d4936bd53ebe4e5baa57db7",
+    "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e"
+    },
+    {
+    "id": "cliui:3.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "120601537a916d29940f934da3b48d585a39213d",
+    "md5": "3a83794ba283c15042e429b11802766d",
+    "sha256": "4ff1f37ab7becd3fb0a38956ad044449a4e7d34a48caa6323530ff0805b6ea40"
+    },
+    {
+    "id": "arr-diff:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
+    "md5": "42ec151186ae4bd9980a212083d98bbe",
+    "sha256": "ddb3765f2b759692dff2f3db49ba693bc14a120180149bf6c43bd76db05f659c"
+    },
+    {
+    "id": "kind-of:5.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "729c91e2d857b7a419a1f9aa65685c4c33f5845d",
+    "md5": "378018a0079fc3bc94e8ec2812d86fe6",
+    "sha256": "4d60c4c0840f198934811b6fbe8cecebb3474f3b7c5a99cb95e23dfe83097772"
+    },
+    {
+    "id": "repeat-element:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "be681520847ab58c7568ac75fbfad28ed42d39e9",
+    "md5": "bf964c7d487f69452bf2196b93908917",
+    "sha256": "366fb0d422e3a6079e3f727e65d29a6013d83dc2ce9d7903a449b6d3a69bc947"
+    },
+    {
+    "id": "parse-json:2.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
+    "md5": "9b98b48019fa25c226348737831cf130",
+    "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5"
+    },
+    {
+    "id": "node-notifier:4.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "056d14244f3dcc1ceadfe68af9cff0c5473a33f3",
+    "md5": "0f04f7a88ceff67961e4277485727ce9",
+    "sha256": "c3704a98840ea4807bfa2ec42a7bd1b494f79b3abdddd48eeb8bf1ccfd1e4e0a"
+    },
+    {
+    "id": "is-extendable:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7470f9e426733d81bd81e1155264e3a3507cab4",
+    "md5": "61392549d95a063512f916897d7069b7",
+    "sha256": "42ebd9d5d0cafcb3ce0bef5f579d0ada4233772386e4f9078169e3d232082658"
+    },
+    {
+    "id": "comment-parser:0.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fa5a3f78013070114866dc7b8e9cf317a9635f74",
+    "md5": "8146e9f78ab76bf3885ca540f9e2c0d8",
+    "sha256": "532e200f481b25a10cf365fd150c5b3a1f855b9a9bb7b9a317e4b62308898a3a"
+    },
+    {
+    "id": "side-channel:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "efce5c8fdc104ee751b25c58d4290011fa5ea2cf",
+    "md5": "abcc258cdccfd0db4007c7be3888d7df",
+    "sha256": "352b84bca536881ae429da1b0574e6805572bdc0312384033f0445204b06d735"
+    },
+    {
+    "id": "pluralize:1.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
+    "md5": "10ffc865fc0a65a38893463e1ab77403",
+    "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130"
+    },
+    {
+    "id": "extglob:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
+    "md5": "c8be79678101bbc03ea2018b80a8ac0a",
+    "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98"
+    },
+    {
+    "id": "async-each:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
+    "md5": "c1130142d7ed405602b1fc38d811e360",
+    "sha256": "8a76b86e848314f6958dd95fd75c9c43ffce736c73462d099e34a5ea21836363"
+    },
+    {
+    "id": "lodash._basecopy:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.toplainobject:3.0.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
+    "md5": "34a2be5e888808f5239e85ae528752bf",
+    "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745"
+    },
+    {
+    "id": "is-my-ip-valid:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f7220d1146257c98672e6fba097a9f3f2d348442",
+    "md5": "9d9e18f4f947f111477e8ee23ee41dd2",
+    "sha256": "c189c5d6a085578b79bfc4bbbdb2470ae45244a0d89df9663eed8fab59b6925f"
+    },
+    {
+    "id": "lodash._getnative:3.9.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._createcache:3.1.2",
+    "lodash._basedifference:3.0.3",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+    "md5": "a311ce03b077bd8a3b4bfe46776f9035",
+    "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960"
+    },
+    {
+    "id": "babel-runtime:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-messages:6.23.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+    "md5": "f791f7898733e02f7216de5d6d6a1602",
+    "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b"
+    },
+    {
+    "id": "es5-ext:0.10.61",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "d:1.0.1",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.1",
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "event-emitter:0.3.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "311de37949ef86b6b0dcea894d1ffedb909d3269",
+    "md5": "84eb1176f35b58e8a606648d61d35584",
+    "sha256": "a4d97b74a47ac8a9364330e304949af6193537794f83005fc6e0776d0a577a77"
+    },
+    {
+    "id": "require-uncached:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4e0d56d6c9662fd31e43011c4b95aa49955421d3",
+    "md5": "b8e947b4460fbdb7bf60c12db84c73d2",
+    "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4"
+    },
+    {
+    "id": "load-json-file:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
+    "md5": "939784db9c3c72c26262cebef2f9b631",
+    "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e"
+    },
+    {
+    "id": "path-type:1.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
+    "md5": "e14c138690b623db36532ff609b81b08",
+    "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b"
+    },
+    {
+    "id": "doctrine:1.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
+    "md5": "8628b3ac690236d809939b9c3ec2531c",
+    "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d"
+    },
+    {
+    "id": "path-exists:2.1.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+    "md5": "4cc32b19e220e3ca0f4d14844996dc56",
+    "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889"
+    },
+    {
+    "id": "strip-ansi:3.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "wrap-ansi:2.1.0",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+    "md5": "823f58e5d7b03f4e924b2be7157f4f43",
+    "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a"
+    },
+    {
+    "id": "user-home:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
+    "md5": "221f00361d182f5dfd195a7d867307c7",
+    "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713"
+    },
+    {
+    "id": "get-intrinsic:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "call-bind:1.0.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-property-descriptors:1.0.0",
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-symbol-description:1.0.0",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "336975123e05ad0b7ba41f152ee4aadbea6cf598",
+    "md5": "100e3a1e0c452360575c70b6b6cb03ad",
+    "sha256": "4759e55e01afaed935a624731dd753bd5a4fe73f4557e007bd8e765a2c1c328b"
+    },
+    {
+    "id": "functions-have-names:1.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0404fe4ee2ba2f607f0e0ec3c80bae994133b834",
+    "md5": "89a2b8928f2e27c2087690ab9f5d846a",
+    "sha256": "3be0c99c006f7c53093e3f6a56a1128f1a72fec3b041ec585a4175b809fab1dc"
+    },
+    {
+    "id": "@types/json5:0.0.29",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ee28707ae94e11d2b827bcbe5270bcea7f3e71ee",
+    "md5": "b2b856287e2f65c5298b7747332bb633",
+    "sha256": "439d14e46f574bc1a62a72ad4598e7f22ebd8021410ab7d869723801c436e95d"
+    },
+    {
+    "id": "is-buffer:1.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "kind-of:3.2.2",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-number:3.0.0",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:3.2.2",
+    "is-number:3.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "kind-of:4.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+    "md5": "374af5d9a1a7e4d3e686419412fa6b72",
+    "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e"
+    },
+    {
+    "id": "define-property:0.2.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+    "md5": "8c5af6494e7554ddba2dbcb7f3ca3cdc",
+    "sha256": "d317d5d4dc0ba4cc92daa979be09f9f7e98bf84a870e9a43049bdf7a90e64fe4"
+    },
+    {
+    "id": "lodash:4.17.21",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-types:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-flowtype:2.50.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-lodash:2.7.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-emoji:1.11.0",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "679591c564c3bffaae8454cf0b3df370c3d6911c",
+    "md5": "25247d3dd7029d08a6ac99adab09086b",
+    "sha256": "6a087ac9e5702a0c9d60fbcd48696012646ec8df1491dea472b150e79fcaf804"
+    },
+    {
+    "id": "source-map-url:0.4.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0af66605a745a5a2f91cf1bbf8a7afbc283dec56",
+    "md5": "db54d6dc84c3bfa7f420da51c493023c",
+    "sha256": "8c05859ff55314e08ff073486a1e552a4b223fbb5e45ea5bb26746d070008281"
+    },
+    {
+    "id": "semver:5.7.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a954f931aeba508d307bbf069eff0c01c96116f7",
+    "md5": "99453010ab0aad4c49dba769e6193c35",
+    "sha256": "fef2fb32aa27fc28c2e834336469d84615cb187449e3622caa2897a0535db56d"
+    },
+    {
+    "id": "prelude-ls:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "levn:0.2.5",
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "type-check:0.3.2",
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "type-check:0.3.2",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
+    "md5": "64ef095ee5260f9d5f62ad68a2c989d1",
+    "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57"
+    },
+    {
+    "id": "is-data-descriptor:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
+    "md5": "f8d653ce6e504d83c985de8d182f1ae5",
+    "sha256": "43a72ac8b607310debe4f2e66deac30927d0d5c0ab12d1da091a65026f952c3f"
+    },
+    {
+    "id": "co:4.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ajv:4.11.8",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+    "md5": "b6f068b290c84d37007997c45148ad18",
+    "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98"
+    },
+    {
+    "id": "ansicolors:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979",
+    "md5": "9a8ff703d6072578025a1a324c9005d1",
+    "sha256": "b8e260ab45c01049f6a58029b723935bcef0cb28e62888e412f217bfd4e228ef"
+    },
+    {
+    "id": "decamelize:1.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:3.10.0",
+    "uglify-js:2.6.2",
+    "handlebars:4.0.5",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "meow:3.7.0",
+    "dateformat:1.0.12",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+    "md5": "330932e4de0e60c36114facb6d3dfafa",
+    "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864"
+    },
+    {
+    "id": "array.prototype.flat:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b",
+    "md5": "4578f7e4eff680e7f1527b26181c52b2",
+    "sha256": "fa6ddc9a63f839e89e7eda58b50879a7c8d850d48bc281a5354b9d2160d51f76"
+    },
+    {
+    "id": "has-bigints:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-bigint:1.0.4",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0871bd3e3d51626f6ca0966668ba35d5602d6eaa",
+    "md5": "df87410ab4558f7e29b52e8733c1a3e6",
+    "sha256": "207b82f1fa30704c5cd488074a29582f64e20c3ceb29d78f2295d68268570ce3"
+    },
+    {
+    "id": "type:2.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ext:1.6.0",
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3ca6099af5981d36ca86b78442973694278a219f",
+    "md5": "b06b1e937cd3671d147ef4f040fa297d",
+    "sha256": "0bb125fb0dfaadc57c467163619c455d577b12d76f15f33e52f2f15ca56c35bc"
+    },
+    {
+    "id": "internal-slot:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7347e307deeea2faac2ac6205d4bc7d34967f59c",
+    "md5": "01f7b7499f71622547496b12f902bec8",
+    "sha256": "a509a651045c962081e6bdff2561795720697377381368fdee2d8f39d6f40463"
+    },
+    {
+    "id": "fast-levenshtein:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
+    "md5": "443a739d106c51a33470c9f018d82e85",
+    "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c"
+    },
+    {
+    "id": "p-try:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-limit:1.3.0",
+    "p-locate:2.0.0",
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+    "md5": "b99fc1bdf12d00fd26921f3662fc3a3a",
+    "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de"
+    },
+    {
+    "id": "strip-json-comments:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
+    "md5": "af7d37e88560f64851d5c27b0abc617e",
+    "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899"
+    },
+    {
+    "id": "doctrine:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5cd01fc101621b42c4cd7f5d1a66243716d3f39d",
+    "md5": "99d2c40ab95bc0cfef3a83fe388f17b6",
+    "sha256": "220d8b27410873a935daa31af93f3f4cac69be2c76b066cc7eabdd7040fd1dcd"
+    },
+    {
+    "id": "get-set-props:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-get-set-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "998475c178445686d0b32246da5df8dbcfbe8ea3",
+    "md5": "ae71d26ef14801348a804a1b2e987ed9",
+    "sha256": "8e1a3ec9df573d0a097c889037a63f7f01164fcc097f7dd0cf5c87cd4418a3be"
+    },
+    {
+    "id": "mixin-deep:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1120b43dc359a785dce65b55b82e257ccf479566",
+    "md5": "53fb379c1187b97eecfcf06399958566",
+    "sha256": "389a23a01feb1e0a17a8dd0e9a77584fb0c3944ff04bd7e457eeb292051cbc4d"
+    },
+    {
+    "id": "imurmurhash:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+    "md5": "54bf7101d59d33d9b13d6a91a72bc9b7",
+    "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60"
+    },
+    {
+    "id": "supports-color:5.5.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+    "md5": "17b1003344e0e0d2719205be85946698",
+    "sha256": "058a32ad244fcf4b4a7240c3ec9afc14ff78c3f9beba691922695460c9a4e0aa"
+    },
+    {
+    "id": "babel-code-frame:6.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
+    "md5": "fdca204ce9b0158bcc65745baa896e4c",
+    "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf"
+    },
+    {
+    "id": "is-windows:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d1850eb9791ecd18e6182ce12a30f396634bb19d",
+    "md5": "bcc9525ed3558792d281951c90ad366e",
+    "sha256": "7b1128270d2aafc5a03af6e5cc5336eab331dd7cfbae805f76da6867fe8731a2"
+    },
+    {
+    "id": "base:0.11.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7bde5ced145b6d551a90db87f83c558b4eb48a8f",
+    "md5": "b457a16eb8603bc0d84d252716f5b0d5",
+    "sha256": "40b19256da00763327b8a914f013c4df34d3b7b89be0d84ae804a321ce580372"
+    },
+    {
+    "id": "code-point-at:1.1.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+    "md5": "c214d9956b6b675ad837e76eecfc2d4b",
+    "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d"
+    },
+    {
+    "id": "fill-range:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
+    "md5": "35483acae8b070dad60c41a99afe6b4d",
+    "sha256": "fd73b16149446ae57657c0f23c2d8a2baa835e7817e88629d36e421fec546a92"
+    },
+    {
+    "id": "atob:2.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6d9517eb9e030d2436666651e86bd9f6f13533c9",
+    "md5": "45eb23f9eb24b3ff24e18466deeaa887",
+    "sha256": "e52d2ad4b7dc244be956d0c3512b66bb3470c8e0762274494c49a5f7afb3b9da"
+    },
+    {
+    "id": "yargs:4.8.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0",
+    "md5": "964f012a6509b1b431de5f58a11e061a",
+    "sha256": "4da90b25d2938653ddfa2728a4971907d8901b11a4003e0737da4dd2076d5dee"
+    },
+    {
+    "id": "is-resolvable:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fb18f87ce1feb925169c9a407c19318a3206ed88",
+    "md5": "1ef35d3591e0e656cf6f6b384d07eb14",
+    "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87"
+    },
+    {
+    "id": "is-fullwidth-code-point:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
+    "md5": "5f3a6c5fdf638bcd945f2ce94087e9a7",
+    "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b"
+    },
+    {
+    "id": "eslint-config-canonical:1.15.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fe5ed1ad41b6fe1e2566b18d6b7d2dd54673f121",
+    "md5": "99ba79ed1e5755e3fdf2b87e6e58fb57",
+    "sha256": "1f4be6b49d1ebb183da535afabacf56c2a033d4381238cb064a36f72eee01889"
+    },
+    {
+    "id": "normalize-package-data:2.5.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e66db1838b200c1dfc233225d12cb36520e234a8",
+    "md5": "b46c083aa373a30b8d2421e9f269d543",
+    "sha256": "ec9b59c56f2223aba94ab8b79af990a0bc7d80a7dd94e80bb7c6fc682c471e7b"
+    },
+    {
+    "id": "posix-character-classes:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+    "md5": "1fc17a88bddf7099b36179e8acbb68e9",
+    "sha256": "99e5e48d09840a2dc918ae128cd29a037a8017a0144a5b432343aa78563c8021"
+    },
+    {
+    "id": "core-js:2.6.12",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-runtime:6.26.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d9333dfa7b065e347cc5682219d6f690859cc2ec",
+    "md5": "a1881352eef45832b331dc025db1b72c",
+    "sha256": "872ff3c544c43364a0a1b4c541e7ab990f4d1dbcc0101ef07d6da90ba3e4aa45"
+    },
+    {
+    "id": "es6-symbol:3.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bad5d3c1bcdac28269f4cb331e431c78ac705d18",
+    "md5": "557b9274c47ebfd76ef9d15a8f6bcf2e",
+    "sha256": "cec119994145a1eeb1274fb5f268a7ae30a86d351e5ddfdd439ac497b1e12aba"
+    },
+    {
+    "id": "is-accessor-descriptor:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "169c2f6d3df1f992618072365c9b0ea1f6878656",
+    "md5": "71d1d01f8028c245544a9a1217fb2bce",
+    "sha256": "14f7ea5a61dbaf00843ea03e55f20e3daf0db2bf1efe8aee3bde60d080a6cba3"
+    },
+    {
+    "id": "escape-string-regexp:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "figures:1.7.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+    "md5": "02440084832abe665260d5db1da1dd9e",
+    "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347"
+    },
+    {
+    "id": "p-limit:1.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "p-locate:2.0.0",
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
+    "md5": "f674d1283c8ac4d11ec813efc2b5934a",
+    "sha256": "c2fdcbbe99cec5a0ef58f887e690f8dd5dff21f5fbad138a9a3f1121c50cc150"
+    },
+    {
+    "id": "is-extglob:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-glob:4.0.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+    "md5": "f84c2f17059e807664dd8e3acc0c34c5",
+    "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19"
+    },
+    {
+    "id": "rx-lite:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "19ce502ca572665f3b647b10939f97fd1615f102",
+    "md5": "3b3a9736b4cebfe5143b32a5875cb7e9",
+    "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6"
+    },
+    {
+    "id": "to-regex-range:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
+    "md5": "5ad83eab061e092ad457387b4317ed45",
+    "sha256": "789100e984786a2bc106baf1f671c1feb666c2c3fcd753cbf3b07366b7ac8867"
+    },
+    {
+    "id": "cli-usage:0.1.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c9d30a3824b48d161580a8f8d5dfe53d66b00d2",
+    "md5": "9f20b9678f9a13b909660a21fee052a4",
+    "sha256": "746e4eb5b2d91264392d2e87b3fe0fe13e975df3eb5c81e89908d000236f836f"
+    },
+    {
+    "id": "error-ex:1.3.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+    "md5": "5d2c673565060037f9e04d7975d04feb",
+    "sha256": "1ab2a842de0e106a8ec57b85de97cd87105131e3b12cbbd040fde26860cdfe89"
+    },
+    {
+    "id": "kind-of:6.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:1.0.0",
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:1.0.0",
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-descriptor:1.0.2",
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "07c05034a6c349fa06e24fa35aa76db4580ce4dd",
+    "md5": "b2b65b012fbbdda2f5f9c9ab2a9b874c",
+    "sha256": "6c24443b5b6ca52d3dce399c1e2c27c4591c7529765513eeaa0c265b0c0e63da"
+    },
+    {
+    "id": "invert-kv:1.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lcid:1.0.0",
+    "os-locale:1.4.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
+    "md5": "2b6a51ceb82956f35051b8a37d77eb7a",
+    "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e"
+    },
+    {
+    "id": "json-stable-stringify:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "ajv:4.11.8",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af",
+    "md5": "7712931a8d538cad6e4beaccd491cbb2",
+    "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150"
+    },
+    {
+    "id": "estraverse:5.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "esrecurse:4.3.0",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "esquery:1.4.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2eea5290702f26ab8fe5370370ff86c965d21123",
+    "md5": "ac5d5752d7928d448689899477f994b0",
+    "sha256": "3e8d45da5b8085a4a8d51368ffead5b551a502c286978962a05d5c8e0d72fda6"
+    },
+    {
+    "id": "shelljs:0.7.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "decbcf874b0d1e5fb72e14b164a9683048e9acb3",
+    "md5": "476ea3b109ecf2179be8b78b444245d0",
+    "sha256": "154f337176ad7711935b650aea2380fd66770b79b50eb53605b48b2234b1aee2"
+    },
+    {
+    "id": "collection-visit:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+    "md5": "735947ef7cec034327b0f2b0144b8256",
+    "sha256": "86b0559c14662f08944683804c780fcef44c1a4c5e4d7a3799db4937143a5818"
+    },
+    {
+    "id": "expand-brackets:2.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
+    "md5": "a49099d108479157c6efcc4b739a00b2",
+    "sha256": "d88edc204920f7e2e1d6fe9d564fd70cf53cad77f16e106e136ef6d05dbf5d33"
+    },
+    {
+    "id": "source-map:0.5.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+    "md5": "3773f963d18f1aca320fae40b04aded2",
+    "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67"
+    },
+    {
+    "id": "rimraf:2.6.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab",
+    "md5": "bd58522df35ee7b727430b41720e912d",
+    "sha256": "8cb56fcabdd214cf19ce24cf82a11950093f388670d01f6b112cc2d86cf67f7e"
+    },
+    {
+    "id": "brace-expansion:1.1.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+    "md5": "02822e3db48e8c5b844fa309fa2cc56b",
+    "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da"
+    },
+    {
+    "id": "randomatic:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b776efc59375984e36c537b2f51a1f0aff0da1ed",
+    "md5": "da226719644d2e64d1127424e028f827",
+    "sha256": "1778660a4edc063ed7aeab44556fe6d303e0170fd717b20f47c9636cbe5d5cc9"
+    },
+    {
+    "id": "marked-terminal:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "25ce0c0299285998c7636beaefc87055341ba1bd",
+    "md5": "3fc3251d4faab2d1df0155b08258bd34",
+    "sha256": "a3efe1d616173ece3720f1ac89c76ac0bfcf03e76d88d9c0ee396f19faf58d6c"
+    },
+    {
+    "id": "cardinal:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7cc1055d822d212954d07b085dea251cc7bc5505",
+    "md5": "876b0338412efe635c487c4bf31a55b1",
+    "sha256": "1cc0c5879ff25e68712c3f4e1b1e6137b583c135c24e165451a16425284f6fbe"
+    },
+    {
+    "id": "is-number:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
+    "md5": "fb4c6b1ce591089d5da379104d9455b8",
+    "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7"
+    },
+    {
+    "id": "lodash.clonedeep:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
+    "md5": "dfef3b8bee7adea034e7224d909d92f5",
+    "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae"
+    },
+    {
+    "id": "pinkie-promise:2.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "del:2.2.0",
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-exists:2.1.0",
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
+    "md5": "d6cf74027e88ca54043e91d59629a656",
+    "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14"
+    },
+    {
+    "id": "is-js-type:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "73617006d659b4eb4729bba747d28782df0f7e22",
+    "md5": "89c1378f5a53fec687827f000e40d29b",
+    "sha256": "f3ec1367ed9ec52732c0deba6bbb00f5a6759ea7ae8925d224f7a489c938c57e"
+    },
+    {
+    "id": "get-caller-file:1.0.3",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
+    "md5": "ce960e0a028d4ddfe95928e6cac32e5f",
+    "sha256": "9d0406179fcf0878c05a8c9c71e6c3ba2f49a3f27bed593c78c7aa2051292b68"
+    },
+    {
+    "id": "kind-of:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20813df3d712928b207378691a45066fae72dd57",
+    "md5": "e24d0d555965b239fb2b6435b0724853",
+    "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29"
+    },
+    {
+    "id": "supports-color:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chalk:1.1.3",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "chalk:1.1.3",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
+    "md5": "49b5f44f9490b8f74f0d0061e2e2030d",
+    "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3"
+    },
+    {
+    "id": "extend-shallow:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "split-string:3.1.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
+    "md5": "194095206e18756d832f5e0ad3d71cb8",
+    "sha256": "a01acad649571a4afc14ac53871ba89c362664c17b65d1a3ebd949bad8647109"
+    },
+    {
+    "id": "y18n:3.2.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "85c901bd6470ce71fc4bb723ad209b70f7f28696",
+    "md5": "e27de69c4cd4979ea3ec3bfbd5eabd28",
+    "sha256": "ac7a166a921edf31c773fab8c303bab810ec60f682bbeb64d34b5c52242d7a39"
+    },
+    {
+    "id": "eslint-import-resolver-node:0.3.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4048b958395da89668252001dbd9eca6b83bacbd",
+    "md5": "bf0a201e44f3e437813f10b97923f452",
+    "sha256": "bab63db860b260d59ef3e6d370655565e912dc81088e1d9d064214c05bb5c836"
+    },
+    {
+    "id": "number-is-nan:1.0.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "is-fullwidth-code-point:1.0.0",
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "097b602b53422a522c1afb8790318336941a011d",
+    "md5": "1c192095065e6b72a7e20a747b110469",
+    "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c"
+    },
+    {
+    "id": "chalk:2.4.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cd42541677a54333cf541a49108c1432b44c9424",
+    "md5": "2c0467f3f122da3e7a9fccf05418b2c8",
+    "sha256": "d0884e52e616cba08dead7b848b06b86c2d7a279eaa17091154bb2572c85c671"
+    },
+    {
+    "id": "lowercase-keys:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-get-set-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-obj-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-proto-prop:1.0.1",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+    "md5": "de9b080b5e473d21200e69b8bfc7c204",
+    "sha256": "e8e8790d430a8250da4d1b4821051c7da7bdb2081e9d62d7270e0a5de99a42cb"
+    },
+    {
+    "id": "safe-buffer:5.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string_decoder:1.1.1",
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "991ec69d296e0313747d59bdfd2b745c35f8828d",
+    "md5": "dc7142b470e0957c5c34098b6fced0ab",
+    "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22"
+    },
+    {
+    "id": "lodash.keys:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
+    "md5": "d2aa104b88db88e2c0f1ed627031ed03",
+    "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e"
+    },
+    {
+    "id": "path-exists:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+    "md5": "7c2676f4502f776524cefe6e0b877136",
+    "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d"
+    },
+    {
+    "id": "is-weakref:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9529f383a9338205e89765e0392efc2f100f06f2",
+    "md5": "f13ba3475e03ab6e1d3e4f4bcd681b51",
+    "sha256": "97c4572be1529c60606e1269dabfb66d55ee86f8644bcafe23e136e513094505"
+    },
+    {
+    "id": "has-symbols:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-symbol:1.0.4",
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-tostringtag:1.0.0",
+    "is-string:1.0.7",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb7b2c4349251dce87b125f7bdf874aa7c8b39f8",
+    "md5": "de53cc38f69c9145fd5613d6457e01b3",
+    "sha256": "ddcc17682f1e12a9d00a1a8b656af941ed584914e55fc5caf1c2e7ce892ce6a6"
+    },
+    {
+    "id": "lodash.isarray:3.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.isplainobject:3.2.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.toplainobject:3.0.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseflatten:3.1.4",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash._pickbycallback:3.0.0",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keysin:3.0.8",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseassign:3.2.0",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseisequal:3.0.7",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.pairs:3.0.1",
+    "lodash._basecallback:3.3.1",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseeach:3.0.4",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.sortby:3.1.5",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash.template:3.6.2",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
+    "md5": "ac707272f6b31e82622b1d581110aec2",
+    "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd"
+    },
+    {
+    "id": "find-up:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
+    "md5": "cb9da6343737d03323119847685addf1",
+    "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d"
+    },
+    {
+    "id": "proto-props:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-proto-prop:1.0.1",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e2606581dd24aa22398aeeeb628fc08e2ec89c91",
+    "md5": "43c4cc31101ee8f37df9b66ff8353003",
+    "sha256": "e54ba8dfa4403ac326977bf590f330ec09978da1607e23f1b0305359ff376de2"
+    },
+    {
+    "id": "file-entry-cache:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c392990c3e684783d838b8c84a45d8a048458361",
+    "md5": "329f8f032842d7a2c711bd18423e5226",
+    "sha256": "4a9ff95ed770fc189389eb60bc99d0f4ffb5bea40a1f99d4f7610c9ecb8c2516"
+    },
+    {
+    "id": "shellwords:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d6b9181c1a48d397324c84871efbcfc73fc0654b",
+    "md5": "406c4d51a834f3ddddfaf96b9303af36",
+    "sha256": "6c81d4f9003e6856f9fb7f3f3cb712eb2bde63fcee7e40fa6d30849b29684402"
+    },
+    {
+    "id": "lodash._arraycopy:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+    "md5": "6de9a4e0d113c056078d1db4e75c748b",
+    "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7"
+    },
+    {
+    "id": "slice-ansi:0.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
+    "md5": "c6a421b62848c96d57d4394964a89162",
+    "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6"
+    },
+    {
+    "id": "isobject:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-plain-object:2.0.4",
+    "is-extendable:1.0.1",
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.pick:1.3.0",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-visit:1.0.1",
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+    "md5": "9e7647515c0885e809f9aeb22de293f3",
+    "sha256": "3cc6c92b005a644c93fbc9e3eb450b6a642bbca3443cc9dcc169152961367d37"
+    },
+    {
+    "id": "regexp.prototype.flags:1.4.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "87cab30f80f66660181a3bb7bf5981a872b367ac",
+    "md5": "61b7a182d81b12b7c8a9bc5105726ab0",
+    "sha256": "444df1245ed8a3a8f5afbffed1e9c589e4878fc3bf9021cb5a6c127f38ccbd95"
+    },
+    {
+    "id": "d:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-iterator:2.0.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.1",
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "event-emitter:0.3.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8698095372d58dbee346ffd0c7093f99f8f9eb5a",
+    "md5": "34f0b6b6c919df899c7c240deb36deed",
+    "sha256": "e7fb647f7a114c2f5bc547454b043c29dd13de095dc6f476b883b266993918a9"
+    },
+    {
+    "id": "is-equal-shallow:0.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "regex-cache:0.4.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2238098fc221de0bcfa5d9eac4c45d638aa1c534",
+    "md5": "79abafbc68151c75a7242adf69c9b7c5",
+    "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9"
+    },
+    {
+    "id": "color-convert:1.9.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb71850690e1f136567de629d2d5471deda4c1e8",
+    "md5": "b4f847ea1c00c2fdf3e4ff91864b1b1f",
+    "sha256": "12c413e46434f562cf3aa9a76080b71cfde72e0ce39c0df7a7fce1b0b56e0baa"
+    },
+    {
+    "id": "debug:3.2.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-import-resolver-node:0.3.6",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "72580b7e9145fb39b6676f9c5e5fb100b934179a",
+    "md5": "0f887df93ceeaa5784063eb8733a6778",
+    "sha256": "72378f4db53abdf4c6d094e85169b0dc35a404ea4257da13ecafeda029a21c84"
+    },
+    {
+    "id": "flat-cache:1.3.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c2ef77525cc2929007dfffa1dd314aa9c9dee6f",
+    "md5": "7f7fe842b74285784727aedf7cf81c4b",
+    "sha256": "dca0a991c51e348120976d6b347b42b19ed015cdf6e4cbaf7cc83e4a8a73e875"
+    },
+    {
+    "id": "micromatch:3.1.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "70859bc95c9840952f359a068a3fc49f9ecfac23",
+    "md5": "cbd070da8fd1f67270cb23f613bd7f2c",
+    "sha256": "e59e75293e290db328efbf5bf1b4b445bffbfda19546974b442b6ad1910f95c8"
+    },
+    {
+    "id": "camelcase:3.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs-parser:2.4.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
+    "md5": "d9d2d730959290cbbb9ef3900cd6126c",
+    "sha256": "78d8cda9e83918a86491c8fb8d71a3ad7851cd562ab00807319be35371c16d02"
+    },
+    {
+    "id": "is-glob:4.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+    "md5": "f2ae49ffa6c02bb48edae7c9360785b9",
+    "sha256": "3fe453fb193bb58f6f0505dfb1151230935380b5b55e1f9864261c2aafc1bec6"
+    },
+    {
+    "id": "which-module:1.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
+    "md5": "004cd541632e781023b01a91b2d4b851",
+    "sha256": "2099f8a4be322bae4d0d5c55b16e8916fab3f73a22b08bc22dd3c3faaae54786"
+    },
+    {
+    "id": "read-pkg-up:1.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "meow:3.7.0",
+    "dateformat:1.0.12",
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
+    "md5": "02cc53c7512931912dcbdcd9c1d55265",
+    "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726"
+    },
+    {
+    "id": "is-posix-bracket:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-brackets:0.1.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
+    "md5": "cd1bc456317e6cf7357683e79b8354c5",
+    "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07"
+    },
+    {
+    "id": "string_decoder:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+    "md5": "7b93eea8153258fea64c3192922effaa",
+    "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a"
+    },
+    {
+    "id": "resolve-from:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-mocha:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
+    "md5": "e19abe316d7d524402ff940ff923406c",
+    "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687"
+    },
+    {
+    "id": "anymatch:1.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "553dcb8f91e3c889845dfdba34c77721b90b9d7a",
+    "md5": "ae54bd38b51eabedd6fb005608b3d4fb",
+    "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3"
+    },
+    {
+    "id": "preserve:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "815ed1f6ebc65926f865b310c0713bcb3315ce4b",
+    "md5": "bca875c4e8d238ef216dc9d1bcabf976",
+    "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382"
+    },
+    {
+    "id": "pascalcase:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+    "md5": "0c6e0012f1d98450a08a7b76b55a3296",
+    "sha256": "556c9cd92f0374592aa0ba702e6c3c402bdb0b0145ffde060a8343a7b3f4a241"
+    },
+    {
+    "id": "is-descriptor:0.1.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "366d8240dde487ca51823b1ab9f07a10a78251ca",
+    "md5": "8e793e2a6d3bef3145c7bfae02099c0a",
+    "sha256": "b0d542e7aa38610efea55af9bf42c812a73d93ae522b1ceaa106f831900bb06a"
+    },
+    {
+    "id": "redeyed:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cardinal:2.1.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8984b5815d99cb220469c99eeeffe38913e6cc0b",
+    "md5": "b143ff11e6aece5ad2722daebb73c708",
+    "sha256": "51cb0de797c354a4f8646ced531db40e9891f7a2bf45f0579ccc332ab6afec83"
+    },
+    {
+    "id": "isexe:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which:1.3.1",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+    "md5": "02bf57881fa200bcd6501e4ded2b1b3a",
+    "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359"
+    },
+    {
+    "id": "eslint-plugin-import:2.26.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f812dc47be4f2b72b478a021605a59fc6fe8b88b",
+    "md5": "9f46ab62fb92c3f10d14890b32b7d0bb",
+    "sha256": "bddeb1bd17cefa19c56b5e9cc861f667e0c82dcc35ee49aad27b1781f616753e"
+    },
+    {
+    "id": "es-to-primitive:1.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e55cd4c9cdc188bcefb03b366c736323fc5c898a",
+    "md5": "a32f26c478b76efa377601b8d17268a9",
+    "sha256": "f30558271d77e69fffa5eea8b4d990fff7cfa9d33e1168d0e28982179e698bea"
+    },
+    {
+    "id": "type:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "d:1.0.1",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "848dd7698dafa3e54a6c479e759c4bc3f18847a0",
+    "md5": "f48dfa6ff6c81629ec0dfc40f804baae",
+    "sha256": "2c11486dfba9243869ee20e217e3885d75694b0276554075495d6480af2897a6"
+    },
+    {
+    "id": "is-binary-path:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
+    "md5": "a989667cf8d696127090b72fe8a674b3",
+    "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417"
+    },
+    {
+    "id": "is-number:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0026e37f5454d73e356dfe6564699867c6a7f0ff",
+    "md5": "0d25f55f9f226fc7c7ae6fb06c9ee46a",
+    "sha256": "5e5bccc70a0fcc5d10e146678a50ee0b2e1cf6ef0f054b6793ca70c025c587b8"
+    },
+    {
+    "id": "spdx-expression-parse:3.0.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-correct:3.1.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
+    "md5": "69faa9bdd7b8eaf4d1e8a91f3dce9fb7",
+    "sha256": "01a89e6a60412e344e74ed81f370fd7d33bbb658773f0cee6e2f15ea15449d1f"
+    },
+    {
+    "id": "sprintf-js:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "argparse:1.0.7",
+    "js-yaml:3.6.0",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "argparse:1.0.10",
+    "js-yaml:3.14.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+    "md5": "8e6b31a052754055683e4a35a317feab",
+    "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83"
+    },
+    {
+    "id": "has-property-descriptors:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610708600606d36961ed04c196193b6a607fa861",
+    "md5": "7f67f61d09b2f2e9faa560ba49b21e85",
+    "sha256": "1ea75b75dc4e6f491cb9f736cb49265ada125f8bf23fc43cff6d16c1c6435f97"
+    },
+    {
+    "id": "is-regex:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eef5663cd59fa4c0ae339505323df6854bb15958",
+    "md5": "13a02d0abc63ff0093ca592e999f713c",
+    "sha256": "2791dd704e8ad3e7ec22e03c68fd8ae82dcc640a8592696fbf6c940691a3303c"
+    },
+    {
+    "id": "eslint-plugin-lodash:2.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "66cdc1070b7c9d4b749368b54820886380a14c35",
+    "md5": "7673c712d2af4c5fdc07ae78775670d6",
+    "sha256": "9e67cdf256147a95c6d3050de2d4d09ed6f9c188fe462ab5697c56bee39ff042"
+    },
+    {
+    "id": "string-width:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+    "md5": "b8aa95585646db49430dbaf185daec5d",
+    "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c"
+    },
+    {
+    "id": "window-size:0.2.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b4315bb4214a3d7058ebeee892e13fa24d98b075",
+    "md5": "250499d281e44d2783aec6cfc458e96a",
+    "sha256": "9c88e1fb3a281deca778c63f97e3cfc70f6f2db8555c6aefcd7223c94fffd91d"
+    },
+    {
+    "id": "ignore:3.3.10",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0a97fb876986e8081c631160f8f9f389157f0043",
+    "md5": "623073ae841f6a00f1d93c50f97065ad",
+    "sha256": "8c633bb8f87352f298c2951032fd7896fb70e6c7fec08ec7eee2571f6562a48a"
+    },
+    {
+    "id": "regenerator-runtime:0.11.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-runtime:6.26.0",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+    "md5": "728ac808fb5276bf420fab33620d0c39",
+    "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b"
+    },
+    {
+    "id": "optionator:0.8.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+    "md5": "88d19ffad4cd8e6737eeb831d4ff761a",
+    "sha256": "51efe6489e57535da59e1abd1c1c44a90a29ff5ee8bd8ce5ca1b3c007dd6bd3d"
+    },
+    {
+    "id": "has-flag:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e8207af1cc7b30d446cc70b734b5e8be18f88d51",
+    "md5": "7ba03f6b47769f2acdc743ac0b23e339",
+    "sha256": "0915ab7bab71d000cd1ccb70b4e29afe1819183538339c8953bc9d3344bc4241"
+    },
+    {
+    "id": "pinkie:2.0.4",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pinkie-promise:2.0.1",
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pinkie-promise:2.0.1",
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pinkie-promise:2.0.1",
+    "find-up:1.1.2",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+    "md5": "41b57c993d8571d9211d5b6c1c75ba7b",
+    "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83"
+    },
+    {
+    "id": "has-flag:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "supports-color:5.5.0",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "supports-color:5.5.0",
+    "supports-hyperlinks:1.0.1",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+    "md5": "1fa1fa951639c7058277abcecca86922",
+    "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea"
+    },
+    {
+    "id": "eslint-plugin-mocha:4.12.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dbacc543b178b4536ec5b19d7f8e8864d85404bf",
+    "md5": "3e429cc644ee80c1c60c86478eee616b",
+    "sha256": "bff1ad657ac8617b7f8b3d49846397dfdec9970b4a7b4fa6a7b95d067fdabca0"
+    },
+    {
+    "id": "assign-symbols:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+    "md5": "e9bb66200b728da39a79c2f235780331",
+    "sha256": "4b7571316a051e6b9c816119fecabc1c23f2d3d72ece4150a28436f89f59ecd2"
+    },
+    {
+    "id": "eslint-plugin-flowtype:2.50.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "61379d6dce1d010370acd6681740fd913d68175f",
+    "md5": "b4c51bbcef5a4a27b8a7fd444c353b32",
+    "sha256": "ed4dc881b6b6952779c0f07ef33921a928fc2f71756190062a55b41caad84252"
+    },
+    {
+    "id": "locate-path:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
+    "md5": "3241773d42e4709beacb91d0e7d92331",
+    "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2"
+    },
+    {
+    "id": "unbox-primitive:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "29032021057d5e6cdbd08c5129c226dff8ed6f9e",
+    "md5": "f8a4b8d86554bfb4b6901ac51bf00863",
+    "sha256": "733eb170b51adb49104a823ed62f1a4606b45ee1e886178f12a1a00fb04fca1d"
+    },
+    {
+    "id": "supports-hyperlinks:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "71daedf36cc1060ac5100c351bb3da48c29c0ef7",
+    "md5": "ac43da5665ec45c28303793339d60e5f",
+    "sha256": "d050baf93bdf8f351811929f5a66cf9563bc93d8505caccfd543cb8ef8fc29a4"
+    },
+    {
+    "id": "lodash._baseclone:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.clonedeep:3.0.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "303519bf6393fe7e42f34d8b630ef7794e3542b7",
+    "md5": "553b734a6902f3363cf41de744286bab",
+    "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549"
+    },
+    {
+    "id": "is-negative-zero:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7bf6f03a28003b8b3965de3ac26f664d765f3150",
+    "md5": "0b44a640179fbf8b79bfbbec6a583cbd",
+    "sha256": "ec49e5479930b982f3ba208ccf366a5b711957865ae2b3cab9ce53cea85656bb"
+    },
+    {
+    "id": "color-name:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "color-convert:1.9.3",
+    "ansi-styles:3.2.1",
+    "chalk:2.4.2",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+    "md5": "b45186c4fe76a2450ec484149ade0066",
+    "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e"
+    },
+    {
+    "id": "normalize-path:2.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+    "md5": "b2f3932160dc03a5604dbac60ef59c34",
+    "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5"
+    },
+    {
+    "id": "has-values:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+    "md5": "b22e4bd0ee56cd167cb12437533618b1",
+    "sha256": "8caff002766ef426bae3d98dfa2ac180fa7adbf54bc1bd6de7b2c682e057efa5"
+    },
+    {
+    "id": "debug:2.6.9",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5d128515df134ff327e90a4c93f4e077a536341f",
+    "md5": "cb6cb63ab5843aee3af94d27c60ea476",
+    "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98"
+    },
+    {
+    "id": "has-tostringtag:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-date-object:1.0.5",
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-regex:1.1.4",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-boolean-object:1.1.2",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number-object:1.0.7",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-string:1.0.7",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7e133818a7d394734f941e73c3d3f9291e658b25",
+    "md5": "25e5a30ea25da9a3e5cf67924512233a",
+    "sha256": "d9c16499115e27d87e091a2f35c27b16ccf2a3a9b7274ccd6a4be374ca755213"
+    },
+    {
+    "id": "filename-regex:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
+    "md5": "59404a8f8ff7bd9ca7c88bec2cb7487e",
+    "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b"
+    },
+    {
+    "id": "strip-ansi:4.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
+    "md5": "f0aa5746513c46c807ea71744ec2bc5c",
+    "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d"
+    },
+    {
+    "id": "is-primitive:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-equal-shallow:0.1.3",
+    "regex-cache:0.4.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "207bab91638499c07b2adf240a41a87210034575",
+    "md5": "73402009e3936aeaa7b5c473d090b017",
+    "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8"
+    },
+    {
+    "id": "is-date-object:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0841d5536e724c25597bf6ea62e1bd38298df31f",
+    "md5": "3b3393d413d848d50129f3f80d37e86a",
+    "sha256": "3312b2b10df8e3f2465948a62e1c6cfb9007edb7ea9c9f8d81b0bb8afbeec5d4"
+    },
+    {
+    "id": "arr-diff:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8f3b827f955a8bd669697e4a4256ac3ceae356cf",
+    "md5": "5aa32e7c03b612d64d433306ecfcd392",
+    "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0"
+    },
+    {
+    "id": "onetime:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "restore-cursor:1.0.1",
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
+    "md5": "7ae8e80cbc47e97d95e30f4e4f382ea8",
+    "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a"
+    },
+    {
+    "id": "graceful-fs:4.2.10",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "147d3a006da4ca3ce14728c7aefc287c367d7a6c",
+    "md5": "094ac6976c4cec6cced67915d6c726c0",
+    "sha256": "b9d05da264d6668f952e6a17b2bf8f3955e977366dabf7c3cdfab3850dd14c6d"
+    },
+    {
+    "id": "union-value:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b6fe7b835aecda61c6ea4d4f02c14221e109847",
+    "md5": "5438ca0bb737dc01e85a61121dcc3626",
+    "sha256": "e5c8fb011e6aeadb3d8d68db81c356a6e7e48dedebe31465de45dabe21e13203"
+    },
+    {
+    "id": "is-symbol:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-to-primitive:1.2.1",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6dac93b635b063ca6872236de88910a57af139c",
+    "md5": "1d481161785d0b7c5a729e39edb86e9a",
+    "sha256": "7c8fe125590c7cbf68267b069c467cd526b69925072d2f2fe45b2fd46530dc0f"
+    },
+    {
+    "id": "is-shared-array-buffer:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8f259c573b60b6a32d4058a1a07430c0a7344c79",
+    "md5": "478da999f49b20d86406f760d98af885",
+    "sha256": "1fe57e0f2a80050e5b0c2d1fed9eec189c1a7650bfb2f6cb800537929961fa90"
+    },
+    {
+    "id": "word-wrap:1.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "610636f6b1f703891bd34771ccb17fb93b47079c",
+    "md5": "48773dbe44ca6aae3bc6b49e7cecddfe",
+    "sha256": "64fbda023432cc8dc32b15d6be6a30d024ee07f16a32b2405209ba4a9f1dfcd9"
+    },
+    {
+    "id": "core-util-is:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6042d3634c2b27e9328f837b965fac83808db85",
+    "md5": "b1d6a20c5b4105190dd24baaa65b43b7",
+    "sha256": "4430fdc71f2cf3b5e297113b9a692da2d6cff96cf84da00f0ecef5e5a6e74d0c"
+    },
+    {
+    "id": "chalk:1.1.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.8.0",
+    "babel-traverse:6.8.0",
+    "babel-plugin-transform-es2015-block-scoping:6.8.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-code-frame:6.7.7",
+    "babel-traverse:6.7.6",
+    "babel-eslint:6.0.4",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fancy-log:1.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-util:3.0.7",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp:3.9.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "run-sequence:1.1.5",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
+    "md5": "d7e0f89d6888d5d9ced994c205926555",
+    "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d"
+    },
+    {
+    "id": "acorn:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "acorn-jsx:3.0.1",
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
+    "md5": "e851da28b89b69e6c1aa7f0ed8d83154",
+    "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e"
+    },
+    {
+    "id": "text-table:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
+    "md5": "4e595139988957453229d6ccd229f626",
+    "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772"
+    },
+    {
+    "id": "js-tokens:3.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "babel-code-frame:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "loose-envify:1.4.0",
+    "invariant:2.2.4",
+    "babel-traverse:6.26.0",
+    "babel-eslint:7.2.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9866df395102130e38f7f996bceb65443209c25b",
+    "md5": "969180644218c18794b6df26d42accd5",
+    "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19"
+    },
+    {
+    "id": "es-shim-unscopables:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "702e632193201e3edf8713635d083d378e510241",
+    "md5": "b84453b40e877a87ea66b886373597f4",
+    "sha256": "a8accca616c58a9c8ce92bc27d9d287d3948cf8310af5fa05d69c1a14d156761"
+    },
+    {
+    "id": "wrappy:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "once:1.4.0",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+    "md5": "567b1699cfae49cb20f598571a6c90c7",
+    "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb"
+    },
+    {
+    "id": "parse-glob:3.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2c376cfb11f35513badd173ef0bb6e3a388391c",
+    "md5": "30e8c3a31d6b2fb80f6171f8e5f5adbb",
+    "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de"
+    },
+    {
+    "id": "regex-cache:0.4.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "75bdc58a2a1496cec48a12835bc54c8d562336dd",
+    "md5": "c08a04a26436892d55f3d2fb294d8b73",
+    "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480"
+    },
+    {
+    "id": "readable-stream:2.3.7",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "comment-parser:0.4.2",
+    "eslint-plugin-jsdoc:2.4.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1eca1cf711aef814c04f62252a36a62f6cb23b57",
+    "md5": "f060c259b513e887f551d073950f12f9",
+    "sha256": "09a07ecf7aa5dce26bad942925abb75fcb85e058f90e42a6329102374d3477c7"
+    },
+    {
+    "id": "is-descriptor:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-property:1.0.0",
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:2.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:1.0.0",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "define-property:1.0.0",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3b159746a66604b04f8c81524ba365c5f14d86ec",
+    "md5": "7cd33adcb4ca927942b08b261badd3ed",
+    "sha256": "fe5ee7a359c2ae4ec7c12a075d903150c23365bf55c0c471b8d34fade96c6ead"
+    },
+    {
+    "id": "figures:1.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
+    "md5": "a9fd6eca788b3ba9bb137fd0b6ec9775",
+    "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89"
+    },
+    {
+    "id": "node-emoji:1.11.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "69a0150e6946e2f115e9d7ea4df7971e2628301c",
+    "md5": "40310f4209362a8df02af58dac079c7d",
+    "sha256": "7b964b4c4fc3047466d66134bf00177244917ed7b45a61708362557b496fac58"
+    },
+    {
+    "id": "pragmatist:3.0.24",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1c6c6203c605dc147677f30dc0aa3d89aa227297",
+    "md5": "282125ff6b702db1e05de93b7b866982",
+    "sha256": "c3bfccad8a4e47d80a5f21446bb3535c85cec8fe1ee8d029c6c1bbc6d3e91255"
+    },
+    {
+    "id": "is-core-module:2.9.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e1c34429cd51c6dd9e09e0799e396e27b19a9c69",
+    "md5": "9862dd9912e0d8158cdb2b339c0ee148",
+    "sha256": "2ba3f3317b3f4055f45e879068a1c37dafef035b407282e420ccf5fa8c13cc6d"
+    },
+    {
+    "id": "acorn:5.7.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "espree:3.5.4",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3e8d8a9947d0599a1796d10225d7432f4a4acf5e",
+    "md5": "861b7e390cd4b067b90229f4b9eec0c9",
+    "sha256": "6f7cdde77522083c2c055aea62f295cb2cb9de2ee301183cc3cb5c73d72e5cbb"
+    },
+    {
+    "id": "ansi-regex:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "strip-ansi:4.0.0",
+    "string-width:2.1.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "123d6479e92ad45ad897d4054e3c7ca7db4944e1",
+    "md5": "7f893ad90437fcded52211151e305234",
+    "sha256": "989c0a482af8797e890d899bdc0c54c343900a5303617604a1c39a98c0a76457"
+    },
+    {
+    "id": "is-number:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "01fcbbb393463a548f2f466cce16dece49db908f",
+    "md5": "16a0b10f0dab47199d6536d319c0c6d5",
+    "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f"
+    },
+    {
+    "id": "is-get-set-prop:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2731877e4d78a6a69edcce6bb9d68b0779e76312",
+    "md5": "584a9b87fdbea36d9c9f3a4b7d8bc2ed",
+    "sha256": "c0bc6a18cbc003208ba8e0293ba9090699d1059fa7cde630bfa822cc130cbf72"
+    },
+    {
+    "id": "object-assign:4.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "figures:1.7.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
+    "md5": "4f52c397ba44c57bcf6ed38d7f2c3f8e",
+    "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed"
+    },
+    {
+    "id": "array-unique:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+    "md5": "c7fa44b0117a3ed0d161f876c68633f7",
+    "sha256": "2fbdcf30f58eda555408afc8d61f763c988061e27f11589ac227661c1059792e"
+    },
+    {
+    "id": "safe-regex:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "regex-not:1.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+    "md5": "6729d2a26cdabb856b9506e567bd8a57",
+    "sha256": "621289fa8cba8059e2e73a8d916b71b03fc7aef591c0e66373765c5951f96cd2"
+    },
+    {
+    "id": "is-fullwidth-code-point:1.0.0",
+    "scopes": [
+    "prod",
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "table:3.7.8",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string-width:1.0.2",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+    "md5": "edbd4281a6ac4fb8d1082592c411f250",
+    "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c"
+    },
+    {
+    "id": "kind-of:3.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-number:2.1.0",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon-util:3.0.1",
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-number:3.0.0",
+    "has-values:1.0.0",
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-object-path:0.3.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object-copy:0.1.0",
+    "static-extend:0.1.2",
+    "class-utils:0.3.6",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-accessor-descriptor:0.1.6",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-data-descriptor:0.1.4",
+    "is-descriptor:0.1.6",
+    "define-property:0.2.5",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+    "md5": "c46cdfc40c94b44938f30b7254194d92",
+    "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47"
+    },
+    {
+    "id": "esrecurse:4.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7ad7964d679abb28bee72cec63758b1c5d2c9921",
+    "md5": "a39f104614e3543dd4522ac4afdace00",
+    "sha256": "3ecf9370d7296b47b570c88a11f70b35bb965af8d536536b259eb55f9b793b61"
+    },
+    {
+    "id": "find-up:1.1.2",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+    "md5": "c5c3ff7b1ec7ab9eb8d205cee67491f3",
+    "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f"
+    },
+    {
+    "id": "lodash.assign:4.2.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs-parser:2.4.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0d99f3ccd7a6d261d19bdaeb9245005d285808e7",
+    "md5": "5a92447d4e8669abba120d5164892902",
+    "sha256": "5585c7be7dbc6a194d759d913406444675a98c40e7e572848158631e2e89a743"
+    },
+    {
+    "id": "get-symbol-description:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
+    "md5": "e14a4c666fa15e9f9173046700ead218",
+    "sha256": "49ae7d22b2c841784307a90ec1fcd9c515c594cb3f56c8d66e94adc6a6426fbc"
+    },
+    {
+    "id": "caller-path:0.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "require-uncached:1.0.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "require-uncached:1.0.2",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "94085ef63581ecd3daa92444a8fe94e82577751f",
+    "md5": "9196bdec9c17e0b57791a88bd1fa5bf1",
+    "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb"
+    },
+    {
+    "id": "concat-stream:1.6.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
+    "md5": "f3d719f26732b5206541e52972316e84",
+    "sha256": "ca47c159978bc826d964dfe45923dc61894551cc547c9f226f95fc90d47c43f1"
+    },
+    {
+    "id": "resolve-url:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "source-map-resolve:0.3.1",
+    "css:2.2.1",
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
+    "md5": "b515d6d96cd554cb0cda158563e82e00",
+    "sha256": "88e9cb578b6373125c416cacb9f42c4896fe3e072e4b94ba6948cba70e551824"
+    },
+    {
+    "id": "supports-preserve-symlinks-flag:1.0.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "resolve:1.22.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6eda4bd344a3c94aea376d4cc31bc77311039e09",
+    "md5": "2ecf7c03c814ab155c5278d61f65583f",
+    "sha256": "97da1160af5344534182e72502978374d20875d32c6071cd2dae997be604f7f9"
+    },
+    {
+    "id": "generate-function:2.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f069617690c10c868e73b8465746764f97c3479f",
+    "md5": "b4fd862f79a3a0a097ea8818a5858d22",
+    "sha256": "6a4d880c7f170c3277a954b4d6ac1686e20494bb8b964d2f278fcb31d4e68d79"
+    },
+    {
+    "id": "function.prototype.name:1.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "cce0505fe1ffb80503e6f9e46cc64e46a12a9621",
+    "md5": "791d82804001c74e1c7b5f14f9f9f9ef",
+    "sha256": "75022ef5d9b8056827769df3cc8dccb7f023baf7850ebeeced921cccfd6cce10"
+    },
+    {
+    "id": "isarray:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "doctrine:1.5.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "doctrine:1.2.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "isobject:2.1.0",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "isobject:2.1.0",
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "through2:2.0.1",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
+    "md5": "c24471c617803171eed93b3516624c97",
+    "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87"
+    },
+    {
+    "id": "remove-trailing-separator:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "normalize-path:2.1.1",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+    "md5": "b22754e30e8983a5be8c5469d4ee5f8d",
+    "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321"
+    },
+    {
+    "id": "espree:3.5.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b0f447187c8a8bed944b815a660bddf5deb5d1a7",
+    "md5": "84b02c58a8ae5ce3da5886773141518b",
+    "sha256": "905abefaa17fd38828c3856da974e877948f4d9114a659af3dabb2518b35534a"
+    },
+    {
+    "id": "is-boolean-object:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5c6dc200246dd9321ae4b885a114bb1f75f63719",
+    "md5": "6c467d1aa73d0b9e512c5e2255af0d49",
+    "sha256": "c499b666c52f648be1445f37ce03c657a76abc543f5a71010572593164fcf2b3"
+    },
+    {
+    "id": "babel-eslint:7.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b2fe2d80126470f5c19442dc757253a897710827",
+    "md5": "85d7580cf18c64e2b1cd165832032bbc",
+    "sha256": "57ae087ab58b7d259ccd42682129017ee78e1e8aca22c37ac63101d3074efe3a"
+    },
+    {
+    "id": "call-bind:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-symbol-description:1.0.0",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "side-channel:1.0.4",
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-regex:1.1.4",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-shared-array-buffer:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-weakref:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-boolean-object:1.1.2",
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
+    "md5": "d244c20a7b3f2c607030df6337a4e68d",
+    "sha256": "c3956f8ad486c8ed25508d016738e3fc2126f9b77c89a080263cdf05e214341a"
+    },
+    {
+    "id": "is-obj-prop:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b34de79c450b8d7c73ab2cdf67dc875adb85f80e",
+    "md5": "7998f3c8c78b764eaf429e1c5b5a32a5",
+    "sha256": "cd13e95f3c090100a4305155e9ad93597f3c4d3683055a1686390ca725f81a39"
+    },
+    {
+    "id": "mute-stream:0.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readline2:1.0.1",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
+    "md5": "597b34af22c4237293f5c05cd5f74214",
+    "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde"
+    },
+    {
+    "id": "buffer-from:1.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
+    "md5": "5fe5f473dc3263473041a56654581058",
+    "sha256": "9c2b03d59eca8f463a1927e07273ddaa87785fe3f61626c42b005540e962e343"
+    },
+    {
+    "id": "concat-map:0.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.4",
+    "minimatch:2.0.10",
+    "babel-core:6.8.0",
+    "babel-plugin-transform-regenerator:6.8.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "brace-expansion:1.1.3",
+    "minimatch:3.0.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+    "md5": "d11d2d19ce6c3d9326cb3e987e8bcd23",
+    "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261"
+    },
+    {
+    "id": "object-visit:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "map-visit:1.0.0",
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+    "md5": "0c309d8c43bc9546676100500c1db1c4",
+    "sha256": "545feba3c3f1b32996f96431e92179645da5d88205555cc56c80602f0fd41717"
+    },
+    {
+    "id": "ansi-regex:2.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "has-ansi:2.0.0",
+    "chalk:1.1.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "strip-ansi:3.0.1",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+    "md5": "1dbdbf937d51c399e3feaf40bd339ea2",
+    "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037"
+    },
+    {
+    "id": "repeat-string:1.6.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex-range:2.1.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
+    "md5": "ed49a5a26c9110a28411da1cded28e3a",
+    "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe"
+    },
+    {
+    "id": "snapdragon-util:3.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "snapdragon-node:2.1.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f956479486f2acd79700693f6f7b805e45ab56e2",
+    "md5": "17c194e41dd12d561800985ef5b4ffdf",
+    "sha256": "4ed40e99aaa722b95031051295eae4bd6d00d5914e560261d6b73e4563668e30"
+    },
+    {
+    "id": "eslint-plugin-react:6.10.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c5435beb06774e12c7db2f6abaddcbf900cd3f78",
+    "md5": "fabc99b1e4722b4e10fe41f348940da3",
+    "sha256": "416e867bb55387107422dc1c47c2fba533213ffa6830fa7d1381f66a68ce7b4d"
+    },
+    {
+    "id": "is-property:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "generate-function:2.3.1",
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "generate-object-property:1.2.0",
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "generate-object-property:1.2.0",
+    "is-my-json-valid:2.13.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "57fe1c4e48474edd65b09911f26b1cd4095dda84",
+    "md5": "29d8709ba7392da7846b05c30cb83832",
+    "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870"
+    },
+    {
+    "id": "table:3.8.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
+    "md5": "caa5899fd31138fdbe11b2944fdf16e4",
+    "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0"
+    },
+    {
+    "id": "decode-uri-component:0.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "source-map-resolve:0.5.3",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
+    "md5": "f933f2c7592a035c86bc1b4d026bb2d7",
+    "sha256": "0a3e427c86cd249b0b402907132bf8ba85efb2a34ed1d2b3aa4694fd21730ad6"
+    },
+    {
+    "id": "obj-props:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-obj-prop:1.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9a9beebb6faf8b287ff7dc1cd133a4247dc85641",
+    "md5": "ace7f0609a71a11dbb9532032b2acab8",
+    "sha256": "41eaa9b49ccc882b9db952d448a180d1c4a5ee17c344634c046ff58ecb4da71a"
+    },
+    {
+    "id": "write:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5fc03828e264cea3fe91455476f7a3c566cb0757",
+    "md5": "935d10b6c5bf569dab4f5d2ec923e1c6",
+    "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25"
+    },
+    {
+    "id": "ansi-escapes:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d3a8a83b319aa67793662b13e761c7911422306e",
+    "md5": "ea55c40ff49fb40e9e2a75072fae0e1b",
+    "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec"
+    },
+    {
+    "id": "has-values:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+    "md5": "59bfd41b8b69c52c77823af62b7bada7",
+    "sha256": "a6826e9f6b99687fd5d655374a5a6e9a1dd99af24c8f9a71ec9d025e3817d7d2"
+    },
+    {
+    "id": "object.values:1.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "959f63e3ce9ef108720333082131e4a459b716ac",
+    "md5": "9b0b1fc1c92a2d24b2b92e11f89f85ab",
+    "sha256": "efa1123c610b37fdcf537baf9affbf52e7990a33e0584f8f2b52bbdb67418df4"
+    },
+    {
+    "id": "glob:7.2.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "rimraf:2.6.3",
+    "flat-cache:1.3.4",
+    "file-entry-cache:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "shelljs:0.7.8",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b",
+    "md5": "16222090f290ce18931eb40cec43fa2a",
+    "sha256": "f0a38eb1318c06cb55dc28f3f32d2df7379e155cefc6a1e5ecc7a0ddad194381"
+    },
+    {
+    "id": "spdx-exceptions:2.3.0",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-expression-parse:3.0.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3f28ce1a77a00372683eade4a433183527a2163d",
+    "md5": "acbb50a4dc418357a51310b852eb2e38",
+    "sha256": "6764ce70da3e6a716b2c9688e9c0adbe384b04233f63f19d986fd057522a0410"
+    },
+    {
+    "id": "spdx-license-ids:3.0.11",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "spdx-correct:3.1.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "spdx-expression-parse:3.0.1",
+    "validate-npm-package-license:3.0.4",
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
+    "md5": "f23bcef1dddee8c6adde84ee5d2532f1",
+    "sha256": "e0c164edbde4c2f68009c409caa439a1cdc2c19ba53a16910e7ad3db55e60913"
+    },
+    {
+    "id": "deep-is:0.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6f2dce612fadd2ef1f519b73551f17e85199831",
+    "md5": "5ae2691701dad1aec2e6bc66a610fbbe",
+    "sha256": "0c03aa83c6bf68e7c2cc2c5b5a2d732c1879e7711b08011b0bc48df10d10bf3c"
+    },
+    {
+    "id": "math-random:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "randomatic:3.1.1",
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5dd6943c938548267016d4e34f057583080c514c",
+    "md5": "029796aed5b40e10d30518bc21ad436a",
+    "sha256": "5d622b4156039240fbf67904040e54fc6ae5466c4d401204cb3154e2d8ba0221"
+    },
+    {
+    "id": "require-main-filename:1.0.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+    "md5": "cb0cbe764a2f9bce39dfb31fe54f7d0e",
+    "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3"
+    },
+    {
+    "id": "cache-base:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
+    "md5": "36ecc4dca8dd03f3a4e56e2f99cbc753",
+    "sha256": "e870d5b8a27320468651257576c9d5503c60b05aa274980653a5a36b231fdec6"
+    },
+    {
+    "id": "jsonpointer:5.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2110e0af0900fd37467b5907ecd13a7884a1b559",
+    "md5": "d6ef3969001e1025effb07a76ff8e3ca",
+    "sha256": "72c2fe2b1034905ed19b2477ccea0167a8490f1ff4e306f3a63a74c7a2ef1e10"
+    },
+    {
+    "id": "util-deprecate:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.0.6",
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "readable-stream:2.0.6",
+    "through2:2.0.1",
+    "gulp-babel:6.1.2",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+    "md5": "280e304a953ba3a89f52cc6ad616b284",
+    "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5"
+    },
+    {
+    "id": "readline2:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.11.4",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "41059608ffc154757b715d9989d199ffbf372e35",
+    "md5": "4e61bfb7db0673cc96401d5c3eea081c",
+    "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681"
+    },
+    {
+    "id": "p-locate:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "locate-path:2.0.0",
+    "find-up:2.1.0",
+    "eslint-module-utils:2.7.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20a0103b222a70c8fd39cc2e580680f3dde5ec43",
+    "md5": "1dd1c9d3ebad6ad80815da62a0d3cf43",
+    "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46"
+    },
+    {
+    "id": "has:1.0.3",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "internal-slot:1.0.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-shim-unscopables:1.0.0",
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-core-module:2.9.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+    "md5": "b765203b0d733534ee6a58d84767223a",
+    "sha256": "c38cf9eefce04e58ec3e945bfe448b9236d64f9337f6bf6e1f62e1c5b6b05573"
+    },
+    {
+    "id": "string-width:1.0.2",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "wrap-ansi:2.1.0",
+    "cliui:3.2.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+    "md5": "c7c4f2c7a348f40cfadc978bbcc30af5",
+    "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d"
+    },
+    {
+    "id": "binary-extensions:1.13.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-binary-path:1.0.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "598afe54755b2868a5330d2aff9d4ebb53209b65",
+    "md5": "013fed37056567a27186a86285f28efd",
+    "sha256": "704e8165efa63d5930fea63ebd9d564ccab1416e58ae9fe9e2df1085a52e509c"
+    },
+    {
+    "id": "eslint-plugin-babel:3.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2f494aedcf6f4aa4e75b9155980837bc1fbde193",
+    "md5": "ffa1c7a89bc7fc874f5ed2c978290cb9",
+    "sha256": "22f525abf8a6107b419024686edaa06bd0d6dade6e778e9567dfeefb61864d4b"
+    },
+    {
+    "id": "is-bigint:1.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "which-boxed-primitive:1.0.2",
+    "unbox-primitive:1.0.2",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "08147a1875bc2b32005d41ccd8291dffc6691df3",
+    "md5": "54f51f1529d609a8762b6f18a9fc5f39",
+    "sha256": "4079a06416a7859fd7d4d7d62277b542664440d0a6e532312e177b4041254ed6"
+    },
+    {
+    "id": "is-dotfile:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
+    "md5": "9c1b18df01884a55636db529eca19fe2",
+    "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e"
+    },
+    {
+    "id": "process-nextick-args:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "readable-stream:2.3.7",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+    "md5": "09e1b13837638717ed3f2aae7bc700db",
+    "sha256": "425bf8c725d23bc5ac76bcedd10d9cdbbd6354c7273dd7def44417cfbca8889b"
+    },
+    {
+    "id": "marked:0.7.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "b64201f051d271b1edc10a04d1ae9b74bb8e5c0e",
+    "md5": "2981b17fa46348526d23658960663d88",
+    "sha256": "d2f79bcb72acf01f054c904506723410a6d1ed298a7a406bff980ff4e29d7479"
+    },
+    {
+    "id": "ext:1.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-symbol:3.1.3",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "3871d50641e874cc172e2b53f919842d19db4c52",
+    "md5": "9cf67c9330abea4cd40a86724154f246",
+    "sha256": "203f2a3237ae83ca048a89354a5b59b652bdd18218afc2af2b9ea954e8fa8a83"
+    },
+    {
+    "id": "os-locale:1.4.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
+    "md5": "fdb77de7d9374b72e7f466c27908a730",
+    "sha256": "c46e48baddd73fac210c0fe16b286e7d34e72725d8d432fbfdc2469612823c56"
+    },
+    {
+    "id": "function-bind:1.1.1",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "call-bind:1.0.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "get-intrinsic:1.1.2",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has:1.0.3",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+    "md5": "ee976e75439af2b82e707f3a64c69684",
+    "sha256": "2d552e7c98b4c3acbf6420cc2eed535e592bb987ed2b32e35795bf777dd2e082"
+    },
+    {
+    "id": "jsonify:0.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "json-stable-stringify:1.0.1",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "json-stable-stringify:1.0.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
+    "md5": "78cc678249f2a175db1cffbd5bb25a14",
+    "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c"
+    },
+    {
+    "id": "fragment-cache:0.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+    "md5": "14306688d4947a100f6cce5b00d07afd",
+    "sha256": "e63cac91ed9159f180a4856278525147e3f037f19638784410e5ef8b4b759284"
+    },
+    {
+    "id": "snapdragon:0.8.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "64922e7c565b0e14204ba1aa7d6964278d25182d",
+    "md5": "4640f9c1fa2bb7b49f5b50d15edccb21",
+    "sha256": "783fd6b53fd9a8289872e766fffd889eddbd1718580140b617fc4905d68ad7aa"
+    },
+    {
+    "id": "type-check:0.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "levn:0.2.5",
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.6.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "levn:0.3.0",
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "optionator:0.8.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
+    "md5": "387d6e4e081fb0bbb34eece2b22d5cba",
+    "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16"
+    },
+    {
+    "id": "es6-map:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9136e0503dcc06a301690f0bb14ff4e364e949f0",
+    "md5": "98c9ef67294b8213745a30395f4a62b5",
+    "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f"
+    },
+    {
+    "id": "lodash.isarguments:3.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.keys:3.1.2",
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2f573d85c6a24289ff00663b491c1d338ff3458a",
+    "md5": "5aee2d8dc451d10cdc97666d9964074d",
+    "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117"
+    },
+    {
+    "id": "object-keys:1.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "define-properties:1.1.4",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1c47f272df277f3b1daf061677d9c82e2322c60e",
+    "md5": "5bff295f2e4eed10ece7c3f618b87b0e",
+    "sha256": "9678d9055619767c8a134033709e88a6e0a19600f3d3f2cda40acdfd75e7f212"
+    },
+    {
+    "id": "js-yaml:3.14.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dae812fdb3825fa306609a8717383c50c36a0537",
+    "md5": "2a522c3e23f7999abd8f852c012c20dd",
+    "sha256": "935a5f5939a5d5f0d1c4d85e7bf8b8a42b432d8692a82bce611720b8d72dbeca"
+    },
+    {
+    "id": "escope:3.6.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e01975e812781a163a6dadfdd80398dc64c889c3",
+    "md5": "9390f529580d458bc659af81607d7114",
+    "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5"
+    },
+    {
+    "id": "braces:2.3.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5979fd3f14cd531565e5fa2df1abfff1dfaee729",
+    "md5": "c0b57e8c8e11d32d2bd8879ab71f248f",
+    "sha256": "3428cfc307d6e64b73050b21eea54fc5e0644e3250676e0197aadf405d43c080"
+    },
+    {
+    "id": "cli-table:0.3.11",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ac69cdecbe81dccdba4889b9a18b7da312a9d3ee",
+    "md5": "96bfe0f1f5719a48401b6f196d0a83cf",
+    "sha256": "627ad03eeb4c373530101bf982e0b2781ddef9b56b6c593dd29ca245dcbe90c0"
+    },
+    {
+    "id": "expand-range:1.8.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a299effd335fe2721ebae8e257ec79644fc85337",
+    "md5": "b9375c64d875584bb5bf5a4829007f32",
+    "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4"
+    },
+    {
+    "id": "map-visit:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "collection-visit:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+    "md5": "1911d8539476d5e5b03c42e63a87b49a",
+    "sha256": "f16e5cdde4bf6b419826fdd7657b5ff599b424b866251db4187dea2a41f6d0a5"
+    },
+    {
+    "id": "generate-object-property:1.2.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-my-json-valid:2.20.6",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-my-json-valid:2.13.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "9c0e1c40308ce804f4783618b937fa88f99d50d0",
+    "md5": "275dde8134c99f03d9ff31a8fa861f19",
+    "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399"
+    },
+    {
+    "id": "extglob:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ad00fe4dc612a9232e8718711dc5cb5ab0285543",
+    "md5": "5e368678ebf35fe8dbaa173517e7adc1",
+    "sha256": "5ea33b732f0bfe301d0d2bf19836b860222c112c86c58fc41a28b30dd120eaf3"
+    },
+    {
+    "id": "colors:1.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-table:0.3.11",
+    "marked-terminal:3.3.0",
+    "cli-usage:0.1.10",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0433f44d809680fdeb60ed260f1b0c262e82a40b",
+    "md5": "5660c2d1f7341b94b7ffd7f915ec7ddd",
+    "sha256": "1fedfc0a611666f9bbe4625a223b6b08ec21e78b11fbb216116892cdeeaa2f8e"
+    },
+    {
+    "id": "string.prototype.trimend:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "914a65baaab25fbdd4ee291ca7dde57e869cb8d0",
+    "md5": "a3663ec694367b3d5df6cd1c904159f7",
+    "sha256": "05c18fe5ad1fac049ffdbdc95aa3d03510ce4838c5d95c5763ef41dc13a75561"
+    },
+    {
+    "id": "once:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "inflight:1.0.6",
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "run-async:0.1.0",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+    "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+    "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf"
+    },
+    {
+    "id": "fill-range:2.2.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
+    "md5": "0cbcf9ffcddcc73fdb710d34ff962c90",
+    "sha256": "d11d78a30328113d6f8ed9c46e0120ef96baf05730d350efe23dc17d452f78a0"
+    },
+    {
+    "id": "object.omit:2.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
+    "md5": "fcecdc1c30b85fdd0c66c31bed20ae2c",
+    "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff"
+    },
+    {
+    "id": "string.prototype.trimstart:1.0.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5466d93ba58cfa2134839f81d7f42437e8c01fef",
+    "md5": "1eb8bb5c0f48eb09d1729982c3b8c843",
+    "sha256": "b427df5466fec97d1dad5d4ef7e2e954ee9ad586ab6357bc9078bf996c95c501"
+    },
+    {
+    "id": "typedarray:0.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "concat-stream:1.6.2",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "concat-stream:1.5.1",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
+    "md5": "54a18bcd7fd55c812993e9ce90a0709d",
+    "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108"
+    },
+    {
+    "id": "object.assign:4.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0ed54a342eceb37b38ff76eb831a0e788cb63940",
+    "md5": "87b8da296ced17d6e062b791d48ed38b",
+    "sha256": "acd6e7522988d9d32b68efbce6da0abaac28dd9cab50a2e7c9ead1d53fa8214f"
+    },
+    {
+    "id": "is-plain-object:2.0.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-extendable:1.0.1",
+    "extend-shallow:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "is-extendable:1.0.1",
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+    "md5": "335972afae19ad1eccb8eee9aad94747",
+    "sha256": "4893fd94b7cf23cc0c936fdea4ada5d174e53adba6c72e7334b8cec0804ffdc6"
+    },
+    {
+    "id": "ajv:4.11.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "ajv-keywords:1.5.1",
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
+    "md5": "b4d4521d612fd1a9c228339a1eaa98b9",
+    "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7"
+    },
+    {
+    "id": "define-properties:1.1.4",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "function.prototype.name:1.1.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "regexp.prototype.flags:1.4.3",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimend:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "string.prototype.trimstart:1.0.5",
+    "es-abstract:1.20.1",
+    "array-includes:3.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.flat:1.3.0",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.values:1.1.5",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "array.prototype.find:2.2.0",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "object.assign:4.1.2",
+    "eslint-plugin-react:6.10.3",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1",
+    "md5": "d2ec48d9ec2ffc96c1cade78993d2fc4",
+    "sha256": "db524cc69a1fb36e417553bcf82df6511685c6b94d4b82eae99759589a686948"
+    },
+    {
+    "id": "pify:2.3.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "del:2.2.0",
+    "flat-cache:1.0.10",
+    "file-entry-cache:1.2.4",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "del:2.2.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "globby:4.0.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ],
+    [
+    "path-type:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
+    "md5": "475310192b9d153240ac82eb66b827e8",
+    "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530"
+    },
+    {
+    "id": "eslint-plugin-promise:3.8.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "65ebf27a845e3c1e9d6f6a5622ddd3801694b621",
+    "md5": "ba6f09078795c4b8612de3a95a483603",
+    "sha256": "6fd1bd71d3b2f1fa542743ff317fd46ed69c4f1bde4355ad6a789fddaa7d7d43"
+    },
+    {
+    "id": "natural-compare:1.4.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
+    "md5": "210787ea3f1a715dd963317ebfc5193f",
+    "sha256": "5e5569ecd12064f73632a8c18a45b1d1de4a27b699a671864801f1c35ee779ee"
+    },
+    {
+    "id": "strip-bom:2.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "gulp-sourcemaps:2.0.0-alpha",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
+    "md5": "3fa008815fc843fd20aa6f15330ebcfb",
+    "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653"
+    },
+    {
+    "id": "js-types:1.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "is-js-type:2.0.0",
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d242e6494ed572ad3c92809fc8bed7f7687cbf03",
+    "md5": "60cccf96110592ca167c2c9b98155a45",
+    "sha256": "f6cd2355c0f1cdacd4c1a97f0172a9d224b7376c2f7fa671af2e9706bfd1eb85"
+    },
+    {
+    "id": "path-is-inside:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "365417dede44430d1c11af61027facf074bdfc53",
+    "md5": "8f27701be0f4d4da9534227663ae61ed",
+    "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d"
+    },
+    {
+    "id": "progress:1.1.8",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
+    "md5": "06556528b7598e755a84c9c8f75c2622",
+    "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2"
+    },
+    {
+    "id": "lcid:1.0.0",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "os-locale:1.4.0",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "os-locale:1.4.0",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "os-locale:1.4.0",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
+    "md5": "33e24746875ebbcc37c40c7297388609",
+    "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43"
+    },
+    {
+    "id": "is-extendable:0.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "fill-range:4.0.0",
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "expand-brackets:2.1.4",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "extglob:2.0.4",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "set-value:2.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "extend-shallow:2.0.1",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
+    "md5": "7f1f2739cadbc7bc14d35c29f92f2969",
+    "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989"
+    },
+    {
+    "id": "class-utils:0.3.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
+    "md5": "8c08ba0d2e8509039d51951f64ae8d4e",
+    "sha256": "503aa70f2c48c67a536df3379fd38bbf60b26e9335bb90643e7425992055c714"
+    },
+    {
+    "id": "which:1.3.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a45043d54f5805316da8d62f9f50918d3da70b0a",
+    "md5": "3077f0c321098e78b78ddd6b4b2789e5",
+    "sha256": "966523d690564508ef1c4a804bc574128a1fe7263501668b853ffc2f2602ed1c"
+    },
+    {
+    "id": "es6-symbol:3.1.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
+    "md5": "5055e54f5b4af5dbcd24b92b1040c07a",
+    "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354"
+    },
+    {
+    "id": "os-homedir:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "user-home:2.0.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+    "md5": "00b6f9a1bc0ae6cf61e412122a7f8616",
+    "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475"
+    },
+    {
+    "id": "is-proto-prop:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-no-use-extend-native:0.3.12",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c8a0455c28fe38c8843d0c22af6f95f01ed4abc4",
+    "md5": "78443d3b543426fda71dfcb27111473b",
+    "sha256": "beb7488dd25d17fd75ae32eab559b5e19ca008aabbdc4ca46f009272fd5cd9e0"
+    },
+    {
+    "id": "glob-base:0.3.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "parse-glob:3.0.4",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
+    "md5": "ea2fd4074a1f129431de415f1c5387aa",
+    "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5"
+    },
+    {
+    "id": "strip-bom:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "tsconfig-paths:3.14.1",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
+    "md5": "a2045f7f89506a0f8301822998d1daf7",
+    "sha256": "48094c11a1f7faa867eb6919c09380232ce9b6d61fb3c43618ca6235b6013ee2"
+    },
+    {
+    "id": "arr-flatten:1.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "arr-diff:2.0.0",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "braces:2.3.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "36048bbff4e7b47e136644316c99669ea5ae91f1",
+    "md5": "1b469d538f9b387d83b3cb7e5994f7a5",
+    "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a"
+    },
+    {
+    "id": "ms:2.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "debug:2.6.9",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
+    "md5": "9615634070dd7751f127b2a0fb362484",
+    "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb"
+    },
+    {
+    "id": "get-value:2.0.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "union-value:1.0.1",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+    "md5": "b45bf08107e22e624dade29284abd265",
+    "sha256": "54006eb984cd6bde4583f72fd3de97bdb9bfb552eb235053f98ffea33cf8fc14"
+    },
+    {
+    "id": "hosted-git-info:2.8.9",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
+    "md5": "e50583bc39341b531466e5de5b6aef94",
+    "sha256": "c97ee798e6c57215cb522ff1d8ddcb3b0a74d352f3edf4adf3cc91cc940af2cd"
+    },
+    {
+    "id": "lodash._basefor:3.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.isplainobject:3.2.0",
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._pickbycallback:3.0.0",
+    "lodash.omit:3.1.0",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "7550b4e9218ef09fad24343b612021c79b4c20c2",
+    "md5": "e0118d593252e3902b3769f0ff775d04",
+    "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb"
+    },
+    {
+    "id": "expand-brackets:0.1.5",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "df07284e342a807cd733ac5af72411e581d1177b",
+    "md5": "15d774bbd64fa32c2c427854bf58143b",
+    "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb"
+    },
+    {
+    "id": "is-arrayish:0.2.1",
+    "scopes": [
+    "dev",
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "error-ex:1.3.0",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.6.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "error-ex:1.3.0",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "pkg-conf:1.1.2",
+    "yargs:4.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "error-ex:1.3.2",
+    "parse-json:2.2.0",
+    "load-json-file:1.1.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+    "md5": "4bbbacda455ab73d86f5eda908989f24",
+    "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c"
+    },
+    {
+    "id": "ajv-keywords:1.5.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "table:3.8.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
+    "md5": "32a05ade9df24d4ba6b0fb880c1ea578",
+    "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4"
+    },
+    {
+    "id": "readdirp:2.2.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "0e87622a3325aa33e892285caf8b4e846529a525",
+    "md5": "3db1ba3d27a388ac352b82fcdd1ca5d8",
+    "sha256": "c9a2309dc0970632d31d7701fd4a59b0616f9c7b944dc7ff5a701a9d638376a3"
+    },
+    {
+    "id": "define-property:2.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "nanomatch:1.2.13",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "to-regex:3.0.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "d459689e8d654ba77e02a817f8710d702cb16e9d",
+    "md5": "2751868d9fa31ebbbe851fdcb729115d",
+    "sha256": "0ade8d2e984ecfcdbaafc3eb236fc61d5ea71e49580676cee1a399e37d1d1d55"
+    },
+    {
+    "id": "es6-iterator:2.0.3",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "es5-ext:0.10.61",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-set:0.1.5",
+    "es6-map:0.1.5",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "es6-weak-map:2.0.3",
+    "escope:3.6.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+    "md5": "57b7a7d3a78acfc092e8a1704b45cecc",
+    "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43"
+    },
+    {
+    "id": "for-in:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "for-own:0.1.5",
+    "object.omit:2.0.1",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "mixin-deep:1.3.2",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+    "md5": "ee6ee930a801ef95ab155a07b5c05e0c",
+    "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e"
+    },
+    {
+    "id": "lodash._arrayeach:3.0.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "lodash.merge:3.3.2",
+    "eslint:1.10.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clone:3.0.3",
+    "css-lint:1.0.1",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "lodash._baseclone:3.3.0",
+    "lodash.clonedeep:3.0.2",
+    "node-notifier:4.6.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
+    "md5": "2500bac4195ee774f346d80500ad77ef",
+    "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91"
+    },
+    {
+    "id": "minimatch:3.1.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "glob:7.2.3",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "19cd194bfd3e428f049a70817c038d89ab4be35b",
+    "md5": "7b4ad790ecb6bd5eef2fa305b3b4c19f",
+    "sha256": "13964b10b60a3b66dd6eec90a2d39af28590721b8c9d1df8ff754f90b081a34d"
+    },
+    {
+    "id": "validate-npm-package-license:3.0.4",
+    "scopes": [
+    "prod"
+    ],
+    "requestedBy": [
+    [
+    "normalize-package-data:2.5.0",
+    "read-pkg:1.1.0",
+    "read-pkg-up:1.0.1",
+    "yargs:4.8.1",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+    "md5": "c84f22a6bf1922d9d2a65c9779b3eea8",
+    "sha256": "0166efb34d41a131d4df2a75f8ff84314be35c0dacf6fec265602de66777fd8c"
+    },
+    {
+    "id": "balanced-match:1.0.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "brace-expansion:1.1.11",
+    "minimatch:3.1.2",
+    "eslint-plugin-import:2.26.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+    "md5": "eaa5cad5807df26bd8eb05ea4af19001",
+    "sha256": "d854f7abdd0c7a8120cf381e0ad5f972cbd0255f5d987424bd672c8c4fcebcc1"
+    },
+    {
+    "id": "isobject:2.1.0",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fill-range:2.2.4",
+    "expand-range:1.8.2",
+    "braces:1.8.5",
+    "micromatch:2.3.11",
+    "anymatch:1.3.2",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "has-value:0.3.1",
+    "unset-value:1.0.0",
+    "cache-base:1.0.1",
+    "base:0.11.2",
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
+    "md5": "0f9182476d89fe76deab4cb4d4d6f6f2",
+    "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91"
+    },
+    {
+    "id": "map-cache:0.2.2",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "fragment-cache:0.2.1",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "snapdragon:0.8.2",
+    "micromatch:3.1.10",
+    "readdirp:2.2.1",
+    "chokidar:1.7.0",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+    "md5": "7ed5e46ed67d87ec937cedc485559cb6",
+    "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d"
+    },
+    {
+    "id": "restore-cursor:1.0.1",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ],
+    [
+    "cli-cursor:1.0.2",
+    "inquirer:0.12.0",
+    "eslint:2.9.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "34661f46886327fed2991479152252df92daa541",
+    "md5": "99b769f599ac64ecf9027f8717f01bb0",
+    "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97"
+    },
+    {
+    "id": "is-my-json-valid:2.20.6",
+    "scopes": [
+    "dev"
+    ],
+    "requestedBy": [
+    [
+    "eslint:3.19.0",
+    "eslint-config-canonical:1.15.0",
+    "canonical:3.2.1",
+    "pragmatist:3.0.24",
+    "bundle-dependencies"
+    ]
+    ],
+    "sha1": "a9d89e56a36493c77bda1440d69ae0dc46a08387",
+    "md5": "97f3e36cfc7cdb679b52fca23d3463d4",
+    "sha256": "e2d7bf61ddf059365c4d906fa93937cde0913ac77f437f7db38d51ea628e0ec3"
     }
-]
+    ]

--- a/build/testdata/npm/project4/npmv8/windows/package-lock.json
+++ b/build/testdata/npm/project4/npmv8/windows/package-lock.json
@@ -24,7 +24,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -42,7 +42,7 @@
     "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^3.0.4"
@@ -51,7 +51,7 @@
     "node_modules/acorn-jsx/node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -63,7 +63,7 @@
     "node_modules/ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "dependencies": {
         "co": "^4.6.0",
@@ -73,7 +73,7 @@
     "node_modules/ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "peerDependencies": {
         "ajv": ">=4.10.0"
@@ -82,7 +82,7 @@
     "node_modules/ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -91,7 +91,7 @@
     "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -100,7 +100,7 @@
     "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -109,7 +109,7 @@
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "node_modules/anymatch": {
@@ -134,7 +134,7 @@
     "node_modules/arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "dependencies": {
         "arr-flatten": "^1.0.1"
@@ -155,21 +155,21 @@
     "node_modules/arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -183,35 +183,37 @@
     "node_modules/array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -223,7 +225,7 @@
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -250,7 +252,7 @@
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -261,7 +263,7 @@
     "node_modules/babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
@@ -277,7 +279,7 @@
     "node_modules/babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -286,7 +288,7 @@
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "dependencies": {
         "core-js": "^2.4.0",
@@ -296,7 +298,7 @@
     "node_modules/babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.26.0",
@@ -313,7 +315,7 @@
     "node_modules/babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -358,7 +360,7 @@
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -370,7 +372,7 @@
     "node_modules/base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -408,7 +410,7 @@
     "node_modules/braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "dependencies": {
         "expand-range": "^1.8.1",
@@ -448,7 +450,7 @@
     "node_modules/cache-base/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -470,7 +472,7 @@
     "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "dependencies": {
         "callsites": "^0.2.0"
@@ -482,7 +484,7 @@
     "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -491,7 +493,7 @@
     "node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -500,7 +502,7 @@
     "node_modules/canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "bundleDependencies": [
         "babel-eslint",
         "chalk",
@@ -3567,7 +3569,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
@@ -3580,7 +3582,7 @@
     "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -3596,7 +3598,7 @@
     "node_modules/chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
@@ -3638,7 +3640,7 @@
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -3650,7 +3652,7 @@
     "node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3662,7 +3664,7 @@
     "node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -3697,7 +3699,7 @@
     "node_modules/class-utils/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3706,7 +3708,7 @@
     "node_modules/cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
@@ -3746,7 +3748,7 @@
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -3757,7 +3759,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -3767,7 +3769,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3776,7 +3778,7 @@
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -3798,13 +3800,13 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
@@ -3813,7 +3815,7 @@
     "node_modules/comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.4"
@@ -3828,7 +3830,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/concat-stream": {
@@ -3849,7 +3851,7 @@
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3859,7 +3861,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -3891,7 +3893,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3900,7 +3902,7 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -3913,15 +3915,19 @@
       "dev": true
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -3940,7 +3946,7 @@
     "node_modules/define-property/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3968,37 +3974,49 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
       }
     },
     "node_modules/es-to-primitive": {
@@ -4019,20 +4037,24 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4043,7 +4065,7 @@
     "node_modules/es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4057,7 +4079,7 @@
     "node_modules/es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4070,7 +4092,7 @@
     "node_modules/es6-set/node_modules/es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4102,7 +4124,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -4111,7 +4133,7 @@
     "node_modules/escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "dependencies": {
         "es6-map": "^0.1.3",
@@ -4126,7 +4148,7 @@
     "node_modules/eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "dependencies": {
         "babel-code-frame": "^6.16.0",
@@ -4175,7 +4197,7 @@
     "node_modules/eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "dependencies": {
         "babel-eslint": "^7.0.0",
@@ -4249,7 +4271,7 @@
     "node_modules/eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=1.0.0"
@@ -4271,9 +4293,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -4281,14 +4303,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "engines": {
         "node": ">=4"
@@ -4300,7 +4322,7 @@
     "node_modules/eslint-plugin-import/node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4321,7 +4343,7 @@
     "node_modules/eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "dependencies": {
         "comment-parser": "^0.4.0",
@@ -4361,7 +4383,7 @@
     "node_modules/eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "dependencies": {
         "is-get-set-prop": "^1.0.0",
@@ -4382,7 +4404,7 @@
     "node_modules/eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "dependencies": {
         "array.prototype.find": "^2.0.1",
@@ -4401,7 +4423,7 @@
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2",
@@ -4500,7 +4522,7 @@
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "dependencies": {
         "d": "1",
@@ -4510,7 +4532,7 @@
     "node_modules/exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4519,7 +4541,7 @@
     "node_modules/expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "dependencies": {
         "is-posix-bracket": "^0.1.0"
@@ -4531,7 +4553,7 @@
     "node_modules/expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "dependencies": {
         "fill-range": "^2.1.0"
@@ -4558,7 +4580,7 @@
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -4583,7 +4605,7 @@
     "node_modules/extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -4595,13 +4617,13 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5",
@@ -4614,7 +4636,7 @@
     "node_modules/file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "dependencies": {
         "flat-cache": "^1.2.1",
@@ -4634,7 +4656,7 @@
     "node_modules/filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4659,7 +4681,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4686,7 +4708,7 @@
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4695,7 +4717,7 @@
     "node_modules/for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "dependencies": {
         "for-in": "^1.0.1"
@@ -4707,7 +4729,7 @@
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "dependencies": {
         "map-cache": "^0.2.2"
@@ -4719,7 +4741,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -4747,6 +4769,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "inBundle": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -4759,7 +4808,7 @@
     "node_modules/generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "dependencies": {
         "is-property": "^1.0.0"
@@ -4772,14 +4821,14 @@
       "inBundle": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4788,7 +4837,7 @@
     "node_modules/get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4813,22 +4862,22 @@
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4842,7 +4891,7 @@
     "node_modules/glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "dependencies": {
         "glob-parent": "^2.0.0",
@@ -4855,7 +4904,7 @@
     "node_modules/glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "dependencies": {
         "is-glob": "^2.0.0"
@@ -4871,15 +4920,15 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "inBundle": true
     },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "node_modules/has": {
@@ -4897,7 +4946,7 @@
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -4907,9 +4956,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4918,16 +4967,28 @@
     "node_modules/has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4954,7 +5015,7 @@
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.6",
@@ -4968,7 +5029,7 @@
     "node_modules/has-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4977,7 +5038,7 @@
     "node_modules/has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -4990,7 +5051,7 @@
     "node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5002,7 +5063,7 @@
     "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5014,7 +5075,7 @@
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5038,7 +5099,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -5047,7 +5108,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -5063,7 +5124,7 @@
     "node_modules/inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
@@ -5116,7 +5177,7 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5146,7 +5207,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "inBundle": true
     },
     "node_modules/is-bigint": {
@@ -5164,7 +5225,7 @@
     "node_modules/is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
@@ -5208,9 +5269,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "inBundle": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -5281,7 +5342,7 @@
     "node_modules/is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5290,7 +5351,7 @@
     "node_modules/is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "dependencies": {
         "is-primitive": "^2.0.0"
@@ -5302,7 +5363,7 @@
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5311,7 +5372,7 @@
     "node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5320,7 +5381,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "inBundle": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -5332,7 +5393,7 @@
     "node_modules/is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "dependencies": {
         "get-set-props": "^0.1.0",
@@ -5342,7 +5403,7 @@
     "node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -5354,16 +5415,16 @@
     "node_modules/is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "dependencies": {
         "js-types": "^1.0.0"
       }
     },
     "node_modules/is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "node_modules/is-my-json-valid": {
@@ -5394,7 +5455,7 @@
     "node_modules/is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -5404,9 +5465,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -5421,7 +5482,7 @@
     "node_modules/is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0",
@@ -5443,7 +5504,7 @@
     "node_modules/is-plain-object/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5452,7 +5513,7 @@
     "node_modules/is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5461,7 +5522,7 @@
     "node_modules/is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5470,7 +5531,7 @@
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "node_modules/is-proto-prop": {
@@ -5506,10 +5567,13 @@
       "dev": true
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5547,7 +5611,7 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "inBundle": true
     },
     "node_modules/is-weakref": {
@@ -5574,19 +5638,19 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -5598,13 +5662,13 @@
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "node_modules/js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5626,7 +5690,7 @@
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "dependencies": {
         "jsonify": "~0.0.0"
@@ -5647,16 +5711,16 @@
     "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5665,7 +5729,7 @@
     "node_modules/jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -5674,7 +5738,7 @@
     "node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -5686,7 +5750,7 @@
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "inBundle": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -5698,7 +5762,7 @@
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -5711,7 +5775,7 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5727,7 +5791,7 @@
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "inBundle": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
@@ -5739,7 +5803,7 @@
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5758,19 +5822,19 @@
     "node_modules/lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "node_modules/lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "node_modules/lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "dependencies": {
         "lodash._basecopy": "^3.0.0",
@@ -5780,7 +5844,7 @@
     "node_modules/lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "dependencies": {
         "lodash._arraycopy": "^3.0.0",
@@ -5794,37 +5858,37 @@
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "node_modules/lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "node_modules/lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "inBundle": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "dependencies": {
         "lodash._baseclone": "^3.0.0",
@@ -5834,19 +5898,19 @@
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "node_modules/lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "node_modules/lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0",
@@ -5878,7 +5942,7 @@
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5887,7 +5951,7 @@
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "dependencies": {
         "object-visit": "^1.0.0"
@@ -5963,7 +6027,7 @@
     "node_modules/marked-terminal/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5990,7 +6054,7 @@
     "node_modules/micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "dependencies": {
         "arr-diff": "^2.0.0",
@@ -6012,9 +6076,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6024,9 +6088,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -6055,12 +6119,12 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -6069,19 +6133,19 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -6110,7 +6174,7 @@
     "node_modules/nanomatch/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6119,7 +6183,7 @@
     "node_modules/nanomatch/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6137,13 +6201,13 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node_modules/node-emoji": {
@@ -6158,7 +6222,7 @@
     "node_modules/node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "dependencies": {
         "cli-usage": "^0.1.1",
@@ -6188,7 +6252,7 @@
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
@@ -6200,16 +6264,16 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6218,7 +6282,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6227,7 +6291,7 @@
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "dependencies": {
         "copy-descriptor": "^0.1.0",
@@ -6241,7 +6305,7 @@
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -6253,7 +6317,7 @@
     "node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6265,7 +6329,7 @@
     "node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -6298,9 +6362,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6318,7 +6382,7 @@
     "node_modules/object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.0"
@@ -6330,7 +6394,7 @@
     "node_modules/object-visit/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6357,7 +6421,7 @@
     "node_modules/object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "dependencies": {
         "for-own": "^0.1.4",
@@ -6370,7 +6434,7 @@
     "node_modules/object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
@@ -6382,7 +6446,7 @@
     "node_modules/object.pick/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6408,7 +6472,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -6417,7 +6481,7 @@
     "node_modules/onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6443,7 +6507,7 @@
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6452,7 +6516,7 @@
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "inBundle": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -6476,7 +6540,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6488,7 +6552,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6497,7 +6561,7 @@
     "node_modules/parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "dependencies": {
         "glob-base": "^0.3.0",
@@ -6512,7 +6576,7 @@
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "inBundle": true,
       "dependencies": {
         "error-ex": "^1.2.0"
@@ -6524,7 +6588,7 @@
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6533,7 +6597,7 @@
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6542,7 +6606,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6551,7 +6615,7 @@
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "node_modules/path-parse": {
@@ -6563,7 +6627,7 @@
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -6577,7 +6641,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6586,7 +6650,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6595,7 +6659,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "inBundle": true,
       "dependencies": {
         "pinkie": "^2.0.0"
@@ -6607,13 +6671,13 @@
     "node_modules/pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6622,7 +6686,7 @@
     "node_modules/pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "bundleDependencies": [
         "babel-plugin-add-module-exports",
         "babel-plugin-check-es2015-constants",
@@ -10440,7 +10504,7 @@
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -10449,7 +10513,7 @@
     "node_modules/preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10464,7 +10528,7 @@
     "node_modules/progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -10520,7 +10584,7 @@
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "inBundle": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
@@ -10534,7 +10598,7 @@
     "node_modules/read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "inBundle": true,
       "dependencies": {
         "find-up": "^1.0.0",
@@ -10547,7 +10611,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "inBundle": true,
       "dependencies": {
         "path-exists": "^2.0.0",
@@ -10560,7 +10624,7 @@
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "inBundle": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
@@ -10601,7 +10665,7 @@
     "node_modules/readdirp/node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10610,7 +10674,7 @@
     "node_modules/readdirp/node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10640,7 +10704,7 @@
     "node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10652,7 +10716,7 @@
     "node_modules/readdirp/node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "dev": true,
       "dependencies": {
         "debug": "^2.3.3",
@@ -10670,7 +10734,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -10682,7 +10746,7 @@
     "node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10736,7 +10800,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -10748,7 +10812,7 @@
     "node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10760,7 +10824,7 @@
     "node_modules/readdirp/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -10775,7 +10839,7 @@
     "node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10787,7 +10851,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10799,7 +10863,7 @@
     "node_modules/readdirp/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10811,7 +10875,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10823,7 +10887,7 @@
     "node_modules/readdirp/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10835,7 +10899,7 @@
     "node_modules/readdirp/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -10847,7 +10911,7 @@
     "node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -10859,7 +10923,7 @@
     "node_modules/readdirp/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10901,7 +10965,7 @@
     "node_modules/readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -10912,7 +10976,7 @@
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
@@ -10924,7 +10988,7 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "dependencies": {
         "esprima": "~4.0.0"
@@ -10961,10 +11025,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "node_modules/repeat-element": {
@@ -10979,7 +11060,7 @@
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -10988,7 +11069,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10997,13 +11078,13 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
       "inBundle": true
     },
     "node_modules/require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "dependencies": {
         "caller-path": "^0.1.0",
@@ -11014,12 +11095,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "inBundle": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11033,7 +11114,7 @@
     "node_modules/resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11042,14 +11123,14 @@
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
@@ -11083,7 +11164,7 @@
     "node_modules/run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0"
@@ -11092,7 +11173,7 @@
     "node_modules/rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "node_modules/safe-buffer": {
@@ -11104,7 +11185,7 @@
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "dependencies": {
         "ret": "~0.1.10"
@@ -11122,7 +11203,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "inBundle": true
     },
     "node_modules/set-value": {
@@ -11143,7 +11224,7 @@
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11155,7 +11236,7 @@
     "node_modules/shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -11193,7 +11274,7 @@
     "node_modules/slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11235,7 +11316,7 @@
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -11247,7 +11328,7 @@
     "node_modules/snapdragon-node/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11268,7 +11349,7 @@
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11280,7 +11361,7 @@
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -11292,7 +11373,7 @@
     "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11304,7 +11385,7 @@
     "node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11339,7 +11420,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11413,13 +11494,13 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "dependencies": {
         "define-property": "^0.2.5",
@@ -11432,7 +11513,7 @@
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -11444,7 +11525,7 @@
     "node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11456,7 +11537,7 @@
     "node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11500,7 +11581,7 @@
     "node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "inBundle": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -11512,26 +11593,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11540,7 +11623,7 @@
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "inBundle": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -11552,7 +11635,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11561,7 +11644,7 @@
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11570,7 +11653,7 @@
     "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -11604,7 +11687,7 @@
     "node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11625,7 +11708,7 @@
     "node_modules/table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "dependencies": {
         "ajv": "^4.7.0",
@@ -11637,9 +11720,9 @@
       }
     },
     "node_modules/table/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11648,7 +11731,7 @@
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -11670,7 +11753,7 @@
     "node_modules/table/node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -11682,19 +11765,19 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11703,7 +11786,7 @@
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11730,7 +11813,7 @@
     "node_modules/to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -11743,7 +11826,7 @@
     "node_modules/to-regex-range/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11753,14 +11836,14 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -11773,7 +11856,7 @@
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -11785,18 +11868,18 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -11821,7 +11904,7 @@
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "dependencies": {
         "has-value": "^0.3.1",
@@ -11834,7 +11917,7 @@
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
       "dev": true,
       "dependencies": {
         "get-value": "^2.0.3",
@@ -11848,7 +11931,7 @@
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
@@ -11860,7 +11943,7 @@
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11869,7 +11952,7 @@
     "node_modules/unset-value/node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11878,7 +11961,7 @@
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
@@ -11894,7 +11977,7 @@
     "node_modules/user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
@@ -11906,7 +11989,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -11950,13 +12033,13 @@
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
       "inBundle": true
     },
     "node_modules/window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
       "inBundle": true,
       "bin": {
         "window-size": "cli.js"
@@ -11977,7 +12060,7 @@
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "inBundle": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -11990,13 +12073,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
@@ -12023,7 +12106,7 @@
     "node_modules/yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "inBundle": true,
       "dependencies": {
         "cliui": "^3.2.0",
@@ -12045,7 +12128,7 @@
     "node_modules/yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "inBundle": true,
       "dependencies": {
         "camelcase": "^3.0.0",
@@ -12057,7 +12140,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "acorn": {
@@ -12069,7 +12152,7 @@
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "requires": {
         "acorn": "^3.0.4"
@@ -12078,7 +12161,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
           "dev": true
         }
       }
@@ -12086,7 +12169,7 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "requires": {
         "co": "^4.6.0",
@@ -12096,31 +12179,31 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "requires": {}
     },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
     "ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true
     },
     "anymatch": {
@@ -12145,7 +12228,7 @@
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1"
@@ -12160,18 +12243,18 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -12179,35 +12262,37 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
+      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.4",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
     },
     "async-each": {
@@ -12225,7 +12310,7 @@
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
@@ -12236,7 +12321,7 @@
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -12248,7 +12333,7 @@
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -12257,7 +12342,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
       "requires": {
         "core-js": "^2.4.0",
@@ -12267,7 +12352,7 @@
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -12284,7 +12369,7 @@
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -12323,7 +12408,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -12332,7 +12417,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12366,7 +12451,7 @@
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "requires": {
         "expand-range": "^1.8.1",
@@ -12400,7 +12485,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -12418,7 +12503,7 @@
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "requires": {
         "callsites": "^0.2.0"
@@ -12427,18 +12512,18 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
     },
     "canonical": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/canonical/-/canonical-3.2.1.tgz",
-      "integrity": "sha1-xBB3o4h4C1Eeh9DFTrRWjx+JlZ4=",
+      "integrity": "sha512-6arZj7SeyneHj8/kS7KPP/M47ExdrhFZga5ZO3aDL+GPhSlXDIGRMePIi6Fn0+cDD2ehbLCz7kWX+/v4mAMMmw==",
       "dev": true,
       "requires": {
         "babel-eslint": "^6.0.4",
@@ -14818,7 +14903,7 @@
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "requires": {
         "ansicolors": "~0.3.2",
@@ -14828,7 +14913,7 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -14841,7 +14926,7 @@
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
@@ -14876,7 +14961,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -14885,7 +14970,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14894,7 +14979,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -14922,7 +15007,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -14930,7 +15015,7 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "requires": {
         "restore-cursor": "^1.0.1"
@@ -14964,7 +15049,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -14974,18 +15059,18 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
@@ -15004,19 +15089,19 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true
     },
     "comment-parser": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
-      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "integrity": "sha512-MXiziwGzPopasDbc8g1pk7xxemubCbLdoS7l/nRKPpBvys8PbH/HEY5DybYgCF13V5DAjL9Q+NCkxg4Kjjt77A==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.4"
@@ -15031,7 +15116,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "concat-stream": {
@@ -15049,7 +15134,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
     "core-js": {
@@ -15086,12 +15171,12 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "deep-is": {
@@ -15101,12 +15186,13 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -15122,7 +15208,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15145,31 +15231,43 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -15184,20 +15282,20 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15208,7 +15306,7 @@
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15222,7 +15320,7 @@
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15235,7 +15333,7 @@
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
           "dev": true,
           "requires": {
             "d": "1",
@@ -15269,13 +15367,13 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
       "dev": true,
       "requires": {
         "es6-map": "^0.1.3",
@@ -15287,7 +15385,7 @@
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "integrity": "sha512-x6LJGXWCGB/4YOBhL48yeppZTo+YQUNC37N5qqCpC1b1kkNzydlQHQAtPuUSFoZSxgIadrysQoW2Hq602P+uEA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.16.0",
@@ -15330,7 +15428,7 @@
     "eslint-config-canonical": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/eslint-config-canonical/-/eslint-config-canonical-1.15.0.tgz",
-      "integrity": "sha1-/l7RrUG2/h4lZrGNa30t1UZz8SE=",
+      "integrity": "sha512-SvXd5w1PowWkg7JsGPbOAp65CIY/lwP7Z9+l+x1YI2zg6iiStg2R7nSl95tvjF9iR0EvqduELbJWbiTuZ8VBYA==",
       "dev": true,
       "requires": {
         "babel-eslint": "^7.0.0",
@@ -15402,7 +15500,7 @@
     "eslint-plugin-babel": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
-      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "integrity": "sha512-Zg2ztRQF4LN5zjVAPJCwLT+661DEKQL/eXx29gMfZjLDtX/g03RUHTmdAGj7qnyfZPHnxyf6YryoKjthVhaN0g==",
       "dev": true,
       "requires": {}
     },
@@ -15416,9 +15514,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -15426,20 +15524,20 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
@@ -15456,7 +15554,7 @@
     "eslint-plugin-jsdoc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-2.4.0.tgz",
-      "integrity": "sha1-fB6qjoj6sEyAdHLBe2/5oax+Vk0=",
+      "integrity": "sha512-adG5FySIY+ijWAVyQ7y9t8ELvcriYuPFFiECHvdSrex9bn2VvJbbDJXnpT+fUH88gpnXsy5MwcGRQywljkwhMA==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.4.0",
@@ -15484,7 +15582,7 @@
     "eslint-plugin-no-use-extend-native": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+      "integrity": "sha512-U+6dbV0TfsRuSbQlRwSo3pODJa65Qkz0lTznHVmRC4/crcWsgC13EuHBN1dO7L12f8eJPjPyzi9mHHaw/Ze75w==",
       "dev": true,
       "requires": {
         "is-get-set-prop": "^1.0.0",
@@ -15502,7 +15600,7 @@
     "eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "requires": {
         "array.prototype.find": "^2.0.1",
@@ -15515,7 +15613,7 @@
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -15589,7 +15687,7 @@
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
       "requires": {
         "d": "1",
@@ -15599,13 +15697,13 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
       "dev": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
@@ -15614,7 +15712,7 @@
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
@@ -15640,7 +15738,7 @@
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -15661,7 +15759,7 @@
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -15670,13 +15768,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
@@ -15686,7 +15784,7 @@
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
       "requires": {
         "flat-cache": "^1.2.1",
@@ -15703,7 +15801,7 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
       "dev": true
     },
     "fill-range": {
@@ -15722,7 +15820,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -15743,13 +15841,13 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
@@ -15758,7 +15856,7 @@
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
@@ -15767,7 +15865,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -15786,6 +15884,24 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -15798,7 +15914,7 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "requires": {
         "is-property": "^1.0.0"
@@ -15810,20 +15926,20 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-set-props": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
       "dev": true
     },
     "get-symbol-description": {
@@ -15839,19 +15955,19 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -15859,7 +15975,7 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
@@ -15869,7 +15985,7 @@
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
@@ -15882,14 +15998,14 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
     "has": {
@@ -15903,28 +16019,37 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-tostringtag": {
@@ -15939,7 +16064,7 @@
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "requires": {
         "get-value": "^2.0.6",
@@ -15950,7 +16075,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -15958,7 +16083,7 @@
     "has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -15968,7 +16093,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15977,7 +16102,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -15988,7 +16113,7 @@
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -16010,13 +16135,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -16032,7 +16157,7 @@
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -16079,7 +16204,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -16101,7 +16226,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -16115,7 +16240,7 @@
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -16144,9 +16269,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -16199,13 +16324,13 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
@@ -16214,19 +16339,19 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -16234,7 +16359,7 @@
     "is-get-set-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
       "dev": true,
       "requires": {
         "get-set-props": "^0.1.0",
@@ -16244,7 +16369,7 @@
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
@@ -16253,16 +16378,16 @@
     "is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
       "dev": true,
       "requires": {
         "js-types": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true
     },
     "is-my-json-valid": {
@@ -16287,16 +16412,16 @@
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -16305,7 +16430,7 @@
     "is-obj-prop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
       "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0",
@@ -16324,7 +16449,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -16332,19 +16457,19 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "is-proto-prop": {
@@ -16374,10 +16499,13 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-string": {
       "version": "1.0.7",
@@ -16400,7 +16528,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -16420,19 +16548,19 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
@@ -16441,13 +16569,13 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
     },
     "js-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
       "dev": true
     },
     "js-yaml": {
@@ -16463,7 +16591,7 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
@@ -16481,25 +16609,25 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true
     },
     "jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "integrity": "sha512-0LwSmMlQjjUdXsdlyYhEfBJCn2Chm0zgUBmfmf1++KUULh+JOdlzrZfiwe2zmlVJx44UF+KX/B/odBoeK9hxmw==",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
@@ -16508,7 +16636,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -16516,7 +16644,7 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -16526,7 +16654,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -16538,7 +16666,7 @@
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -16548,7 +16676,7 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -16564,19 +16692,19 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "dev": true,
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -16586,7 +16714,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "dev": true,
       "requires": {
         "lodash._arraycopy": "^3.0.0",
@@ -16600,36 +16728,36 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
       "dev": true
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "dev": true,
       "requires": {
         "lodash._baseclone": "^3.0.0",
@@ -16639,19 +16767,19 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -16677,13 +16805,13 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
@@ -16738,7 +16866,7 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -16761,7 +16889,7 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "requires": {
         "arr-diff": "^2.0.0",
@@ -16780,18 +16908,18 @@
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -16816,30 +16944,30 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -16865,13 +16993,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "kind-of": {
@@ -16885,13 +17013,13 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node-emoji": {
@@ -16906,7 +17034,7 @@
     "node-notifier": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "integrity": "sha512-UPTmeIGLTzZSizsf7EX8xr1iN/xXbULADNW3aOHnNf6mSUu2vtWcRTLTKHs/iNfV9Gbttp0iTQfICDNOeqlsLw==",
       "dev": true,
       "requires": {
         "cli-usage": "^0.1.1",
@@ -16932,7 +17060,7 @@
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -16941,24 +17069,24 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "obj-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.3.0.tgz",
-      "integrity": "sha512-k2Xkjx5wn6eC3537SWAXHzB6lkI81kS+icMKMkh4nG3w7shWG6MaWOBrNvhWVOszrtL5uxdfymQQfPUxwY+2eg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -16969,7 +17097,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -16978,7 +17106,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -16987,7 +17115,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -17015,9 +17143,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -17029,7 +17157,7 @@
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
@@ -17038,7 +17166,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17058,7 +17186,7 @@
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "dev": true,
       "requires": {
         "for-own": "^0.1.4",
@@ -17068,7 +17196,7 @@
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -17077,7 +17205,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -17096,7 +17224,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -17105,7 +17233,7 @@
     "onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "dev": true
     },
     "optionator": {
@@ -17125,13 +17253,13 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -17148,7 +17276,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -17157,13 +17285,13 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
@@ -17175,7 +17303,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -17183,25 +17311,25 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
       "dev": true
     },
     "path-parse": {
@@ -17212,7 +17340,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -17222,17 +17350,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -17240,19 +17368,19 @@
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "integrity": "sha512-TH+BeeL6Ct98C7as35JbZLf8lgsRzlNJb5gklRIGHKaPkGl1esOKBc5ALUMd+q08Sr6tiEKM+Icbsxg5vuhMKQ==",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
     "pragmatist": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/pragmatist/-/pragmatist-3.0.24.tgz",
-      "integrity": "sha1-HGxiA8YF3BR2d/MNwKo9iaoicpc=",
+      "integrity": "sha512-fRRjxO2AyUdz/U9WV9fCkPy+qDcwap1u6Nsrh4T8cTEx2mZScgoXOI64EpveWMuXY0zziJh658/Qs6OU8+gMOQ==",
       "dev": true,
       "requires": {
         "babel-plugin-add-module-exports": "^0.2.1",
@@ -20211,13 +20339,13 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
       "dev": true
     },
     "process-nextick-args": {
@@ -20229,7 +20357,7 @@
     "progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "integrity": "sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==",
       "dev": true
     },
     "proto-props": {
@@ -20272,7 +20400,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -20282,7 +20410,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -20291,7 +20419,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -20300,7 +20428,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -20336,13 +20464,13 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
           "dev": true
         },
         "braces": {
@@ -20366,7 +20494,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20377,7 +20505,7 @@
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -20392,7 +20520,7 @@
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -20401,7 +20529,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20445,7 +20573,7 @@
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -20454,7 +20582,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20465,7 +20593,7 @@
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -20477,7 +20605,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -20488,7 +20616,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20497,7 +20625,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20508,7 +20636,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20517,7 +20645,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20528,7 +20656,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20537,7 +20665,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -20548,7 +20676,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         },
         "kind-of": {
@@ -20583,7 +20711,7 @@
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
@@ -20594,7 +20722,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -20603,7 +20731,7 @@
     "redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
@@ -20634,10 +20762,21 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "repeat-element": {
@@ -20649,23 +20788,23 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
       "requires": {
         "caller-path": "^0.1.0",
@@ -20673,11 +20812,11 @@
       }
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -20685,19 +20824,19 @@
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "dev": true,
       "requires": {
         "exit-hook": "^1.0.0",
@@ -20722,7 +20861,7 @@
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "dev": true,
       "requires": {
         "once": "^1.3.0"
@@ -20731,7 +20870,7 @@
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
     "safe-buffer": {
@@ -20743,7 +20882,7 @@
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
@@ -20757,7 +20896,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -20774,7 +20913,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20785,7 +20924,7 @@
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "integrity": "sha512-/YF5Uk8hcwi7ima04ppkbA4RaRMdPMBfwAvAf8sufYOxsJRtbdoBsT8vGvlb+799BrlGdYrd+oczIA2eN2JdWA==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -20813,7 +20952,7 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true
     },
     "snapdragon": {
@@ -20835,7 +20974,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -20844,7 +20983,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -20853,7 +20992,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20862,7 +21001,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -20903,7 +21042,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -20912,7 +21051,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -20929,7 +21068,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true
     },
     "source-map-resolve": {
@@ -20991,13 +21130,13 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "requires": {
         "define-property": "^0.2.5",
@@ -21007,7 +21146,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -21016,7 +21155,7 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21025,7 +21164,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21064,7 +21203,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -21072,29 +21211,31 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -21102,19 +21243,19 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true
     },
     "supports-hyperlinks": {
@@ -21139,7 +21280,7 @@
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
               "dev": true
             }
           }
@@ -21154,7 +21295,7 @@
     "table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "integrity": "sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==",
       "dev": true,
       "requires": {
         "ajv": "^4.7.0",
@@ -21166,15 +21307,15 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -21190,7 +21331,7 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -21201,25 +21342,25 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -21240,7 +21381,7 @@
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -21250,7 +21391,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -21259,14 +21400,14 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -21279,7 +21420,7 @@
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -21288,18 +21429,18 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -21318,7 +21459,7 @@
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "requires": {
         "has-value": "^0.3.1",
@@ -21328,7 +21469,7 @@
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
           "dev": true,
           "requires": {
             "get-value": "^2.0.3",
@@ -21339,7 +21480,7 @@
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -21350,13 +21491,13 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
           "dev": true
         }
       }
@@ -21364,7 +21505,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "dev": true
     },
     "use": {
@@ -21376,7 +21517,7 @@
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
@@ -21385,7 +21526,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -21422,12 +21563,12 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ=="
     },
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw=="
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -21438,7 +21579,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -21447,13 +21588,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -21473,7 +21614,7 @@
     "yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "requires": {
         "cliui": "^3.2.0",
         "decamelize": "^1.1.1",
@@ -21494,7 +21635,7 @@
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -264,7 +264,7 @@ func TestDependenciesTreeDiffrentBetweenOss(t *testing.T) {
 	}
 }
 
-func TestNpmDevProdFlags(t *testing.T) {
+func TestNpmProdFlags(t *testing.T) {
 	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
 	assert.NoError(t, err)
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
@@ -273,13 +273,12 @@ func TestNpmDevProdFlags(t *testing.T) {
 		scope     string
 		totalDeps int
 	}{
-		{"", 201},
-		{"--prod", 55},
-		{"--dev", 150},
+		{"", 2},
+		{"--prod", 1},
 	}
 	for _, entry := range testDependencyScopes {
 
-		projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project1", false, npmVersion)
+		projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project3", false, npmVersion)
 		defer cleanup()
 		cacachePath := filepath.Join(projectPath, "tmpcache")
 		npmArgs := []string{"--cache=" + cacachePath, entry.scope}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -264,7 +264,7 @@ func TestDependenciesTreeDiffrentBetweenOss(t *testing.T) {
 	}
 }
 
-func TestNpmProdFlags(t *testing.T) {
+func TestNpmProdFlag(t *testing.T) {
 	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
 	assert.NoError(t, err)
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))


### PR DESCRIPTION
To be compatible with and collect build-information, package-lock.json had to be generated differently since npm 8.11.0.
Package-lock.json moved from sha1 to sha512.
In this PR, the package-lock.json files, in npm tests, were upgraded and as a result, The expected dependencies have also changed.

- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
