### PR TITLE
Add support to calculate npm tree only by package-lock.json file

### DIFF
--- a/build/npm.go
+++ b/build/npm.go
@@ -74,7 +74,8 @@ func (nm *NpmModule) CalcDependencies() error {
 	if !nm.containingBuild.buildNameAndNumberProvided() {
 		return errors.New("a build name must be provided in order to collect the project's dependencies")
 	}
-	buildInfoDependencies, err := buildutils.CalculateNpmDependenciesList(nm.executablePath, nm.srcPath, nm.name, nm.npmArgs, true, nm.containingBuild.logger)
+	buildInfoDependencies, err := buildutils.CalculateNpmDependenciesList(nm.executablePath, nm.srcPath, nm.name,
+		buildutils.NpmTreeDepListParam{Args: nm.npmArgs}, true, nm.containingBuild.logger)
 	if err != nil {
 		return err
 	}

--- a/build/testdata/npm/project6/package-lock_test.json
+++ b/build/testdata/npm/project6/package-lock_test.json
@@ -1,0 +1,36 @@
+{
+  "name": "project6",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "project6",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "lightweight": "^0.1.0",
+        "minimist": "^0.1.0",
+        "underscore": "^1.13.6"
+      }
+    },
+    "node_modules/lightweight": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lightweight/-/lightweight-0.1.0.tgz",
+      "integrity": "sha512-10pYSQA9EJqZZnXDR0urhg8Z0Y1XnRfi41ZFj3ZFTKJ5PjRq82HzT7LKlPyxewy3w2WA2POfi3jQQn7Y53oPcQ==",
+      "bin": {
+        "lwt": "bin/lwt.js"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+      "integrity": "sha512-wR5Ipl99t0mTGwLjQJnBjrP/O7zBbLZqvA3aw32DmLx+nXHfWctUjzDjnDx09pX1Po86WFQazF9xUzfMea3Cnw=="
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    }
+  }
+}

--- a/build/testdata/npm/project6/package.json
+++ b/build/testdata/npm/project6/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm_test2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "lightweight": "^0.1.0",
+    "minimist": "^0.1.0",
+    "underscore": "^1.13.6",
+    "cors.js": "0.0.1-security"
+  }
+}

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -135,7 +135,7 @@ func runNpmLsWithoutNodeModules(executablePath, srcPath string, npmListParams Np
 	if isDirExistsErr != nil {
 		return nil, isDirExistsErr
 	}
-	if !isPackageLockExist || (npmListParams.OverWritePackageLock && checkIfLockFileShouldBeUpdated(srcPath, log)) {
+	if !isPackageLockExist || (npmListParams.OverwritePackageLock && checkIfLockFileShouldBeUpdated(srcPath, log)) {
 		err := installPackageLock(executablePath, srcPath, npmListParams.Args, log, npmVersion)
 		if err != nil {
 			return nil, err
@@ -164,8 +164,8 @@ func installPackageLock(executablePath, srcPath string, npmArgs []string, log ut
 	return errors.New("it looks like you’re using version " + npmVersion.GetVersion() + " of the npm client. Versions below 6.0.0 require running `npm install` before running this command")
 }
 
-// check package.json modified,
-// this can hint us new packages added to package.json which were not updated in package-lock.json..
+// Check if package.json has been modified.
+// This might indicate the addition of new packages to package.json that haven't been reflected in package-lock.json.
 func checkIfLockFileShouldBeUpdated(srcPath string, log utils.Log) bool {
 	packageJsonInfo, err := os.Stat(filepath.Join(srcPath, "package.json"))
 	if err != nil {
@@ -193,10 +193,10 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 
 type NpmTreeDepListParam struct {
 	Args []string
-	// ignore node modules folder if exists.
+	// Ignore the node_modules folder if exists, using the '--package-lock-only' flag
 	IgnoreNodeModules bool
-	// rewrite package lock json if exists.
-	OverWritePackageLock bool
+	// Rewrite package-lock.json, if exists.
+	OverwritePackageLock bool
 }
 
 // npm >=7 ls results for a single dependency

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -17,19 +17,19 @@ import (
 )
 
 // CalculateNpmDependenciesList gets an npm project's dependencies.
-func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmArgs []string, calculateChecksums bool, log utils.Log) ([]entities.Dependency, error) {
+func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmParams NpmTreeDepListParam, calculateChecksums bool, log utils.Log) ([]entities.Dependency, error) {
 	if log == nil {
 		log = &utils.NullLog{}
 	}
 	// Calculate npm dependency tree using 'npm ls...'.
-	dependenciesMap, err := CalculateDependenciesMap(executablePath, srcPath, moduleId, npmArgs, log)
+	dependenciesMap, err := CalculateDependenciesMap(executablePath, srcPath, moduleId, npmParams, log)
 	if err != nil {
 		return nil, err
 	}
 	var cacache *cacache
 	if calculateChecksums {
 		// Get local npm cache.
-		cacheLocation, err := GetNpmConfigCache(srcPath, executablePath, npmArgs, log)
+		cacheLocation, err := GetNpmConfigCache(srcPath, executablePath, npmParams.Args, log)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ type dependencyInfo struct {
 
 // Run 'npm list ...' command and parse the returned result to create a dependencies map of.
 // The dependencies map looks like name:version -> entities.Dependency.
-func CalculateDependenciesMap(executablePath, srcPath, moduleId string, npmArgs []string, log utils.Log) (map[string]*dependencyInfo, error) {
+func CalculateDependenciesMap(executablePath, srcPath, moduleId string, npmListParams NpmTreeDepListParam, log utils.Log) (map[string]*dependencyInfo, error) {
 	dependenciesMap := make(map[string]*dependencyInfo)
 	// These arguments must be added at the end of the command, to override their other values (if existed in nm.npmArgs).
 	npmVersion, err := GetNpmVersion(executablePath, log)
@@ -100,10 +100,10 @@ func CalculateDependenciesMap(executablePath, srcPath, moduleId string, npmArgs 
 	}
 	var data []byte
 	// If we don't have node_modules, the function will use the package-lock dependencies.
-	if nodeModulesExist {
-		data = runNpmLsWithNodeModules(executablePath, srcPath, npmArgs, log)
+	if nodeModulesExist && !npmListParams.IgnoreNodeModules {
+		data = runNpmLsWithNodeModules(executablePath, srcPath, npmListParams.Args, log)
 	} else {
-		data, err = runNpmLsWithoutNodeModules(executablePath, srcPath, npmArgs, log, npmVersion)
+		data, err = runNpmLsWithoutNodeModules(executablePath, srcPath, npmListParams, log, npmVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -130,19 +130,19 @@ func runNpmLsWithNodeModules(executablePath, srcPath string, npmArgs []string, l
 	return
 }
 
-func runNpmLsWithoutNodeModules(executablePath, srcPath string, npmArgs []string, log utils.Log, npmVersion *version.Version) ([]byte, error) {
+func runNpmLsWithoutNodeModules(executablePath, srcPath string, npmListParams NpmTreeDepListParam, log utils.Log, npmVersion *version.Version) ([]byte, error) {
 	isPackageLockExist, isDirExistsErr := utils.IsFileExists(filepath.Join(srcPath, "package-lock.json"), false)
 	if isDirExistsErr != nil {
 		return nil, isDirExistsErr
 	}
-	if !isPackageLockExist {
-		err := installPackageLock(executablePath, srcPath, npmArgs, log, npmVersion)
+	if !isPackageLockExist || (npmListParams.OverWritePackageLock && checkIfLockFileShouldBeUpdated(srcPath, log)) {
+		err := installPackageLock(executablePath, srcPath, npmListParams.Args, log, npmVersion)
 		if err != nil {
 			return nil, err
 		}
 	}
-	npmArgs = append(npmArgs, "--json", "--all", "--long", "--package-lock-only")
-	data, errData, err := RunNpmCmd(executablePath, srcPath, AppendNpmCommand(npmArgs, "ls"), log)
+	npmListParams.Args = append(npmListParams.Args, "--json", "--all", "--long", "--package-lock-only")
+	data, errData, err := RunNpmCmd(executablePath, srcPath, AppendNpmCommand(npmListParams.Args, "ls"), log)
 	if err != nil {
 		log.Warn(err.Error())
 	} else if len(errData) > 0 {
@@ -164,12 +164,39 @@ func installPackageLock(executablePath, srcPath string, npmArgs []string, log ut
 	return errors.New("it looks like you’re using version " + npmVersion.GetVersion() + " of the npm client. Versions below 6.0.0 require running `npm install` before running this command")
 }
 
+// check package.json modified,
+// this can hint us new packages added to package.json which were not updated in package-lock.json..
+func checkIfLockFileShouldBeUpdated(srcPath string, log utils.Log) bool {
+	packageJsonInfo, err := os.Stat(filepath.Join(srcPath, "package.json"))
+	if err != nil {
+		log.Warn("Failed to get file info for package.json, err: %v", err)
+		return false
+	}
+
+	packageJsonInfoModTime := packageJsonInfo.ModTime()
+	packageLockInfo, err := os.Stat(filepath.Join(srcPath, "package-lock.json"))
+	if err != nil {
+		log.Warn("Failed to get file info for package-lock.json, err: %v", err)
+		return false
+	}
+	packageLockInfoModTime := packageLockInfo.ModTime()
+	return packageJsonInfoModTime.After(packageLockInfoModTime)
+}
+
 func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, error) {
 	versionData, _, err := RunNpmCmd(executablePath, "", []string{"--version"}, log)
 	if err != nil {
 		return nil, err
 	}
 	return version.NewVersion(string(versionData)), nil
+}
+
+type NpmTreeDepListParam struct {
+	Args []string
+	// ignore node modules folder if exists.
+	IgnoreNodeModules bool
+	// rewrite package lock json if exists.
+	OverWritePackageLock bool
 }
 
 // npm >=7 ls results for a single dependency

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -211,9 +211,9 @@ func TestDependencyPackageLockOnly(t *testing.T) {
 	require.NoError(t, err)
 	info, err := os.Stat(filepath.Join(path, "package-lock_test.json"))
 	require.NoError(t, err)
-	os.WriteFile(filepath.Join(path, "package-lock.json"), data, info.Mode().Perm())
+	require.NoError(t, os.WriteFile(filepath.Join(path, "package-lock.json"), data, info.Mode().Perm()))
 	// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
-	time.Sleep(time.Millisecond * 5)
+	time.Sleep(time.Millisecond * 1000)
 	require.NoError(t, os.Chtimes(filepath.Join(path, "package.json"), time.Now(), time.Now()))
 
 	// Calculate dependencies.

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -205,6 +205,7 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 // this according to the params 'IgnoreNodeModules' and 'OverWritePackageLock'.
 func TestDependencyPackageLockOnly(t *testing.T) {
 	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
+	require.NoError(t, err)
 	if !npmVersion.AtLeast("7.0.0") {
 		t.Skip("Running on npm v7 and above only, skipping...")
 	}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -192,7 +192,7 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "jfrogtest", npmArgs, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "jfrogtest", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 	assert.NoError(t, err)
 
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -214,7 +214,7 @@ func TestDependenciesTreeDifferentBetweenOKs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "bundle-dependencies", npmArgs, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "bundle-dependencies", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 	assert.NoError(t, err)
 
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -222,7 +222,7 @@ func TestDependenciesTreeDifferentBetweenOKs(t *testing.T) {
 	// Remove node_modules directory, then calculate dependencies by package-lock.
 	assert.NoError(t, utils.RemoveTempDir(filepath.Join(projectPath, "node_modules")))
 
-	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", npmArgs, true, logger)
+	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 	assert.NoError(t, err)
 
 	// Asserting there is at least one dependency.
@@ -253,7 +253,7 @@ func TestNpmProdFlag(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Calculate dependencies with scope.
-			dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", npmArgs, true, logger)
+			dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 			assert.NoError(t, err)
 			assert.Len(t, dependencies, entry.totalDeps)
 		}()
@@ -302,7 +302,7 @@ func validateDependencies(t *testing.T, projectPath string, npmArgs []string) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", npmArgs, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 	assert.NoError(t, err)
 
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -310,7 +310,7 @@ func validateDependencies(t *testing.T, projectPath string, npmArgs []string) {
 	// Remove node_modules directory, then calculate dependencies by package-lock.
 	assert.NoError(t, utils.RemoveTempDir(filepath.Join(projectPath, "node_modules")))
 
-	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", npmArgs, true, logger)
+	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
 	assert.NoError(t, err)
 
 	// Asserting there is at least one dependency.

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -204,6 +204,10 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 // This test case check that CalculateNpmDependenciesList ignore node_modules and update package-lock.json when needed,
 // this according to the params 'IgnoreNodeModules' and 'OverWritePackageLock'.
 func TestDependencyPackageLockOnly(t *testing.T) {
+	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
+	if !npmVersion.AtLeast("7.0.0") {
+		t.Skip("Running on npm v7 and above only, skipping...")
+	}
 	path, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
 	defer cleanup()
 	data, err := os.ReadFile(filepath.Join(path, "package-lock_test.json"))

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -205,17 +205,13 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 // This test case check that CalculateNpmDependenciesList ignore node_modules and update package-lock.json when needed,
 // this according to the params 'IgnoreNodeModules' and 'OverWritePackageLock'.
 func TestDependencyPackageLockOnly(t *testing.T) {
-	path, err := filepath.Abs(filepath.Join("..", "testdata/npm/project6"))
-	assert.NoError(t, err)
+	path, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
+	defer cleanup()
 	data, err := os.ReadFile(filepath.Join(path, "package-lock_test.json"))
 	require.NoError(t, err)
 	info, err := os.Stat(filepath.Join(path, "package-lock_test.json"))
 	require.NoError(t, err)
 	os.WriteFile(filepath.Join(path, "package-lock.json"), data, info.Mode().Perm())
-	defer func() {
-		assert.NoError(t, os.Remove(filepath.Join(path, "package-lock.json")))
-		assert.NoError(t, os.Remove(filepath.Join(path, "node_modules", ".package-lock.json")))
-	}()
 	// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
 	time.Sleep(time.Millisecond * 5)
 	require.NoError(t, os.Chtimes(filepath.Join(path, "package.json"), time.Now(), time.Now()))


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

This PR introduce more control on the possible ways npm tree is calculated:
1) create the tree (which is the "ls" command) only by the package-lock file, with no mater if node modules exists.
2) if package-lock exists, check if the package.json is more updated than the lock, if so, then recalculate th package-lock file.