### PR TITLE
fix: same vcs info appened twice when running jf rt build-add-git command twice

### DIFF
--- a/build-info.json
+++ b/build-info.json
@@ -11,23 +11,7 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "id": "github.com/davecgh/go-spew:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
@@ -38,46 +22,17 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/gofrog:v1.7.1",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/stretchr/testify:v1.9.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.7.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "bc08f2022e028af87edc5566e92aba24835aed4b",
-          "md5": "9fb2aa335cdc9e1c2b378910901d5bdd",
-          "sha256": "c425494db98af2ef4f75dd72ef3104dd4a975f6189b9962a1af91c9285f0e464"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         },
         {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
@@ -104,32 +59,69 @@
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
-          "id": "github.com/stretchr/testify:v1.9.0",
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "fc0b37507f793f847c2f40fc42b22978a99ab283",
-          "md5": "070e5af51101aeed36fa6547716c9895",
-          "sha256": "ee5d4f73cb689b1b5432c6908a189f9fbdb172507c49c32dbdf79b239ea9b8e0"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
               "github.com/jfrog/build-info-go"
             ],
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
+          "md5": "9e1040379513ae9a01332c37ad8f0d78",
+          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "bc08f2022e028af87edc5566e92aba24835aed4b",
+          "md5": "9fb2aa335cdc9e1c2b378910901d5bdd",
+          "sha256": "c425494db98af2ef4f75dd72ef3104dd4a975f6189b9962a1af91c9285f0e464"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -160,16 +152,40 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "id": "github.com/stretchr/testify:v1.9.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
-          "md5": "9e1040379513ae9a01332c37ad8f0d78",
-          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
+          "sha1": "fc0b37507f793f847c2f40fc42b22978a99ab283",
+          "md5": "070e5af51101aeed36fa6547716c9895",
+          "sha256": "ee5d4f73cb689b1b5432c6908a189f9fbdb172507c49c32dbdf79b239ea9b8e0"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20240318143956-a85f2c67cd81",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "83867de4064e8a3cb0002cf5a88b5c34357cbe69",
+          "md5": "d4c9339cec979932670c2413e5a23c11",
+          "sha256": "91c8393eee2f7d72a94e3ce25d18db565c55e8a5e2a18ec97f213b1bc58b9561"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
           "id": "github.com/minio/sha256-simd:v1.0.1",
@@ -184,41 +200,20 @@
           "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "id": "golang.org/x/sync:v0.6.0",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/jfrog/gofrog:v1.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
-          "md5": "784986a05b774fc16942ec0978297fed",
-          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+          "sha1": "e94394cd9fb40440d969f1126e9ef23635c99004",
+          "md5": "277faf5e637336f74979296d236d7dd3",
+          "sha256": "7c75175297a3b368b806bd24c7401629df11dcc655e3c14470058282f101ca6a"
         },
         {
           "id": "github.com/!burnt!sushi/toml:v1.3.2",
@@ -237,32 +232,32 @@
           "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
-          "id": "github.com/buger/jsonparser:v1.1.1",
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
+          "md5": "784986a05b774fc16942ec0978297fed",
+          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/minio/sha256-simd:v1.0.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -290,35 +285,23 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "golang.org/x/sync:v0.6.0",
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/jfrog/gofrog:v1.7.1",
+              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e94394cd9fb40440d969f1126e9ef23635c99004",
-          "md5": "277faf5e637336f74979296d236d7dd3",
-          "sha256": "7c75175297a3b368b806bd24c7401629df11dcc655e3c14470058282f101ca6a"
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "golang.org/x/exp:v0.0.0-20240318143956-a85f2c67cd81",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "83867de4064e8a3cb0002cf5a88b5c34357cbe69",
-          "md5": "d4c9339cec979932670c2413e5a23c11",
-          "sha256": "91c8393eee2f7d72a94e3ce25d18db565c55e8a5e2a18ec97f213b1bc58b9561"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
             [
@@ -329,20 +312,37 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.7.1",
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/stretchr/testify:v1.9.0",
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         }
       ]
     }
   ],
-  "started": "2024-04-15T13:10:43.420+0000"
+  "started": "2024-05-22T12:54:57.023+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,30 +11,6 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
           "type": "zip",
           "requestedBy": [
@@ -60,178 +36,6 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230817173708-d852ddb80c63",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ea6c0bc78e3934600f91a62711adaf49bce9ae4c",
-          "md5": "93228bd52e8ed7350227d11f4d72919c",
-          "sha256": "ea94dfbce3a89f62bacebf5015a26c56d392116d2967395a5769c8801da1556b"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
-          "md5": "9528e04062f189c6e53af39e91f487de",
-          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
@@ -248,15 +52,36 @@
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
           "id": "gopkg.in/yaml.v3:v3.0.1",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
               "github.com/jfrog/build-info-go"
             ],
             [
               "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -276,22 +101,43 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "id": "github.com/jfrog/gofrog:v1.3.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         },
         {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
             [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -302,9 +148,204 @@
           "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
           "md5": "1355152ef669012354342f3f0a133987",
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         }
       ]
     }
   ],
-  "started": "2023-08-28T14:43:51.883+0000"
+  "started": "2023-09-10T19:04:45.742+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,155 +11,35 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
-          "md5": "9e1040379513ae9a01332c37ad8f0d78",
-          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.6.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "475aca72f99661c31520655c457b831216298b5b",
-          "md5": "e9e6b1f73d09996a634c426281256e13",
-          "sha256": "685ce4c7f7b3a2f9f069379cb655368050bb42549ea33873a89cecb223c2e86b"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
               "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "id": "github.com/jfrog/gofrog:v1.6.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
-          "md5": "784986a05b774fc16942ec0978297fed",
-          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
+          "sha1": "7731dd85a4d411705b2d0e1657c12ed5ed6da638",
+          "md5": "8377c41d4191d8f0061dfed980e55485",
+          "sha256": "340dda3c41a2fdcdc1b5c55ba780fecc93ceace92916f5a624d83d5667a32df4"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
             [
@@ -168,41 +48,23 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
-          "md5": "aa5736fbce71f5445909d34800459416",
-          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -213,7 +75,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/gofrog:v1.6.3",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -223,7 +85,7 @@
             ],
             [
               "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/gofrog:v1.6.3",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -243,6 +105,46 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
+          "md5": "784986a05b774fc16942ec0978297fed",
+          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
+          "md5": "aa5736fbce71f5445909d34800459416",
+          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
           "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
@@ -257,18 +159,6 @@
           "sha1": "6429461f86edd94bb679272748c522f41f6453df",
           "md5": "1bbcae037201b315dccd6e535b20bca0",
           "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
@@ -296,36 +186,16 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "id": "github.com/urfave/cli/v2:v2.27.1",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
+          "md5": "9e1040379513ae9a01332c37ad8f0d78",
+          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
         },
         {
           "id": "github.com/stretchr/testify:v1.8.4",
@@ -336,7 +206,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/gofrog:v1.6.3",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -348,7 +218,66 @@
           "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
@@ -359,12 +288,83 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         }
       ]
     }
   ],
-  "started": "2024-02-21T12:26:15.116+0000"
+  "started": "2024-03-18T14:10:15.587+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,207 +11,6 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
           "id": "github.com/jfrog/gofrog:v1.3.2",
           "type": "zip",
           "requestedBy": [
@@ -222,22 +21,6 @@
           "sha1": "49a17f3a8854d8525850d815e1a64faa63152730",
           "md5": "0ff3a677c3460bfb18aa6bb1cfd3b5a8",
           "sha256": "78e3e91549761f2b04cdba6c20f98aaad1962526c1b2e7bd199d0a36187f3fe0"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -273,22 +56,72 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -296,25 +129,21 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "id": "github.com/urfave/cli/v2:v2.25.7",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         },
         {
           "id": "github.com/stretchr/testify:v1.8.4",
@@ -333,6 +162,38 @@
           "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         },
         {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
           "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
           "type": "zip",
           "requestedBy": [
@@ -343,9 +204,148 @@
           "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
           "md5": "a351a01d700150d778eeae97bd6859d0",
           "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         }
       ]
     }
   ],
-  "started": "2023-11-30T13:54:42.777+0000"
+  "started": "2023-12-14T16:56:35.308+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -23,50 +23,6 @@
           "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
           "type": "zip",
           "requestedBy": [
@@ -90,6 +46,163 @@
           "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
           "md5": "812aaf45e505b2953d31a75ce668e46e",
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.6.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "475aca72f99661c31520655c457b831216298b5b",
+          "md5": "e9e6b1f73d09996a634c426281256e13",
+          "sha256": "685ce4c7f7b3a2f9f069379cb655368050bb42549ea33873a89cecb223c2e86b"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
+          "md5": "784986a05b774fc16942ec0978297fed",
+          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
+          "md5": "aa5736fbce71f5445909d34800459416",
+          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -130,56 +243,32 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/minio/sha256-simd:v1.0.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
@@ -207,43 +296,7 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
-          "md5": "784986a05b774fc16942ec0978297fed",
-          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
-          "md5": "aa5736fbce71f5445909d34800459416",
-          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
             [
@@ -252,90 +305,53 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.6.0",
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "475aca72f99661c31520655c457b831216298b5b",
-          "md5": "e9e6b1f73d09996a634c426281256e13",
-          "sha256": "685ce4c7f7b3a2f9f069379cb655368050bb42549ea33873a89cecb223c2e86b"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
               "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -343,28 +359,12 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         }
       ]
     }
   ],
-  "started": "2024-02-20T09:00:01.555+0000"
+  "started": "2024-02-21T12:26:15.116+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,22 +11,6 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
           "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
@@ -51,62 +35,6 @@
           "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         },
         {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
           "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
@@ -121,6 +49,30 @@
           "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
           "md5": "86a066c9aaad807da54f481b8286f8ce",
           "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.4.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0461da8f5992650adfed08958b6128ccf762ad19",
+          "md5": "b99ca543f9b6f8978e9e7013c5154493",
+          "sha256": "2d527597437427ca2b1ca1da5d29123cfaf0b64a916565647b788f7ee7ded5ab"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -148,7 +100,32 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
@@ -156,10 +133,10 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.4.0",
               "github.com/jfrog/build-info-go"
             ],
             [
+              "github.com/jfrog/gofrog:v1.4.1",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -172,9 +149,41 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
@@ -193,40 +202,19 @@
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.4.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
             [
@@ -235,36 +223,11 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.4.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
@@ -292,7 +255,69 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.4.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.4.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
           "type": "zip",
           "requestedBy": [
             [
@@ -303,49 +328,24 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.4.0",
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "fd21ca315e4d57461f7e243da2653e0580fbd961",
-          "md5": "4c5f91a7d3e18de7d2a29d3b1f99c4e2",
-          "sha256": "770cec378ae0a252126f763a629d2cfd29b7aaee2aa62ad2935b36ec97de50f8"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         }
       ]
     }
   ],
-  "started": "2023-12-27T07:46:46.793+0000"
+  "started": "2024-01-07T11:48:00.759+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,178 +11,16 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.1",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
-          "md5": "761f115010a0fc45c0950edacdec8e35",
-          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
-        },
-        {
-          "id": "github.com/pkg/errors:v0.9.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
-          "md5": "5d8002959a144c1bea1f86228fe09755",
-          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
-          "md5": "9528e04062f189c6e53af39e91f487de",
-          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
-          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
-          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
-          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
-          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
           "id": "github.com/jfrog/gofrog:v1.3.0",
@@ -197,51 +35,6 @@
           "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
         },
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
           "type": "zip",
           "requestedBy": [
@@ -254,11 +47,11 @@
             ],
             [
               "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ]
           ],
@@ -267,16 +60,32 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230817173708-d852ddb80c63",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
-          "md5": "ba5fd44152526428564448abdd71c467",
-          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
+          "sha1": "ea6c0bc78e3934600f91a62711adaf49bce9ae4c",
+          "md5": "93228bd52e8ed7350227d11f4d72919c",
+          "sha256": "ea94dfbce3a89f62bacebf5015a26c56d392116d2967395a5769c8801da1556b"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -295,11 +104,139 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
+          "md5": "9528e04062f189c6e53af39e91f487de",
+          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -311,35 +248,63 @@
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.2.1",
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "03b80e70043e52b2f3599d056ab4eb6620e2bb62",
-          "md5": "41001e8e47b9b3ec81f9f7790d585da0",
-          "sha256": "6fb658e8262179ffd34d57eaef6b076b25c77e8b2129659b66697cded29a7121"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         }
       ]
     }
   ],
-  "started": "2023-05-21T14:08:25.458+0000"
+  "started": "2023-08-28T14:43:51.883+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,212 +11,6 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
-          "md5": "761f115010a0fc45c0950edacdec8e35",
-          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
-          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
-          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
-          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
-          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
-        },
-        {
-          "id": "github.com/pkg/errors:v0.9.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
-          "md5": "5d8002959a144c1bea1f86228fe09755",
-          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
-          "md5": "9528e04062f189c6e53af39e91f487de",
-          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
           "type": "zip",
           "requestedBy": [
@@ -262,30 +56,6 @@
           "sha256": "6fb658e8262179ffd34d57eaef6b076b25c77e8b2129659b66697cded29a7121"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
-          "md5": "ba5fd44152526428564448abdd71c467",
-          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
-        },
-        {
           "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
@@ -296,6 +66,108 @@
           "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
           "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
           "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
+          "md5": "9528e04062f189c6e53af39e91f487de",
+          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
+          "md5": "761f115010a0fc45c0950edacdec8e35",
+          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -323,6 +195,50 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
+          "id": "github.com/stretchr/testify:v1.8.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
+          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
+          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
@@ -337,9 +253,93 @@
           "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
           "md5": "b5a17afb05c11c10713e33e390729bd7",
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/pkg/errors:v0.9.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
+          "md5": "5d8002959a144c1bea1f86228fe09755",
+          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
+          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
+          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
+          "md5": "ba5fd44152526428564448abdd71c467",
+          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
         }
       ]
     }
   ],
-  "started": "2023-05-02T13:39:07.599+0000"
+  "started": "2023-05-17T15:43:45.796+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -1,0 +1,345 @@
+{
+  "name": "go-build",
+  "number": "1",
+  "agent": {},
+  "buildAgent": {
+    "name": "GENERIC"
+  },
+  "modules": [
+    {
+      "type": "go",
+      "id": "github.com/jfrog/build-info-go",
+      "dependencies": [
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
+          "md5": "761f115010a0fc45c0950edacdec8e35",
+          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
+          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
+          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
+          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
+          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
+        },
+        {
+          "id": "github.com/pkg/errors:v0.9.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
+          "md5": "5d8002959a144c1bea1f86228fe09755",
+          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
+          "md5": "9528e04062f189c6e53af39e91f487de",
+          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.2.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "03b80e70043e52b2f3599d056ab4eb6620e2bb62",
+          "md5": "41001e8e47b9b3ec81f9f7790d585da0",
+          "sha256": "6fb658e8262179ffd34d57eaef6b076b25c77e8b2129659b66697cded29a7121"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
+          "md5": "ba5fd44152526428564448abdd71c467",
+          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        }
+      ]
+    }
+  ],
+  "started": "2023-05-02T13:39:07.599+0000"
+}

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,34 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
           "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
           "type": "zip",
           "requestedBy": [
@@ -23,45 +51,118 @@
           "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         },
         {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/stretchr/testify:v1.8.4",
           "type": "zip",
           "requestedBy": [
             [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
               "github.com/jfrog/build-info-go"
             ],
             [
               "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/urfave/cli/v2:v2.25.7",
@@ -101,6 +202,63 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
@@ -126,18 +284,6 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
@@ -152,140 +298,6 @@
           "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
           "md5": "ebbf84ea1a07065b100c33e2736e6d03",
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
           "id": "github.com/davecgh/go-spew:v1.1.1",
@@ -317,35 +329,23 @@
           "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
               "github.com/jfrog/build-info-go"
             ],
             [
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         }
       ]
     }
   ],
-  "started": "2023-10-03T12:59:26.706+0000"
+  "started": "2023-10-17T06:12:42.798+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -27,16 +27,20 @@
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.6.3",
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "7731dd85a4d411705b2d0e1657c12ed5ed6da638",
-          "md5": "8377c41d4191d8f0061dfed980e55485",
-          "sha256": "340dda3c41a2fdcdc1b5c55ba780fecc93ceace92916f5a624d83d5667a32df4"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
@@ -55,56 +59,6 @@
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
-        },
-        {
           "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
           "type": "zip",
           "requestedBy": [
@@ -117,214 +71,40 @@
           "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
         },
         {
-          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
+          "id": "github.com/jfrog/gofrog:v1.6.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
-          "md5": "aa5736fbce71f5445909d34800459416",
-          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
+          "sha1": "7731dd85a4d411705b2d0e1657c12ed5ed6da638",
+          "md5": "8377c41d4191d8f0061dfed980e55485",
+          "sha256": "340dda3c41a2fdcdc1b5c55ba780fecc93ceace92916f5a624d83d5667a32df4"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/stretchr/testify:v1.9.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "fc0b37507f793f847c2f40fc42b22978a99ab283",
+          "md5": "070e5af51101aeed36fa6547716c9895",
+          "sha256": "ee5d4f73cb689b1b5432c6908a189f9fbdb172507c49c32dbdf79b239ea9b8e0"
         },
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
-          "md5": "9e1040379513ae9a01332c37ad8f0d78",
-          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -352,6 +132,87 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.9.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
+          "md5": "9e1040379513ae9a01332c37ad8f0d78",
+          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
           "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
@@ -362,9 +223,110 @@
           "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
           "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
           "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.9.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20240318143956-a85f2c67cd81",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "83867de4064e8a3cb0002cf5a88b5c34357cbe69",
+          "md5": "d4c9339cec979932670c2413e5a23c11",
+          "sha256": "91c8393eee2f7d72a94e3ce25d18db565c55e8a5e2a18ec97f213b1bc58b9561"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.9.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         }
       ]
     }
   ],
-  "started": "2024-03-18T14:10:15.587+0000"
+  "started": "2024-03-27T14:34:33.096+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,22 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
@@ -36,20 +52,16 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
@@ -60,7 +72,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/gofrog:v1.3.1",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -81,19 +93,32 @@
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
-          "id": "github.com/buger/jsonparser:v1.1.1",
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
             [
@@ -102,24 +127,11 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -147,40 +159,20 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -191,7 +183,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/gofrog:v1.3.1",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -232,45 +224,28 @@
           "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/stretchr/testify:v1.8.4",
@@ -289,44 +264,40 @@
           "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "id": "github.com/jfrog/gofrog:v1.3.1",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+          "sha1": "5f23415aaf23b7e919a6788491c2a2a27de3cb45",
+          "md5": "c04c8acb7f2ab48a286e7a51172ff6cf",
+          "sha256": "d1b9e8e7d447d91c84bf93e3fd72f79e8ef74f63319eaf61d4720bc2acb688f7"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "id": "github.com/urfave/cli/v2:v2.25.7",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         },
         {
           "id": "github.com/klauspost/cpuid/v2:v2.2.3",
@@ -343,9 +314,38 @@
           "sha1": "6429461f86edd94bb679272748c522f41f6453df",
           "md5": "1bbcae037201b315dccd6e535b20bca0",
           "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         }
       ]
     }
   ],
-  "started": "2023-10-22T13:22:45.316+0000"
+  "started": "2023-11-08T07:45:14.137+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,16 +11,186 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/jfrog/gofrog:v1.3.2",
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "49a17f3a8854d8525850d815e1a64faa63152730",
-          "md5": "0ff3a677c3460bfb18aa6bb1cfd3b5a8",
-          "sha256": "78e3e91549761f2b04cdba6c20f98aaad1962526c1b2e7bd199d0a36187f3fe0"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.4.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -31,7 +201,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.2",
+              "github.com/jfrog/gofrog:v1.4.0",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -67,7 +237,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.2",
+              "github.com/jfrog/gofrog:v1.4.0",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -85,115 +255,6 @@
           "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
           "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
           "type": "zip",
           "requestedBy": [
@@ -204,47 +265,6 @@
           "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
           "md5": "a351a01d700150d778eeae97bd6859d0",
           "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
           "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
@@ -272,38 +292,6 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
@@ -320,32 +308,44 @@
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "id": "github.com/jfrog/gofrog:v1.4.0",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+          "sha1": "fd21ca315e4d57461f7e243da2653e0580fbd961",
+          "md5": "4c5f91a7d3e18de7d2a29d3b1f99c4e2",
+          "sha256": "770cec378ae0a252126f763a629d2cfd29b7aaee2aa62ad2935b36ec97de50f8"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         }
       ]
     }
   ],
-  "started": "2023-12-14T16:56:35.308+0000"
+  "started": "2023-12-27T07:46:46.793+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,47 +11,6 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
           "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
           "type": "zip",
           "requestedBy": [
@@ -64,6 +23,30 @@
           "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+        },
+        {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
           "type": "zip",
           "requestedBy": [
@@ -72,7 +55,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.1",
+              "github.com/jfrog/gofrog:v1.3.2",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -91,6 +74,22 @@
           "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
           "md5": "fb72df530a7f3fca56ccc192c9f30a58",
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -118,7 +117,7 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
             [
@@ -127,11 +126,65 @@
             ],
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -159,20 +212,32 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "id": "github.com/jfrog/gofrog:v1.3.2",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "49a17f3a8854d8525850d815e1a64faa63152730",
+          "md5": "0ff3a677c3460bfb18aa6bb1cfd3b5a8",
+          "sha256": "78e3e91549761f2b04cdba6c20f98aaad1962526c1b2e7bd199d0a36187f3fe0"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -183,7 +248,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.3.1",
+              "github.com/jfrog/gofrog:v1.3.2",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -208,6 +273,18 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
           "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
@@ -222,82 +299,6 @@
           "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
           "md5": "86a066c9aaad807da54f481b8286f8ce",
           "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "5f23415aaf23b7e919a6788491c2a2a27de3cb45",
-          "md5": "c04c8acb7f2ab48a286e7a51172ff6cf",
-          "sha256": "d1b9e8e7d447d91c84bf93e3fd72f79e8ef74f63319eaf61d4720bc2acb688f7"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         },
         {
           "id": "github.com/klauspost/cpuid/v2:v2.2.3",
@@ -316,7 +317,7 @@
           "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/stretchr/testify:v1.8.4",
           "type": "zip",
           "requestedBy": [
             [
@@ -325,27 +326,26 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
+          "type": "zip",
+          "requestedBy": [
             [
-              "github.com/jfrog/gofrog:v1.3.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         }
       ]
     }
   ],
-  "started": "2023-11-08T07:45:14.137+0000"
+  "started": "2023-11-30T13:54:42.777+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,59 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
+        },
+        {
+          "id": "github.com/russross/blackfriday/v2:v2.1.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
+          "md5": "eea4411c54002a5fb7d0db351270eefe",
+          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
           "id": "github.com/urfave/cli/v2:v2.25.7",
           "type": "zip",
           "requestedBy": [
@@ -73,6 +126,18 @@
           "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
           "type": "zip",
           "requestedBy": [
@@ -89,32 +154,16 @@
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
           "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
@@ -133,59 +182,6 @@
           "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/russross/blackfriday/v2:v2.1.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
-          "md5": "eea4411c54002a5fb7d0db351270eefe",
-          "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
           "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
@@ -200,87 +196,6 @@
           "sha1": "6429461f86edd94bb679272748c522f41f6453df",
           "md5": "1bbcae037201b315dccd6e535b20bca0",
           "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
@@ -310,6 +225,34 @@
           "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
           "md5": "fb72df530a7f3fca56ccc192c9f30a58",
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -343,9 +286,66 @@
           "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
           "md5": "292e318d64256fb05395c45c176c94c2",
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         }
       ]
     }
   ],
-  "started": "2023-10-02T14:15:03.391+0000"
+  "started": "2023-10-03T12:59:26.706+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,31 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
@@ -25,58 +50,6 @@
           "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
           "md5": "b5a17afb05c11c10713e33e390729bd7",
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
         },
         {
           "id": "github.com/pmezard/go-difflib:v1.0.0",
@@ -106,6 +79,108 @@
           "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
           "md5": "fb72df530a7f3fca56ccc192c9f30a58",
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -141,68 +216,7 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
@@ -213,9 +227,9 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -243,23 +257,23 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "id": "github.com/stretchr/testify:v1.8.4",
           "type": "zip",
           "requestedBy": [
             [
@@ -268,20 +282,23 @@
             ],
             [
               "github.com/jfrog/build-info-go"
-            ],
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
             [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
         },
         {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
@@ -300,52 +317,35 @@
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/minio/sha256-simd:v1.0.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         }
       ]
     }
   ],
-  "started": "2023-10-17T06:12:42.798+0000"
+  "started": "2023-10-22T13:22:45.316+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,50 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "github.com/urfave/cli/v2:v2.27.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c437cebc0750758eaab4906811916035efaf46bf",
+          "md5": "9e1040379513ae9a01332c37ad8f0d78",
+          "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
           "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
@@ -23,16 +67,83 @@
           "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         },
         {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "gopkg.in/yaml.v3:v3.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
+          "md5": "292e318d64256fb05395c45c176c94c2",
+          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
         },
         {
           "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
@@ -42,13 +153,58 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
           "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
           "md5": "86a066c9aaad807da54f481b8286f8ce",
           "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
         },
         {
           "id": "github.com/minio/sha256-simd:v1.0.1",
@@ -63,41 +219,108 @@
           "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.4.1",
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0461da8f5992650adfed08958b6128ccf762ad19",
-          "md5": "b99ca543f9b6f8978e9e7013c5154493",
-          "sha256": "2d527597437427ca2b1ca1da5d29123cfaf0b64a916565647b788f7ee7ded5ab"
+          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
+          "md5": "784986a05b774fc16942ec0978297fed",
+          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
         },
         {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "id": "golang.org/x/exp:v0.0.0-20240213143201-ec583247a57a",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+          "sha1": "109d12b447281267eb4a33182b7b337f1c2e7a87",
+          "md5": "aa5736fbce71f5445909d34800459416",
+          "sha256": "8ccaa530254f149d4fa0d7f44dee83f8b12eef2067ae22b5b2cb9527ab0da7e9"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.6.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "475aca72f99661c31520655c457b831216298b5b",
+          "md5": "e9e6b1f73d09996a634c426281256e13",
+          "sha256": "685ce4c7f7b3a2f9f069379cb655368050bb42549ea33873a89cecb223c2e86b"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/gofrog:v1.6.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -112,46 +335,17 @@
             ],
             [
               "github.com/cpuguy83/go-md2man/v2:v2.0.2",
-              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
           "sha1": "b733cda2c795193ad2a65e13dcd7529b93bf04e9",
           "md5": "eea4411c54002a5fb7d0db351270eefe",
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.4.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         },
         {
           "id": "github.com/klauspost/cpuid/v2:v2.2.3",
@@ -168,184 +362,9 @@
           "sha1": "6429461f86edd94bb679272748c522f41f6453df",
           "md5": "1bbcae037201b315dccd6e535b20bca0",
           "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "gopkg.in/yaml.v3:v3.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.4.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
-          "md5": "292e318d64256fb05395c45c176c94c2",
-          "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.4.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
         }
       ]
     }
   ],
-  "started": "2024-01-07T11:48:00.759+0000"
+  "started": "2024-02-20T09:00:01.555+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,6 +11,156 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
+          "id": "github.com/urfave/cli/v2:v2.25.7",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
+          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
+          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
+        },
+        {
+          "id": "github.com/stretchr/testify:v1.8.4",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
+          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
+          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
+          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
+          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+        },
+        {
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.25.7",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
           "type": "zip",
           "requestedBy": [
@@ -36,23 +186,64 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/urfave/cli/v2:v2.25.7",
               "github.com/jfrog/build-info-go"
             ],
             [
+              "github.com/minio/sha256-simd:v1.0.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
           "type": "zip",
           "requestedBy": [
             [
@@ -63,9 +254,62 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
+          "md5": "a351a01d700150d778eeae97bd6859d0",
+          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
+        },
+        {
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.4",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -99,253 +343,9 @@
           "sha1": "65825246447882d6f2bddb3f89ac4b9abc2612ef",
           "md5": "292e318d64256fb05395c45c176c94c2",
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230905200255-921286631fa9",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "34532361e43d59695caabf5248d0464aae3561b9",
-          "md5": "a351a01d700150d778eeae97bd6859d0",
-          "sha256": "e789921a203695edf0d1bffc98b0f76b5f9a264c2f88ef084a2ea9a768081f85"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "ca3fae95bf1b898f1dff98f4ea7c2de175f4d4ff",
-          "md5": "e6c907f90de64339ee4d4222a3de7f1a",
-          "sha256": "0ec9a7c538af92e884d7caed88c62890d5eaadc3d0bb0e2e0e0d7c5d0cb5fdbb"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
-        },
-        {
-          "id": "github.com/stretchr/testify:v1.8.4",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "874d98aac38304b0ac3e046475fb39f11219d5c0",
-          "md5": "7bbb2058ef66c6829ebd3b652aff5296",
-          "sha256": "e206daaede0bd03de060bdfbeb984ac2c49b83058753fffc93fe0c220ea87532"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.2",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.4",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/buger/jsonparser:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.25.7",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
-        },
-        {
-          "id": "github.com/urfave/cli/v2:v2.25.7",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c93f96a6feceef906da4bdb4d337ad5fa9e5048d",
-          "md5": "b5bbdbfb52f8f83b451200a216b6d504",
-          "sha256": "10941b24689d7c953a78b6d196a03e04274e012d27d4f297fe844cf58221a86c"
         }
       ]
     }
   ],
-  "started": "2023-09-10T19:04:45.742+0000"
+  "started": "2023-10-02T14:15:03.391+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -11,36 +11,57 @@
       "id": "github.com/jfrog/build-info-go",
       "dependencies": [
         {
-          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ],
             [
+              "github.com/minio/sha256-simd:v1.0.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
-          "md5": "b5a17afb05c11c10713e33e390729bd7",
-          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
         },
         {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "bc08f2022e028af87edc5566e92aba24835aed4b",
+          "md5": "9fb2aa335cdc9e1c2b378910901d5bdd",
+          "sha256": "c425494db98af2ef4f75dd72ef3104dd4a975f6189b9962a1af91c9285f0e464"
         },
         {
           "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
@@ -59,28 +80,28 @@
           "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "id": "github.com/pmezard/go-difflib:v1.0.0",
           "type": "zip",
           "requestedBy": [
             [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
               "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
-          "md5": "784986a05b774fc16942ec0978297fed",
-          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
-        },
-        {
-          "id": "github.com/jfrog/gofrog:v1.6.3",
-          "type": "zip",
-          "requestedBy": [
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.9.0",
+              "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "7731dd85a4d411705b2d0e1657c12ed5ed6da638",
-          "md5": "8377c41d4191d8f0061dfed980e55485",
-          "sha256": "340dda3c41a2fdcdc1b5c55ba780fecc93ceace92916f5a624d83d5667a32df4"
+          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
+          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
+          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
           "id": "github.com/stretchr/testify:v1.9.0",
@@ -95,41 +116,20 @@
           "sha256": "ee5d4f73cb689b1b5432c6908a189f9fbdb172507c49c32dbdf79b239ea9b8e0"
         },
         {
-          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
-          "md5": "89452597fdd0efbda45051a98284f8cd",
-          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
-          "md5": "812aaf45e505b2953d31a75ce668e46e",
-          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+          "sha1": "79a771d85bf5b4df5b583c8435343b323f52995e",
+          "md5": "b5a17afb05c11c10713e33e390729bd7",
+          "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -140,7 +140,7 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.6.3",
+              "github.com/jfrog/gofrog:v1.7.1",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -172,20 +172,97 @@
           "sha256": "52d60db880c758bdfd6b5fb67a7063b53dc08f3a63802ea1c4e290ae408f11b3"
         },
         {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
+          "id": "github.com/minio/sha256-simd:v1.0.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c6b381b6f945ddea88df93edebf185f29c7fc477",
+          "md5": "89452597fdd0efbda45051a98284f8cd",
+          "sha256": "e8805d8f0438b7fa0286c0cb160180ad8fc726e06bca1eabcd59c142523c625c"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.8.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "295993006bfe6085a808c5ed9c8e210a6790217b",
+          "md5": "784986a05b774fc16942ec0978297fed",
+          "sha256": "32f507e078e7093518db8933dd0b4ba83a6eae30aa7bf731f1a019165c88f74b"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "c00ffab826fdd7e3aa1284ed3a0918cbdf2ec095",
+          "md5": "812aaf45e505b2953d31a75ce668e46e",
+          "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
+        },
+        {
+          "id": "github.com/!burnt!sushi/toml:v1.3.2",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/minio/sha256-simd:v1.0.1",
+              "github.com/urfave/cli/v2:v2.27.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
+          "md5": "e06df9631c9e1897912dfa92a40b4928",
+          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+        },
+        {
+          "id": "github.com/buger/jsonparser:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/urfave/cli/v2:v2.27.1",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -213,81 +290,20 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/buger/jsonparser:v1.1.1",
+          "id": "golang.org/x/sync:v0.6.0",
           "type": "zip",
           "requestedBy": [
+            [
+              "github.com/jfrog/gofrog:v1.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
-        },
-        {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.8.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.6.3",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.9.0",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
-        },
-        {
-          "id": "github.com/!burnt!sushi/toml:v1.3.2",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/urfave/cli/v2:v2.27.1",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "a0fc876bb92fdbe9ad75c300588f2c63e954985c",
-          "md5": "e06df9631c9e1897912dfa92a40b4928",
-          "sha256": "5de246a0cb4c256f3fd5d0db8a08a114f58af0c2e193bbf0ad9012104adbb6b2"
+          "sha1": "e94394cd9fb40440d969f1126e9ef23635c99004",
+          "md5": "277faf5e637336f74979296d236d7dd3",
+          "sha256": "7c75175297a3b368b806bd24c7401629df11dcc655e3c14470058282f101ca6a"
         },
         {
           "id": "golang.org/x/exp:v0.0.0-20240318143956-a85f2c67cd81",
@@ -302,7 +318,7 @@
           "sha256": "91c8393eee2f7d72a94e3ce25d18db565c55e8a5e2a18ec97f213b1bc58b9561"
         },
         {
-          "id": "github.com/pmezard/go-difflib:v1.0.0",
+          "id": "github.com/davecgh/go-spew:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
@@ -310,10 +326,10 @@
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/gofrog:v1.6.3",
               "github.com/jfrog/build-info-go"
             ],
             [
+              "github.com/jfrog/gofrog:v1.7.1",
               "github.com/jfrog/build-info-go"
             ],
             [
@@ -321,12 +337,12 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "f200e2a5211b527ef2d2ff301718ccc4ad5c705b",
-          "md5": "fb72df530a7f3fca56ccc192c9f30a58",
-          "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         }
       ]
     }
   ],
-  "started": "2024-03-27T14:34:33.096+0000"
+  "started": "2024-04-15T13:10:43.420+0000"
 }

--- a/build-info.json
+++ b/build-info.json
@@ -40,7 +40,47 @@
           "sha256": "de04cecc1a4b8d53e4357051026794bcbc54f2e6a260cfac508ce69d5d6457a0"
         },
         {
-          "id": "github.com/!burnt!sushi/toml:v1.2.1",
+          "id": "github.com/urfave/cli/v2:v2.25.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
+          "md5": "761f115010a0fc45c0950edacdec8e35",
+          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
+        },
+        {
+          "id": "github.com/pkg/errors:v0.9.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
+          "md5": "5d8002959a144c1bea1f86228fe09755",
+          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
+        },
+        {
+          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
+          "md5": "9528e04062f189c6e53af39e91f487de",
+          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
+        },
+        {
+          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
           "type": "zip",
           "requestedBy": [
             [
@@ -51,50 +91,49 @@
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "03b80e70043e52b2f3599d056ab4eb6620e2bb62",
-          "md5": "41001e8e47b9b3ec81f9f7790d585da0",
-          "sha256": "6fb658e8262179ffd34d57eaef6b076b25c77e8b2129659b66697cded29a7121"
+          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
+          "md5": "86a066c9aaad807da54f481b8286f8ce",
+          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
         },
         {
-          "id": "github.com/buger/jsonparser:v1.1.1",
+          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
-          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
-          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
+          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
+          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
+          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
         },
         {
-          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
           "type": "zip",
           "requestedBy": [
             [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/stretchr/testify:v1.8.2",
+              "github.com/xeipuuv/gojsonschema:v1.2.0",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
-          "md5": "feef6644bd69286382139b28be3f0b91",
-          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
+          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
+          "md5": "1355152ef669012354342f3f0a133987",
+          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+        },
+        {
+          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
+          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
+          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
         },
         {
           "id": "gopkg.in/yaml.v3:v3.0.1",
@@ -130,44 +169,77 @@
           "sha256": "aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015"
         },
         {
-          "id": "github.com/!cyclone!d!x/cyclonedx-go:v0.7.1",
+          "id": "github.com/stretchr/testify:v1.8.2",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
+          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
+          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
+        },
+        {
+          "id": "github.com/jfrog/gofrog:v1.3.0",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "5f8aecf69069b522e1dd066a4db85a0124f579e7",
-          "md5": "9528e04062f189c6e53af39e91f487de",
-          "sha256": "f83d84c60b300bba77eb2e853989c50c7abf98c59620fb5a0b6e31da07776805"
+          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
+          "md5": "5d9e342169edaebb03848c040018ed37",
+          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
         },
         {
-          "id": "github.com/urfave/cli/v2:v2.25.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "1a92db5e29bdd82bad97d48b8345af27c06fce8b",
-          "md5": "761f115010a0fc45c0950edacdec8e35",
-          "sha256": "779fdd63dc246087efbddb0aed29351b5764226ba75181cbfc56e916aa8729b1"
-        },
-        {
-          "id": "github.com/cpuguy83/go-md2man/v2:v2.0.2",
+          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/urfave/cli/v2:v2.25.1",
+              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "cab8c09415bb3aa49892aac866a2732980d44c95",
-          "md5": "86a066c9aaad807da54f481b8286f8ce",
-          "sha256": "70a7e609809cf2a92c5535104db5eb82d75c54bfcfed2d224e87dd2fd9729f62"
+          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
+          "md5": "1bbcae037201b315dccd6e535b20bca0",
+          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
+        },
+        {
+          "id": "github.com/davecgh/go-spew:v1.1.1",
+          "type": "zip",
+          "requestedBy": [
+            [
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/jfrog/gofrog:v1.3.0",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
+              "github.com/jfrog/build-info-go"
+            ],
+            [
+              "github.com/stretchr/testify:v1.8.2",
+              "github.com/jfrog/build-info-go"
+            ]
+          ],
+          "sha1": "0f9760bda0c6ccacac5e57f62d0f5ad9c7dab03f",
+          "md5": "feef6644bd69286382139b28be3f0b91",
+          "sha256": "6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d"
         },
         {
           "id": "github.com/russross/blackfriday/v2:v2.1.0",
@@ -195,20 +267,16 @@
           "sha256": "7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae"
         },
         {
-          "id": "github.com/stretchr/testify:v1.8.2",
+          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
           "type": "zip",
           "requestedBy": [
-            [
-              "github.com/CycloneDX/cyclonedx-go:v0.7.1",
-              "github.com/jfrog/build-info-go"
-            ],
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "1321bb535d2d6b92bbaf804fa8abcc9fe34234fc",
-          "md5": "5fd93697a6df28ed6704b74bfc9b10e9",
-          "sha256": "400e18c88e5c4beb7ecca5d675048f1915a6e675b30fc03f8f563eb4dfde079a"
+          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
+          "md5": "ba5fd44152526428564448abdd71c467",
+          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
         },
         {
           "id": "github.com/xeipuuv/gojsonpointer:v0.0.0-20180127040702-4e3ac2762d5f",
@@ -227,18 +295,6 @@
           "sha256": "5b1a4bcc8e003f214c92b3fa52959d9eb0e3af1c0c529efa55815db951146e48"
         },
         {
-          "id": "github.com/jfrog/gofrog:v1.3.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "3573718594f8e6adc6cf8b6dbb47d3f0303a8ca6",
-          "md5": "5d9e342169edaebb03848c040018ed37",
-          "sha256": "142a4e680245cbd253dfcffbfea62ad2fc7c112cfd21e6f84755c62630acb637"
-        },
-        {
           "id": "github.com/xrash/smetrics:v0.0.0-20201216005158-039620a65673",
           "type": "zip",
           "requestedBy": [
@@ -255,91 +311,35 @@
           "sha256": "bbebb9a00f44ff3e27bec16111effdcf2706d727821a4833ec8da19aad96e26d"
         },
         {
-          "id": "github.com/xeipuuv/gojsonreference:v0.0.0-20180127040603-bd5ef7bd5415",
+          "id": "github.com/!burnt!sushi/toml:v1.2.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ],
             [
-              "github.com/xeipuuv/gojsonschema:v1.2.0",
+              "github.com/urfave/cli/v2:v2.25.1",
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "133e9c4987a455db1a748f79522b79e95bd395ff",
-          "md5": "1355152ef669012354342f3f0a133987",
-          "sha256": "7ec98f4df894413f4dc58c8df330ca8b24ff425b05a8e1074c3028c99f7e45e7"
+          "sha1": "03b80e70043e52b2f3599d056ab4eb6620e2bb62",
+          "md5": "41001e8e47b9b3ec81f9f7790d585da0",
+          "sha256": "6fb658e8262179ffd34d57eaef6b076b25c77e8b2129659b66697cded29a7121"
         },
         {
-          "id": "github.com/pkg/errors:v0.9.1",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/gofrog:v1.3.0",
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6ac37cf1eab63f464a8ec2d20bc7224271528d7d",
-          "md5": "5d8002959a144c1bea1f86228fe09755",
-          "sha256": "d4c36b8bcd0616290a3913215e0f53b931bd6e00670596f2960df1b44af2bd07"
-        },
-        {
-          "id": "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
+          "id": "github.com/buger/jsonparser:v1.1.1",
           "type": "zip",
           "requestedBy": [
             [
               "github.com/jfrog/build-info-go"
             ]
           ],
-          "sha1": "acecfdf33b21b042ac08417ba7c845e2b3e04044",
-          "md5": "cf0413af37c19aefe8fddea66edb4ce4",
-          "sha256": "230880088ce2269538439d6d0d9a579c164a442f6169ad0e22ef846c68b93436"
-        },
-        {
-          "id": "github.com/klauspost/cpuid/v2:v2.2.3",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ],
-            [
-              "github.com/minio/sha256-simd:v1.0.1-0.20230222114820-6096f891a77b",
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "6429461f86edd94bb679272748c522f41f6453df",
-          "md5": "1bbcae037201b315dccd6e535b20bca0",
-          "sha256": "f68ff82caa807940fee615b4898d428365761eeb36861959ca8b91a034bd0e7e"
-        },
-        {
-          "id": "github.com/xeipuuv/gojsonschema:v1.2.0",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "e1529901eb2cf8c9ff2b1fbf504cb08d05d3d578",
-          "md5": "ebbf84ea1a07065b100c33e2736e6d03",
-          "sha256": "55c8ce068257aa0d263aad7470113dafcd50f955ee754fc853c2fdcd31ad096f"
-        },
-        {
-          "id": "golang.org/x/exp:v0.0.0-20230418202329-0354be287a23",
-          "type": "zip",
-          "requestedBy": [
-            [
-              "github.com/jfrog/build-info-go"
-            ]
-          ],
-          "sha1": "8c7c92a4b219e6138d5d1bdf6c3b9ad50b78f7ba",
-          "md5": "ba5fd44152526428564448abdd71c467",
-          "sha256": "c2bbeffc6c46927056154ce505a15dd436d31c08baa8f71795c6a47d2d663a82"
+          "sha1": "e0c54d96564262a70bc7ed33fb3ee2b15596f68f",
+          "md5": "7ab77d10951f73b96b9c19a6cca51bb1",
+          "sha256": "be17ef1b44c22eac645eeac80f0e26cdfc70d77262e631358e00c2aa817eab8c"
         }
       ]
     }
   ],
-  "started": "2023-05-17T15:43:45.796+0000"
+  "started": "2023-05-21T14:08:25.458+0000"
 }

--- a/build/build.go
+++ b/build/build.go
@@ -8,6 +8,7 @@ import (
 	ioutils "github.com/jfrog/gofrog/io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -281,7 +282,11 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 		buildInfo.Properties = env
 	}
 
-	buildInfo.VcsList = append(buildInfo.VcsList, vcsList...)
+	for _, vcs := range vcsList {
+		if !slices.Contains(buildInfo.VcsList, vcs) {
+			buildInfo.VcsList = append(buildInfo.VcsList, vcs)
+		}
+	}
 
 	// Check for Tracker as it must be set
 	if issues.Tracker != nil && issues.Tracker.Name != "" {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
