### PR TITLE
Move IsStringInSlice out from fileutils

### DIFF
--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/jfrog/build-info-go/entities"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jfrog/build-info-go/entities"
 )
 
 const (
@@ -517,15 +518,6 @@ func CreateDirIfNotExist(path string) error {
 	}
 	_, err = CreateFilePath(path, "")
 	return err
-}
-
-func IsStringInSlice(string string, strings []string) bool {
-	for _, v := range strings {
-		if v == string {
-			return true
-		}
-	}
-	return false
 }
 
 func IsPathSymlink(path string) bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,3 +11,12 @@ func GetRegExp(regex string) (*regexp.Regexp, error) {
 	}
 	return regExp, nil
 }
+
+func IsStringInSlice(str string, strings []string) bool {
+	for _, v := range strings {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

IsStringInSlice has nothing to do with Files.