### PR TITLE
Allow the `GetDependenciesList` for Go to accept an error handler

### DIFF
--- a/build/golang.go
+++ b/build/golang.go
@@ -81,7 +81,7 @@ func (gm *GoModule) loadDependencies() ([]entities.Dependency, error) {
 }
 
 func (gm *GoModule) getGoDependencies(cachePath string) (map[string]entities.Dependency, error) {
-	modulesMap, err := utils.GetDependenciesList(gm.srcPath, gm.containingBuild.logger)
+	modulesMap, err := utils.GetDependenciesList(gm.srcPath, gm.containingBuild.logger, nil)
 	if err != nil || len(modulesMap) == 0 {
 		return nil, err
 	}

--- a/utils/goutils.go
+++ b/utils/goutils.go
@@ -91,6 +91,8 @@ func getListCmdArgs() (cmdArgs []string, err error) {
 	return []string{"list", "-mod=mod"}, nil
 }
 
+// The handle error function is designed to manage errors that occur while running the
+// 'go list' command. If the function returns true, the error will be propagated back to the caller.
 type HandleErrorFunc func(err error) (bool, error)
 
 // Runs go list -f {{with .Module}}{{.Path}}:{{.Version}}{{end}} all command and returns map of the dependencies

--- a/utils/goutils_test.go
+++ b/utils/goutils_test.go
@@ -89,8 +89,8 @@ func TestGetDependenciesListWithIgnoreErrors(t *testing.T) {
 	// In some cases, we see that running go list on some Go packages may fail.
 	// We should allow ignoring the errors in such cases and build the Go dependency tree, even if partial.
 	testGetDependenciesList(t, "testBadGoList", nil)
-	// In some cases we would like to exit after we receive an error, this can be done with custom error handle func.
-	// this test handleErrorFunc return an error
+	// In some cases we would like to exit after we receive an error. This can be done with custom error handle func.
+	// This test handleErrorFunc return an error
 	testGetDependenciesList(t, "testBadGoList", func(err error) (bool, error) {
 		if err != nil {
 			return true, err

--- a/utils/goutils_test.go
+++ b/utils/goutils_test.go
@@ -113,7 +113,7 @@ func testGetDependenciesList(t *testing.T, testDir string) {
 		err = os.Rename(filepath.Join(goModPath, "test.go"), filepath.Join(goModPath, "test.go.txt"))
 		assert.NoError(t, err)
 	}()
-	actual, err := GetDependenciesList(goModPath, log)
+	actual, err := GetDependenciesList(goModPath, log, nil)
 	assert.NoError(t, err)
 
 	// Since Go 1.16 'go list' command won't automatically update go.mod and go.sum.


### PR DESCRIPTION
…n when building go tree

- [X] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----

The PR introduces support for recognizing errors that occur while building the Go dependency tree. The primary reason for adding this support is to detect errors originating from the curation service. It's essential to catch these errors during the tree-building process, as they can occur when fetching dependencies from Artifactory as a result of running the go list command. The code changes involve passing a function to handle these errors, allowing the libraries that use it to manage error handling and reduce code duplication.