### PR TITLE
Add original deployment repo field to build info artifacts

### DIFF
--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -408,6 +408,8 @@ type Artifact struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
 	Path string `json:"path,omitempty"`
+	// This field is not recognized by Artifactory, and is used for internal purposes only.
+	OriginalRepo string `json:"originalRepo,omitempty"`
 	Checksum
 }
 

--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -408,8 +408,10 @@ type Artifact struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
 	Path string `json:"path,omitempty"`
+	// The target repository to which the artifact was deployed to.
+	// Named 'original' because the repository might change throughout the lifecycle of the build.
 	// This field is not recognized by Artifactory, and is used for internal purposes only.
-	OriginalRepo string `json:"originalRepo,omitempty"`
+	OriginalDeploymentRepo string `json:"originalDeploymentRepo,omitempty"`
 	Checksum
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This field was required in GitHub job summary, to generate a link for artifacts to the artifact tree.
This field is not recognized by Artifactory, and is used for internal purposes only.