### PR TITLE
fix: adds support for all yarn version by removing the minimun versio…

### DIFF
--- a/build/yarn.go
+++ b/build/yarn.go
@@ -6,13 +6,10 @@ import (
 	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/gofrog/version"
 	"golang.org/x/exp/slices"
 	"os"
 	"os/exec"
 )
-
-const minSupportedYarnVersion = "2.4.0"
 
 type YarnModule struct {
 	containingBuild          *Build
@@ -156,13 +153,9 @@ func (ym *YarnModule) AddArtifacts(artifacts ...entities.Artifact) error {
 }
 
 func validateYarnVersion(executablePath, srcPath string) error {
-	yarnVersionStr, err := buildutils.GetVersion(executablePath, srcPath)
+	_, err := buildutils.GetVersion(executablePath, srcPath)
 	if err != nil {
 		return err
-	}
-	yarnVersion := version.NewVersion(yarnVersionStr)
-	if yarnVersion.Compare(minSupportedYarnVersion) > 0 {
-		return errors.New("Yarn must have version " + minSupportedYarnVersion + " or higher. The current version is: " + yarnVersionStr)
 	}
 	return nil
 }


### PR DESCRIPTION
…n check.

PR #172 adds supports for yarn V1 but fails to actually enable it when building via the API's

- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
