### PR TITLE
Parse Gradle versions even if strerr is not empty

### DIFF
--- a/build/gradle.go
+++ b/build/gradle.go
@@ -149,12 +149,12 @@ func (gm *GradleModule) getExtractorVersionAndInitScript(gradleExecPath string) 
 	if err := gradleRunConfig.runCmd(outBuffer, errBuffer); err != nil {
 		return "", "", err
 	}
-	if errBuffer.Len() > 0 {
-		return "", "", errors.New("unexpected error occurred during attempt to get the Gradle version: " + errBuffer.String())
-	}
 
 	gradleVersion, err := parseGradleVersion(outBuffer.String())
 	if err != nil {
+		if errBuffer.Len() > 0 {
+			err = errors.Join(err, errors.New(errBuffer.String()))
+		}
 		return "", "", err
 	}
 	gm.containingBuild.logger.Info("Using Gradle version:", gradleVersion.GetVersion())


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following error:
> 17:57:27 [Error] unexpected error occurred during attempt to get the Gradle version: Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8

In specific Java versions, if you set the `JAVA_TOOL_OPTIONS` environment variable, starting a Java process will result in the message "Picked up JAVA_TOOL_OPTIONS" being shown on the standard error (stderr). This pull request alters the way Gradle version is determined, enabling it to capture output from the standard output (stdout) even when there is text on the standard error (stderr).