### PR TITLE
Upgrade Maven Extractor Version to 2.39.7

### DIFF
--- a/build/gradle.go
+++ b/build/gradle.go
@@ -16,7 +16,7 @@ const (
 	GradleExtractorFileName          = "build-info-extractor-gradle-%s-uber.jar"
 	gradleInitScriptTemplate         = "gradle.init"
 	GradleExtractorRemotePath        = "org/jfrog/buildinfo/build-info-extractor-gradle/%s"
-	GradleExtractorDependencyVersion = "4.31.5"
+	GradleExtractorDependencyVersion = "4.31.7"
 )
 
 type GradleModule struct {

--- a/build/maven.go
+++ b/build/maven.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/jfrog/build-info-go/utils"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jfrog/build-info-go/utils"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 	PropertiesTempfolderName        = "properties"
 	MavenExtractorRemotePath        = "org/jfrog/buildinfo/build-info-extractor-maven3/%s"
 	GeneratedBuildInfoTempPrefix    = "generatedBuildInfo"
-	MavenExtractorDependencyVersion = "2.39.5"
+	MavenExtractorDependencyVersion = "2.39.7"
 
 	ClassworldsConf = `main is org.apache.maven.cli.MavenCli from plexus.core
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following https://github.com/jfrog/build-info/pull/718
Should fix the following maven error:
```java
[main] ERROR org.apache.maven.cli.MavenCli - NullPointerException
java.lang.NullPointerException
    at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolve (DefaultMetadataResolver.java:213)
    at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolveMetadata (DefaultMetadataResolver.java:198)
```