### PR TITLE
Ensure `CreateTempDir()` is Multi-Process Safe

### DIFF
--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -273,7 +273,7 @@ func GetFileContentAndInfo(filePath string) (fileContent []byte, fileInfo os.Fil
 func CreateTempDir() (string, error) {
 	tempDirBase := os.TempDir()
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"-")
+	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"-*")
 }
 
 func RemoveTempDir(dirPath string) error {

--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -273,7 +273,7 @@ func GetFileContentAndInfo(filePath string) (fileContent []byte, fileInfo os.Fil
 func CreateTempDir() (string, error) {
 	tempDirBase := os.TempDir()
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"*")
+	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"-")
 }
 
 func RemoveTempDir(dirPath string) error {

--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -273,7 +273,7 @@ func GetFileContentAndInfo(filePath string) (fileContent []byte, fileInfo os.Fil
 func CreateTempDir() (string, error) {
 	tempDirBase := os.TempDir()
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"-")
+	return os.MkdirTemp(tempDirBase, tempDirPrefix+timestamp+"*")
 }
 
 func RemoveTempDir(dirPath string) error {

--- a/utils/fileutils_test.go
+++ b/utils/fileutils_test.go
@@ -56,17 +56,17 @@ func TestReadNLines(t *testing.T) {
 }
 
 func TestCreateTempDir(t *testing.T) {
-    tempDir, err := CreateTempDir()
-    assert.NoError(t, err)
+	tempDir, err := CreateTempDir()
+	assert.NoError(t, err)
 
-    _, err = os.Stat(tempDir)
+	_, err = os.Stat(tempDir)
 	assert.NotErrorIs(t, err, os.ErrNotExist)
 
 	defer func() {
-	// Check that a timestamp can be extracted from the temp dir name
-	_, err = extractTimestamp(tempDir)
-	assert.NoError(t, err)
+		// Check that a timestamp can be extracted from the temp dir name
+		_, err = extractTimestamp(tempDir)
+		assert.NoError(t, err)
 
-    assert.NoError(t, os.RemoveAll(tempDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
 }

--- a/utils/fileutils_test.go
+++ b/utils/fileutils_test.go
@@ -62,9 +62,11 @@ func TestCreateTempDir(t *testing.T) {
     _, err = os.Stat(tempDir)
 	assert.NotErrorIs(t, err, os.ErrNotExist)
 
+	defer func() {
 	// Check that a timestamp can be extracted from the temp dir name
 	_, err = extractTimestamp(tempDir)
 	assert.NoError(t, err)
 
-	assert.NoError(t, os.RemoveAll(tempDir))
+    assert.NoError(t, os.RemoveAll(tempDir))
+	}()
 }

--- a/utils/fileutils_test.go
+++ b/utils/fileutils_test.go
@@ -54,3 +54,17 @@ func TestReadNLines(t *testing.T) {
 	assert.True(t, strings.HasPrefix(lines[1], "781"))
 	assert.True(t, strings.HasSuffix(lines[1], ":true}}}"))
 }
+
+func TestCreateTempDir(t *testing.T) {
+    tempDir, err := CreateTempDir()
+    assert.NoError(t, err)
+
+    _, err = os.Stat(tempDir)
+	assert.NotErrorIs(t, err, os.ErrNotExist)
+
+	// Check that a timestamp can be extracted from the temp dir name
+	_, err = extractTimestamp(tempDir)
+	assert.NoError(t, err)
+
+	assert.NoError(t, os.RemoveAll(tempDir))
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Refining `CreateTempDir()` by appending a wildcard `*` at the end of the `MkdirTemp()` pattern argument. This ensures that a unique random string replaces the last `*`, preventing concurrent processes or goroutines from selecting the same directory. This approach is preferred over using only `strconv.FormatInt(time.Now().Unix(), 10)`, which may not offer sufficient distinction between processes.