### PR TITLE
Yarn - Deleting error message & test for a deprecated issue

### DIFF
--- a/build/utils/yarn.go
+++ b/build/utils/yarn.go
@@ -115,12 +115,6 @@ func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInf
 	if err != nil {
 		log.Warn("An error was thrown while collecting dependencies info: " + err.Error() + "\nCommand output:\n" + responseStr)
 
-		// Spacial case: when 'yarn install' wasn't executed on the project we will get an error with non-empty responseStr (for yarn v2 and v3 ONLY)
-		if strings.Contains(responseStr, "present in your lockfile") {
-			err = errors.New("fetching dependencies failed since '" + packageInfo.Name + "' doesn't present in your lockfile\nPlease run 'yarn install' to update lockfile\n" + err.Error())
-			return
-		}
-
 		// A returned error doesn't necessarily mean that the operation totally failed. If, in addition, the response is empty, then it probably failed.
 		if responseStr == "" {
 			return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Error message for uninstalled yarn project in GetYarnDependencies and test for this case have been deleted since in every scenario of reaching this function the yarn project will be already installed