### PR TITLE
Fix Maven/Gradle Artifacts build.timestamp property

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -378,6 +378,10 @@ func (b *Build) buildNameAndNumberProvided() bool {
 	return len(b.buildName) > 0 && len(b.buildNumber) > 0
 }
 
+func (b *Build) GetBuildTimestamp() time.Time {
+	return b.buildTimestamp
+}
+
 type partialModule struct {
 	moduleType   entities.ModuleType
 	artifacts    map[string]entities.Artifact

--- a/build/build.go
+++ b/build/build.go
@@ -28,6 +28,7 @@ const (
 type Build struct {
 	buildName         string
 	buildNumber       string
+	buildTimestamp    time.Time
 	projectKey        string
 	tempDirPath       string
 	logger            utils.Log
@@ -38,13 +39,14 @@ type Build struct {
 	buildUrl          string
 }
 
-func NewBuild(buildName, buildNumber, projectKey, tempDirPath string, logger utils.Log) *Build {
+func NewBuild(buildName, buildNumber string, buildTimestamp time.Time, projectKey, tempDirPath string, logger utils.Log) *Build {
 	return &Build{
-		buildName:   buildName,
-		buildNumber: buildNumber,
-		projectKey:  projectKey,
-		tempDirPath: tempDirPath,
-		logger:      logger,
+		buildName:      buildName,
+		buildNumber:    buildNumber,
+		buildTimestamp: buildTimestamp,
+		projectKey:     projectKey,
+		tempDirPath:    tempDirPath,
+		logger:         logger,
 	}
 }
 
@@ -336,8 +338,8 @@ func (b *Build) readPartialBuildInfoFiles() (entities.Partials, error) {
 	return partials, nil
 }
 
-func (b *Build) readBuildInfoGeneralDetails() (*entities.General, error) {
-	partialsBuildDir, err := utils.GetPartialsBuildDir(b.buildName, b.buildNumber, b.projectKey, b.tempDirPath)
+func ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey, buildsDirPath string) (*entities.General, error) {
+	partialsBuildDir, err := utils.GetPartialsBuildDir(buildName, buildNumber, projectKey, buildsDirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -348,10 +350,10 @@ func (b *Build) readBuildInfoGeneralDetails() (*entities.General, error) {
 	}
 	if !fileExists {
 		var buildString string
-		if b.projectKey != "" {
-			buildString = fmt.Sprintf("build-name: <%s>, build-number: <%s> and project: <%s>", b.buildName, b.buildNumber, b.projectKey)
+		if projectKey != "" {
+			buildString = fmt.Sprintf("build-name: <%s>, build-number: <%s> and project: <%s>", buildName, buildNumber, projectKey)
 		} else {
-			buildString = fmt.Sprintf("build-name: <%s> and build-number: <%s>", b.buildName, b.buildNumber)
+			buildString = fmt.Sprintf("build-name: <%s> and build-number: <%s>", buildName, buildNumber)
 		}
 		return nil, errors.New("Failed to construct the build-info to be published. " +
 			"This may be because there were no previous commands, which collected build-info for " + buildString)
@@ -366,6 +368,10 @@ func (b *Build) readBuildInfoGeneralDetails() (*entities.General, error) {
 		return nil, err
 	}
 	return details, nil
+}
+
+func (b *Build) readBuildInfoGeneralDetails() (*entities.General, error) {
+	return ReadBuildInfoGeneralDetails(b.buildName, b.buildNumber, b.projectKey, b.tempDirPath)
 }
 
 func (b *Build) buildNameAndNumberProvided() bool {

--- a/build/gradle.go
+++ b/build/gradle.go
@@ -179,7 +179,7 @@ func (gm *GradleModule) createGradleRunConfig(gradleExecPath string) (*gradleRun
 	if err != nil {
 		return nil, err
 	}
-	extractorPropsFile, err := utils.CreateExtractorPropsFile(gm.gradleExtractorDetails.propsDir, buildInfoPath, gm.containingBuild.buildName, gm.containingBuild.buildNumber, gm.containingBuild.projectKey, gm.gradleExtractorDetails.props)
+	extractorPropsFile, err := utils.CreateExtractorPropsFile(gm.gradleExtractorDetails.propsDir, buildInfoPath, gm.containingBuild.buildName, gm.containingBuild.buildNumber, gm.containingBuild.buildTimestamp, gm.containingBuild.projectKey, gm.gradleExtractorDetails.props)
 	if err != nil {
 		return nil, err
 	}

--- a/build/maven.go
+++ b/build/maven.go
@@ -137,7 +137,7 @@ func (mm *MavenModule) createMvnRunConfig() (*mvnRunConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	extractorProps, err := utils.CreateExtractorPropsFile(mm.extractorDetails.propsDir, buildInfoPath, mm.containingBuild.buildName, mm.containingBuild.buildNumber, mm.containingBuild.projectKey, mm.extractorDetails.props)
+	extractorProps, err := utils.CreateExtractorPropsFile(mm.extractorDetails.propsDir, buildInfoPath, mm.containingBuild.buildName, mm.containingBuild.buildNumber, mm.containingBuild.buildTimestamp, mm.containingBuild.projectKey, mm.extractorDetails.props)
 	if err != nil {
 		return nil, err
 	}

--- a/build/service.go
+++ b/build/service.go
@@ -63,7 +63,7 @@ func getOrCreateBuildGeneralDetails(buildName, buildNumber string, buildTime tim
 		log.Debug("Reading build general details from: " + partialsBuildDir)
 		var generalDetails *buildinfo.General
 		generalDetails, err = ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey, buildsDirPath)
-		return generalDetails.Timestamp, nil
+		return generalDetails.Timestamp, err
 	}
 	log.Debug("Saving build general details at: " + partialsBuildDir)
 	meta := buildinfo.General{

--- a/build/service.go
+++ b/build/service.go
@@ -38,39 +38,45 @@ func (bis *BuildInfoService) GetOrCreateBuild(buildName, buildNumber string) (*B
 
 // GetOrCreateBuildWithProject gets a build from cache, or creates a new one if it doesn't exist.
 // It's important to invoke this function at the very beginning of the build, so that the start time property in the build-info will be accurate.
-func (bis *BuildInfoService) GetOrCreateBuildWithProject(buildName, buildNumber, projectKey string) (*Build, error) {
+func (bis *BuildInfoService) GetOrCreateBuildWithProject(buildName, buildNumber, projectKey string) (build *Build, err error) {
+	buildTime := time.Now()
 	if len(buildName) > 0 && len(buildNumber) > 0 {
-		err := saveBuildGeneralDetails(buildName, buildNumber, projectKey, bis.tempDirPath, bis.logger)
-		if err != nil {
-			return nil, err
+		if buildTime, err = getOrCreateBuildGeneralDetails(buildName, buildNumber, buildTime, projectKey, bis.tempDirPath, bis.logger); err != nil {
+			return
 		}
 	}
-	return NewBuild(buildName, buildNumber, projectKey, bis.tempDirPath, bis.logger), nil
+	return NewBuild(buildName, buildNumber, buildTime, projectKey, bis.tempDirPath, bis.logger), nil
 }
 
-func saveBuildGeneralDetails(buildName, buildNumber, projectKey, buildsDirPath string, log utils.Log) error {
+func getOrCreateBuildGeneralDetails(buildName, buildNumber string, buildTime time.Time, projectKey, buildsDirPath string, log utils.Log) (time.Time, error) {
 	partialsBuildDir, err := utils.GetPartialsBuildDir(buildName, buildNumber, projectKey, buildsDirPath)
 	if err != nil {
-		return err
+		return buildTime, err
 	}
-	log.Debug("Saving build general details at: " + partialsBuildDir)
 	detailsFilePath := filepath.Join(partialsBuildDir, BuildInfoDetails)
 	var exists bool
 	exists, err = utils.IsFileExists(detailsFilePath, true)
-	if err != nil || exists {
-		return err
+	if err != nil {
+		return buildTime, err
 	}
+	if exists {
+		log.Debug("Reading build general details from: " + partialsBuildDir)
+		var generalDetails *buildinfo.General
+		generalDetails, err = ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey, buildsDirPath)
+		return generalDetails.Timestamp, nil
+	}
+	log.Debug("Saving build general details at: " + partialsBuildDir)
 	meta := buildinfo.General{
-		Timestamp: time.Now(),
+		Timestamp: buildTime,
 	}
 	b, err := json.Marshal(&meta)
 	if err != nil {
-		return err
+		return buildTime, err
 	}
 	var content bytes.Buffer
 	err = json.Indent(&content, b, "", "  ")
 	if err != nil {
-		return err
+		return buildTime, err
 	}
-	return os.WriteFile(detailsFilePath, content.Bytes(), 0600)
+	return buildTime, os.WriteFile(detailsFilePath, content.Bytes(), 0600)
 }

--- a/buildinfoschema_test.go
+++ b/buildinfoschema_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jfrog/build-info-go/tests"
 	buildutils "github.com/jfrog/build-info-go/build/utils"
+	"github.com/jfrog/build-info-go/tests"
 	"github.com/jfrog/build-info-go/utils"
 
 	"github.com/stretchr/testify/assert"

--- a/utils/dependenciesutils.go
+++ b/utils/dependenciesutils.go
@@ -12,7 +12,7 @@ const (
 	configPropertiesPathTempPrefix = "extractorProperties"
 	buildInfoPathKey               = "buildInfo.generated.build.info"
 	buildNameKey                   = "buildInfo.build.name"
-	buildTimeStampKey              = "buildInfo.build.timestamp"
+	buildTimestampKey              = "buildInfo.build.timestamp"
 	buildNumberKey                 = "buildInfo.build.number"
 	projectKey                     = "buildInfo.build.project"
 )
@@ -67,7 +67,7 @@ func CreateExtractorPropsFile(extractorConfPath, buildInfoPath, buildName, build
 	var buildProperties = map[string]string{
 		buildInfoPathKey:  buildInfoPath,
 		buildNameKey:      buildName,
-		buildTimeStampKey: fmt.Sprintf("%d", buildTimestamp.UnixMilli()),
+		buildTimestampKey: fmt.Sprintf("%d", buildTimestamp.UnixMilli()),
 		buildNumberKey:    buildNumber,
 		projectKey:        project,
 	}

--- a/utils/dependenciesutils.go
+++ b/utils/dependenciesutils.go
@@ -1,15 +1,18 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 )
 
 const (
 	configPropertiesPathTempPrefix = "extractorProperties"
 	buildInfoPathKey               = "buildInfo.generated.build.info"
 	buildNameKey                   = "buildInfo.build.name"
+	buildTimeStampKey              = "buildInfo.build.timestamp"
 	buildNumberKey                 = "buildInfo.build.number"
 	projectKey                     = "buildInfo.build.project"
 )
@@ -47,7 +50,7 @@ func downloadExtractorIfNeeded(downloadTo, filename, downloadPath string, downlo
 // project - JFrog Project key of the current build
 // configProperties - Data of the actual extractor's properties.
 // Returns the extractor Config file path.
-func CreateExtractorPropsFile(extractorConfPath, buildInfoPath, buildName, buildNumber, project string, configProperties map[string]string) (string, error) {
+func CreateExtractorPropsFile(extractorConfPath, buildInfoPath, buildName, buildNumber string, buildTimestamp time.Time, project string, configProperties map[string]string) (string, error) {
 	if err := os.MkdirAll(extractorConfPath, 0777); err != nil {
 		return "", err
 	}
@@ -62,10 +65,11 @@ func CreateExtractorPropsFile(extractorConfPath, buildInfoPath, buildName, build
 		}
 	}()
 	var buildProperties = map[string]string{
-		buildInfoPathKey: buildInfoPath,
-		buildNameKey:     buildName,
-		buildNumberKey:   buildNumber,
-		projectKey:       project,
+		buildInfoPathKey:  buildInfoPath,
+		buildNameKey:      buildName,
+		buildTimeStampKey: fmt.Sprintf("%d", buildTimestamp.UnixMilli()),
+		buildNumberKey:    buildNumber,
+		projectKey:        project,
 	}
 	return propertiesFile.Name(), writeProps(propertiesFile, configProperties, buildProperties)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

At `build-info-extractor` in `ArtifactoryClientConfiguration` (at the `addDefaultPublisherAttributes` method) we sets the timestamp to the buildestarted timestamp if it does not exist:
![image](https://github.com/jfrog/build-info-go/assets/49212512/4c442a06-8257-49e2-b0e9-5f95182adeff)

For Maven and Gradle, when creating properties, we didn't pass a timestamp, so BuildStarted was used.

**If a general timestamp was already defined, it was ignored. This PR addresses this issue and passes the correct values.**

This issue caused the `"undefined/No path found (externally resolved or deleted/overwritten)"` error in the `Repo path` column for Maven and Gradle artifacts with multiple modules:
![image](https://github.com/jfrog/build-info-go/assets/49212512/5d103663-890f-4cd0-a51a-c1551c9c2ca4)

