### PR TITLE
Support running npm install without package.json

### DIFF
--- a/build/maven_test.go
+++ b/build/maven_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
 	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/jfrog/build-info-go/utils"
 	"os"
 	"path/filepath"
@@ -45,7 +45,7 @@ func TestGenerateBuildInfoForMavenProject(t *testing.T) {
 	assert.NoError(t, err)
 	// Create maven project
 	projectPath := filepath.Join(testdataDir, "maven", "project")
-	tmpProjectPath, cleanup := testdatautils.CreateTestProject(t, projectPath)
+	tmpProjectPath, cleanup := tests.CreateTestProject(t, projectPath)
 	defer cleanup()
 	// Add maven project as module in build-info.
 	mavenModule, err := mavenBuild.AddMavenModule(tmpProjectPath)
@@ -65,7 +65,7 @@ func TestGenerateBuildInfoForMavenProject(t *testing.T) {
 		match, err := entities.IsEqualModuleSlices(buildInfo.Modules, expectedModules)
 		assert.NoError(t, err)
 		if !match {
-			testdatautils.PrintBuildInfoMismatch(t, expectedModules, buildInfo.Modules)
+			tests.PrintBuildInfoMismatch(t, expectedModules, buildInfo.Modules)
 		}
 	}
 }

--- a/build/npm.go
+++ b/build/npm.go
@@ -43,7 +43,7 @@ func newNpmModule(srcPath string, containingBuild *Build) (*NpmModule, error) {
 	}
 
 	// Read module name
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(srcPath, npmVersion)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExists(srcPath, npmVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/build/npm.go
+++ b/build/npm.go
@@ -43,7 +43,7 @@ func newNpmModule(srcPath string, containingBuild *Build) (*NpmModule, error) {
 	}
 
 	// Read module name
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJson(srcPath, npmVersion)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(srcPath, npmVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/build/npm_test.go
+++ b/build/npm_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
 	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +28,7 @@ func TestGenerateBuildInfoForNpm(t *testing.T) {
 	// Create npm project.
 	path, err := filepath.Abs(filepath.Join(".", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project3", false, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project3", false, npmVersion)
 	defer cleanup()
 
 	// Install dependencies in the npm project.
@@ -45,11 +45,11 @@ func TestGenerateBuildInfoForNpm(t *testing.T) {
 
 	// Verify results.
 	expectedBuildInfoJson := filepath.Join(projectPath, "expected_npm_buildinfo.json")
-	expectedBuildInfo := testdatautils.GetBuildInfo(t, expectedBuildInfoJson)
+	expectedBuildInfo := tests.GetBuildInfo(t, expectedBuildInfoJson)
 	match, err := entities.IsEqualModuleSlices(buildInfo.Modules, expectedBuildInfo.Modules)
 	assert.NoError(t, err)
 	if !match {
-		testdatautils.PrintBuildInfoMismatch(t, expectedBuildInfo.Modules, buildInfo.Modules)
+		tests.PrintBuildInfoMismatch(t, expectedBuildInfo.Modules, buildInfo.Modules)
 	}
 }
 
@@ -66,7 +66,7 @@ func TestFilterNpmArgsFlags(t *testing.T) {
 	// Create npm project.
 	path, err := filepath.Abs(filepath.Join(".", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project3", false, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project3", false, npmVersion)
 	defer cleanup()
 
 	// Set arguments in npmArgs.

--- a/build/python_test.go
+++ b/build/python_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils/pythonutils"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +47,7 @@ func testGenerateBuildInfoForPython(t *testing.T, pythonTool pythonutils.PythonT
 	assert.NoError(t, err)
 	// Create python project
 	projectPath := filepath.Join(testdataDir, "python", string(pythonTool))
-	tmpProjectPath, cleanup := testdatautils.CreateTestProject(t, projectPath)
+	tmpProjectPath, cleanup := tests.CreateTestProject(t, projectPath)
 	defer cleanup()
 
 	// Install dependencies in the pip project.
@@ -59,11 +59,11 @@ func testGenerateBuildInfoForPython(t *testing.T, pythonTool pythonutils.PythonT
 	if assert.NoError(t, err) {
 		// Verify results.
 		expectedBuildInfoJson := filepath.Join(projectPath, expectedResultsJson)
-		expectedBuildInfo := testdatautils.GetBuildInfo(t, expectedBuildInfoJson)
+		expectedBuildInfo := tests.GetBuildInfo(t, expectedBuildInfoJson)
 		match, err := entities.IsEqualModuleSlices(buildInfo.Modules, expectedBuildInfo.Modules)
 		assert.NoError(t, err)
 		if !match {
-			testdatautils.PrintBuildInfoMismatch(t, expectedBuildInfo.Modules, buildInfo.Modules)
+			tests.PrintBuildInfoMismatch(t, expectedBuildInfo.Modules, buildInfo.Modules)
 		}
 	}
 }

--- a/build/testdata/test_helpers.go
+++ b/build/testdata/test_helpers.go
@@ -73,3 +73,11 @@ func PrintBuildInfoMismatch(t *testing.T, expected, actual []entities.Module) {
 	assert.NoError(t, err)
 	t.Errorf("build-info don't match. want: \n%v\ngot:\n%s\n", string(excpectedStr), string(actualStr))
 }
+
+func CreateTempDirWithCallbackAndAssert(t *testing.T) (string, func()) {
+	tempDirPath, err := utils.CreateTempDir()
+	assert.NoError(t, err, "Couldn't create temp dir")
+	return tempDirPath, func() {
+		assert.NoError(t, utils.RemoveTempDir(tempDirPath), "Couldn't remove temp dir")
+	}
+}

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -442,10 +442,16 @@ type PackageInfo struct {
 	Scope                string
 }
 
-func ReadPackageInfoFromPackageJson(packageJsonDirectory string, npmVersion *version.Version) (*PackageInfo, error) {
+// Read and populate package name, version and scope from the package.json file in the provided directory.
+// If package.json does not exist, return an empty PackageInfo object.
+func ReadPackageInfoFromPackageJsonIfExist(packageJsonDirectory string, npmVersion *version.Version) (*PackageInfo, error) {
 	packageJson, err := os.ReadFile(filepath.Join(packageJsonDirectory, "package.json"))
 	if err != nil {
-		return nil, err
+		if os.IsNotExist(err) {
+			return &PackageInfo{}, nil
+		} else {
+			return nil, err
+		}
 	}
 	return ReadPackageInfo(packageJson, npmVersion)
 }

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -443,8 +443,8 @@ type PackageInfo struct {
 }
 
 // Read and populate package name, version and scope from the package.json file in the provided directory.
-// If package.json does not exist, return an empty PackageInfo object.
-func ReadPackageInfoFromPackageJsonIfExist(packageJsonDirectory string, npmVersion *version.Version) (*PackageInfo, error) {
+// If package.json does not exist, return an empty PackageInfo struct.
+func ReadPackageInfoFromPackageJsonIfExists(packageJsonDirectory string, npmVersion *version.Version) (*PackageInfo, error) {
 	packageJson, err := os.ReadFile(filepath.Join(packageJsonDirectory, "package.json"))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/stretchr/testify/require"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -44,13 +44,13 @@ func TestReadPackageInfo(t *testing.T) {
 	}
 }
 
-func TestReadPackageInfoFromPackageJsonIfExist(t *testing.T) {
+func TestReadPackageInfoFromPackageJsonIfExists(t *testing.T) {
 	// Prepare tests data
 	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
 	assert.NoError(t, err)
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project1", false, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project1", false, npmVersion)
 	defer cleanup()
 
 	// Prepare test cases
@@ -66,7 +66,7 @@ func TestReadPackageInfoFromPackageJsonIfExist(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
 			// Read package info
-			packageInfo, err := ReadPackageInfoFromPackageJsonIfExist(testCase.packageJsonDirectory, npmVersion)
+			packageInfo, err := ReadPackageInfoFromPackageJsonIfExists(testCase.packageJsonDirectory, npmVersion)
 			assert.NoError(t, err)
 
 			// Remove "v" prefix, if exist
@@ -83,13 +83,13 @@ func TestReadPackageInfoFromPackageJsonIfExistErr(t *testing.T) {
 	// Prepare test data
 	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
 	assert.NoError(t, err)
-	tempDir, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
+	tempDir, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	assert.NoError(t, err)
 	defer createTempDirCallback()
 
 	// Create bad package.json file and expect error
 	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "package.json"), []byte("non json file"), 0600))
-	_, err = ReadPackageInfoFromPackageJsonIfExist(tempDir, npmVersion)
+	_, err = ReadPackageInfoFromPackageJsonIfExists(tempDir, npmVersion)
 	assert.IsType(t, &json.SyntaxError{}, err)
 }
 
@@ -180,7 +180,7 @@ func TestBundledDependenciesList(t *testing.T) {
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
 
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project1", false, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project1", false, npmVersion)
 	defer cleanup()
 	cacachePath := filepath.Join(projectPath, "tmpcache")
 	npmArgs := []string{"--cache=" + cacachePath}
@@ -200,7 +200,7 @@ func TestConflictsDependenciesList(t *testing.T) {
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
 
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project5", true, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project5", true, npmVersion)
 	defer cleanup()
 	cacachePath := filepath.Join(projectPath, "tmpcache")
 	npmArgs := []string{"--cache=" + cacachePath}
@@ -218,7 +218,7 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 	// Create the second npm project which has a transitive dependency without integrity (ansi-regex:5.0.0).
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project2", true, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project2", true, npmVersion)
 	defer cleanup()
 
 	// Run npm CI to create this special case where the 'ansi-regex:5.0.0' is missing the integrity.
@@ -241,7 +241,7 @@ func TestDependencyPackageLockOnly(t *testing.T) {
 	if !npmVersion.AtLeast("7.0.0") {
 		t.Skip("Running on npm v7 and above only, skipping...")
 	}
-	path, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
+	path, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
 	defer cleanup()
 	assert.NoError(t, utils.MoveFile(filepath.Join(path, "package-lock_test.json"), filepath.Join(path, "package-lock.json")))
 	// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
@@ -318,7 +318,7 @@ func TestDependenciesTreeDifferentBetweenOKs(t *testing.T) {
 	assert.NoError(t, err)
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project4", true, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project4", true, npmVersion)
 	defer cleanup()
 	cacachePath := filepath.Join(projectPath, "tmpcache")
 
@@ -357,7 +357,7 @@ func TestNpmProdFlag(t *testing.T) {
 	}
 	for _, entry := range testDependencyScopes {
 		func() {
-			projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project3", false, npmVersion)
+			projectPath, cleanup := tests.CreateNpmTest(t, path, "project3", false, npmVersion)
 			defer cleanup()
 			cacachePath := filepath.Join(projectPath, "tmpcache")
 			npmArgs := []string{"--cache=" + cacachePath, entry.scope}
@@ -382,7 +382,7 @@ func TestGetConfigCacheNpmIntegration(t *testing.T) {
 	// Create the first npm project which contains peerDependencies, devDependencies & bundledDependencies
 	path, err := filepath.Abs(filepath.Join("..", "testdata"))
 	assert.NoError(t, err)
-	projectPath, cleanup := testdatautils.CreateNpmTest(t, path, "project1", false, npmVersion)
+	projectPath, cleanup := tests.CreateNpmTest(t, path, "project1", false, npmVersion)
 	defer cleanup()
 	cachePath := filepath.Join(projectPath, "tmpcache")
 	npmArgs := []string{"--cache=" + cachePath}

--- a/build/utils_test.go
+++ b/build/utils_test.go
@@ -1,10 +1,10 @@
 package build
 
 import (
-	"github.com/jfrog/build-info-go/entities"
-	"github.com/jfrog/build-info-go/utils"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/stretchr/testify/assert"
 )
 
 func validateModule(t *testing.T, module entities.Module, expectedDependencies, expectedArtifacts int, moduleName string, moduleType entities.ModuleType, depsContainChecksums bool) {
@@ -25,13 +25,5 @@ func validateModule(t *testing.T, module entities.Module, expectedDependencies, 
 		assert.NotEmpty(t, module.Dependencies[0].Checksum.Sha1, "Empty Sha1 field.")
 		assert.NotEmpty(t, module.Dependencies[0].Checksum.Md5, "Empty MD5 field.")
 		assert.NotEmpty(t, module.Dependencies[0].Checksum.Sha256, "Empty SHA256 field.")
-	}
-}
-
-func createTempDirWithCallbackAndAssert(t *testing.T) (string, func()) {
-	tempDirPath, err := utils.CreateTempDir()
-	assert.NoError(t, err, "Couldn't create temp dir")
-	return tempDirPath, func() {
-		assert.NoError(t, utils.RemoveTempDir(tempDirPath), "Couldn't remove temp dir")
 	}
 }

--- a/build/yarn.go
+++ b/build/yarn.go
@@ -50,7 +50,7 @@ func newYarnModule(srcPath string, containingBuild *Build) (*YarnModule, error) 
 	}
 
 	// Read module name
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(srcPath, nil)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExists(srcPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/build/yarn.go
+++ b/build/yarn.go
@@ -3,13 +3,14 @@ package build
 import (
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+
 	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/version"
 	"golang.org/x/exp/slices"
-	"os"
-	"os/exec"
 )
 
 const minSupportedYarnVersion = "2.4.0"
@@ -49,7 +50,7 @@ func newYarnModule(srcPath string, containingBuild *Build) (*YarnModule, error) 
 	}
 
 	// Read module name
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJson(srcPath, nil)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(srcPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/build/yarn_test.go
+++ b/build/yarn_test.go
@@ -2,10 +2,12 @@ package build
 
 import (
 	"errors"
-	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	testdatautils "github.com/jfrog/build-info-go/build/testdata"
+	buildutils "github.com/jfrog/build-info-go/build/utils"
 
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
@@ -79,7 +81,7 @@ func TestAppendDependencyRecursively(t *testing.T) {
 
 func TestGenerateBuildInfoForYarnProject(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := createTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -105,7 +107,7 @@ func TestGenerateBuildInfoForYarnProject(t *testing.T) {
 
 func TestCollectDepsForYarnProjectWithTraverse(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := createTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -146,7 +148,7 @@ func TestCollectDepsForYarnProjectWithTraverse(t *testing.T) {
 
 func TestCollectDepsForYarnProjectWithErrorInTraverse(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := createTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -169,7 +171,7 @@ func TestCollectDepsForYarnProjectWithErrorInTraverse(t *testing.T) {
 
 func TestBuildYarnProjectWithArgs(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := createTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")

--- a/build/yarn_test.go
+++ b/build/yarn_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
 	buildutils "github.com/jfrog/build-info-go/build/utils"
+	"github.com/jfrog/build-info-go/tests"
 
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
@@ -81,7 +81,7 @@ func TestAppendDependencyRecursively(t *testing.T) {
 
 func TestGenerateBuildInfoForYarnProject(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -107,7 +107,7 @@ func TestGenerateBuildInfoForYarnProject(t *testing.T) {
 
 func TestCollectDepsForYarnProjectWithTraverse(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -148,7 +148,7 @@ func TestCollectDepsForYarnProjectWithTraverse(t *testing.T) {
 
 func TestCollectDepsForYarnProjectWithErrorInTraverse(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")
@@ -171,7 +171,7 @@ func TestCollectDepsForYarnProjectWithErrorInTraverse(t *testing.T) {
 
 func TestBuildYarnProjectWithArgs(t *testing.T) {
 	// Copy the project directory to a temporary directory
-	tempDirPath, createTempDirCallback := testdatautils.CreateTempDirWithCallbackAndAssert(t)
+	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
 	testDataSource := filepath.Join("testdata", "yarn", "v2")
 	testDataTarget := filepath.Join(tempDirPath, "yarn")

--- a/buildinfoschema_test.go
+++ b/buildinfoschema_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jfrog/build-info-go/build/testdata"
+	"github.com/jfrog/build-info-go/tests"
 	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/build-info-go/utils"
 
@@ -67,7 +67,7 @@ func validateBuildInfoSchema(t *testing.T, commandName, pathInTestData string, i
 func prepareProject(t *testing.T, pathInTestdata string, install func()) func() {
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
-	tempDir, cleanup := testdata.CreateTestProject(t, filepath.Join("build", "testdata", pathInTestdata))
+	tempDir, cleanup := tests.CreateTestProject(t, filepath.Join("build", "testdata", pathInTestdata))
 	assert.NoError(t, os.Chdir(tempDir))
 	install()
 

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -1,4 +1,4 @@
-package testdata
+package tests
 
 import (
 	"encoding/json"
@@ -53,12 +53,10 @@ func CreateNpmTest(t *testing.T, testdataPath, projectDirName string, withOsInPa
 		switch runtime.GOOS {
 		case "windows":
 			npmVersionDir = filepath.Join(npmVersionDir, "windows")
-
 		case "linux":
 			npmVersionDir = filepath.Join(npmVersionDir, "linux")
-
 		default:
-			//MacOs
+			// MacOs
 			npmVersionDir = filepath.Join(npmVersionDir, "macos")
 		}
 	}

--- a/utils/pythonutils/piputils_test.go
+++ b/utils/pythonutils/piputils_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +45,7 @@ var moduleNameTestProvider = []struct {
 func TestDetermineModuleName(t *testing.T) {
 	for _, test := range moduleNameTestProvider {
 		t.Run(strings.Join([]string{test.projectName, test.moduleName}, "/"), func(t *testing.T) {
-			tmpProjectPath, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata", "pip", test.projectName))
+			tmpProjectPath, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata", "pip", test.projectName))
 			defer cleanup()
 
 			// Determine module name

--- a/utils/pythonutils/poetryutils_test.go
+++ b/utils/pythonutils/poetryutils_test.go
@@ -6,12 +6,12 @@ import (
 	"sort"
 	"testing"
 
-	testdatautils "github.com/jfrog/build-info-go/build/testdata"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetProjectNameFromPyproject(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		poetryProject       string
 		expectedProjectName string
 	}{
@@ -19,22 +19,22 @@ func TestGetProjectNameFromPyproject(t *testing.T) {
 		{"nodevdeps", "my-poetry-project:1.1.17"},
 	}
 
-	for _, test := range tests {
-		t.Run(test.poetryProject, func(t *testing.T) {
-			tmpProjectPath, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata", "poetry", test.poetryProject))
+	for _, testCase := range testCases {
+		t.Run(testCase.poetryProject, func(t *testing.T) {
+			tmpProjectPath, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata", "poetry", testCase.poetryProject))
 			defer cleanup()
 
 			actualValue, err := extractProjectFromPyproject(filepath.Join(tmpProjectPath, "pyproject.toml"))
 			assert.NoError(t, err)
-			if actualValue.Name != test.expectedProjectName {
-				t.Errorf("Expected value: %s, got: %s.", test.expectedProjectName, actualValue)
+			if actualValue.Name != testCase.expectedProjectName {
+				t.Errorf("Expected value: %s, got: %s.", testCase.expectedProjectName, actualValue)
 			}
 		})
 	}
 }
 
 func TestGetProjectDependencies(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		poetryProject                  string
 		expectedDirectDependencies     []string
 		expectedTransitiveDependencies [][]string
@@ -43,22 +43,22 @@ func TestGetProjectDependencies(t *testing.T) {
 		{"nodevdeps", []string{"numpy:1.23.0", "python:"}, [][]string{nil, nil, nil}},
 	}
 
-	for _, test := range tests {
-		t.Run(test.poetryProject, func(t *testing.T) {
-			tmpProjectPath, cleanup := testdatautils.CreateTestProject(t, filepath.Join("..", "testdata", "poetry", test.poetryProject))
+	for _, testCase := range testCases {
+		t.Run(testCase.poetryProject, func(t *testing.T) {
+			tmpProjectPath, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata", "poetry", testCase.poetryProject))
 			defer cleanup()
 
 			graph, directDependencies, err := getPoetryDependencies(tmpProjectPath)
 			assert.NoError(t, err)
 			sort.Strings(directDependencies)
-			if !reflect.DeepEqual(directDependencies, test.expectedDirectDependencies) {
-				t.Errorf("Expected value: %s, got: %s.", test.expectedDirectDependencies, directDependencies)
+			if !reflect.DeepEqual(directDependencies, testCase.expectedDirectDependencies) {
+				t.Errorf("Expected value: %s, got: %s.", testCase.expectedDirectDependencies, directDependencies)
 			}
 			for i, directDependency := range directDependencies {
 				transitiveDependencies := graph[directDependency]
 				sort.Strings(transitiveDependencies)
-				if !reflect.DeepEqual(transitiveDependencies, test.expectedTransitiveDependencies[i]) {
-					t.Errorf("Expected value: %s, got: %s.", test.expectedTransitiveDependencies[i], graph[directDependency])
+				if !reflect.DeepEqual(transitiveDependencies, testCase.expectedTransitiveDependencies[i]) {
+					t.Errorf("Expected value: %s, got: %s.", testCase.expectedTransitiveDependencies[i], graph[directDependency])
 				}
 			}
 		})


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Dependent PRs:
* https://github.com/jfrog/jfrog-cli-core/pull/1002
* https://github.com/jfrog/jfrog-cli/pull/2269

Allow running npm install (`jf npm install <package-name>`) without `package.json` file. 