### PR TITLE
Locking Yarn tests into major 3

### DIFF
--- a/build/utils/yarn_test.go
+++ b/build/utils/yarn_test.go
@@ -36,7 +36,7 @@ func TestBuildYarnV1Dependencies(t *testing.T) {
 
 func TestGetYarnDependenciesUninstalled(t *testing.T) {
 	checkGetYarnDependenciesUninstalled(t, "2.4.0")
-	checkGetYarnDependenciesUninstalled(t, "latest")
+	checkGetYarnDependenciesUninstalled(t, "3.6.4")
 }
 
 func checkGetYarnDependenciesUninstalled(t *testing.T, versionToSet string) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

changing version updates in a Yarn test to the latest V3 version instead of 'latest' since Yarn released a new Major that need to be tested whether its supported