### PR TITLE
Recognize "403 forbidden" error from mvn command output, and clasiffy it as "forbidden"  error type

### DIFF
--- a/build/maven.go
+++ b/build/maven.go
@@ -342,7 +342,8 @@ func (config *mvnRunConfig) SetOutputWriter(outputWriter io.Writer) *mvnRunConfi
 
 func (config *mvnRunConfig) runCmd() error {
 	command := config.GetCmd()
-	command.Stderr = os.Stderr
+	errBuffer := bytes.NewBuffer([]byte{})
+	command.Stderr = errBuffer
 	if config.outputWriter == nil {
 		command.Stdout = os.Stderr
 	} else {
@@ -350,5 +351,10 @@ func (config *mvnRunConfig) runCmd() error {
 	}
 	command.Dir = config.workspace
 	config.logger.Info("Running mvn command:", strings.Join(command.Args, " "))
+	err := command.Run()
+	if err != nil {
+		errResult := errBuffer.Bytes()
+		return fmt.Errorf("error while running '%s %s': %s\n%s", "mvn", strings.Join(command.Args, " "), err.Error(), strings.TrimSpace(string(errResult)))
+	}
 	return command.Run()
 }

--- a/build/maven.go
+++ b/build/maven.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/jfrog/build-info-go/utils"
+	"golang.org/x/term"
 )
 
 const (
@@ -340,21 +341,41 @@ func (config *mvnRunConfig) SetOutputWriter(outputWriter io.Writer) *mvnRunConfi
 	return config
 }
 
-func (config *mvnRunConfig) runCmd() error {
+func (config *mvnRunConfig) runCmd() (err error) {
 	command := config.GetCmd()
 	errBuffer := bytes.NewBuffer([]byte{})
-	command.Stderr = errBuffer
+	multiWriter := io.MultiWriter(os.Stderr, errBuffer)
+	command.Stderr = multiWriter
 	if config.outputWriter == nil {
 		command.Stdout = os.Stderr
 	} else {
 		command.Stdout = config.outputWriter
 	}
 	command.Dir = config.workspace
+	addColorToCmdOutput(command)
 	config.logger.Info("Running mvn command:", strings.Join(command.Args, " "))
-	err := command.Run()
+
+	err = command.Run()
 	if err != nil {
-		errResult := errBuffer.Bytes()
-		return fmt.Errorf("error while running '%s %s': %s\n%s", "mvn", strings.Join(command.Args, " "), err.Error(), strings.TrimSpace(string(errResult)))
+		if utils.IsForbiddenOutput("maven", errBuffer.String()) {
+			err = errors.Join(utils.NewForbiddenError(), err)
+		}
 	}
-	return nil
+	return
+}
+
+// To always have color in Maven's output, add "-Dstyle.color=always" to the command line arguments
+func addColorToCmdOutput(command *exec.Cmd) {
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		shouldAddColor := true
+		for _, arg := range command.Args {
+			if strings.Contains(arg, "-Dstyle.color") {
+				shouldAddColor = false
+				break
+			}
+		}
+		if shouldAddColor {
+			command.Args = append(command.Args, "-Dstyle.color=always")
+		}
+	}
 }

--- a/build/maven.go
+++ b/build/maven.go
@@ -356,5 +356,5 @@ func (config *mvnRunConfig) runCmd() error {
 		errResult := errBuffer.Bytes()
 		return fmt.Errorf("error while running '%s %s': %s\n%s", "mvn", strings.Join(command.Args, " "), err.Error(), strings.TrimSpace(string(errResult)))
 	}
-	return command.Run()
+	return nil
 }

--- a/build/maven.go
+++ b/build/maven.go
@@ -357,7 +357,7 @@ func (config *mvnRunConfig) runCmd() (err error) {
 
 	err = command.Run()
 	if err != nil {
-		if utils.IsForbiddenOutput("maven", errBuffer.String()) {
+		if utils.IsForbiddenOutput(utils.Maven, errBuffer.String()) {
 			err = errors.Join(utils.NewForbiddenError(), err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/exp v0.0.0-20240707233637-46b078467d37
+	golang.org/x/term v0.23.0
 )
 
 require (
@@ -26,6 +27,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
+	golang.org/x/sys v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,10 @@ golang.org/x/exp v0.0.0-20240707233637-46b078467d37/go.mod h1:M4RDyNAINzryxdtnbR
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
-golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ForbiddenError represents a 403 Forbidden error.
+type ForbiddenError struct {
+	Message string
+}
+
+// Error implements the error interface for ForbiddenError.
+func (e *ForbiddenError) Error() string {
+	return fmt.Sprintf("403 Forbidden")
+}
+
+// NewForbiddenError creates a new ForbiddenError with the given message.
+func NewForbiddenError() *ForbiddenError {
+	return &ForbiddenError{}
+}
+
+// IsForbiddenOutput verify the output is forbidden, each tech have its own forbidden output.
+func IsForbiddenOutput(tech string, cmdOutput string) bool {
+	switch tech {
+	case "npm":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
+	case "maven":
+		return strings.Contains(cmdOutput, "status code: 403") ||
+			strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
+			// In some cases mvn returns 500 status code even though it got 403 from artifactory.
+			strings.Contains(cmdOutput, "status code: 500")
+	case "pip":
+		return strings.Contains(strings.ToLower(cmdOutput), "http error 403")
+	case "go":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
+			strings.Contains(strings.ToLower(cmdOutput), " 403")
+	}
+	return false
+}

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -12,7 +11,7 @@ type ForbiddenError struct {
 
 // Error implements the error interface for ForbiddenError.
 func (e *ForbiddenError) Error() string {
-	return fmt.Sprintf("403 Forbidden")
+	return "403 Forbidden"
 }
 
 // NewForbiddenError creates a new ForbiddenError with the given message.

--- a/utils/error.go
+++ b/utils/error.go
@@ -4,6 +4,15 @@ import (
 	"strings"
 )
 
+type PackageManager string
+
+const (
+	Npm   PackageManager = "npm"
+	Maven PackageManager = "maven"
+	Pip   PackageManager = "pip"
+	Go    PackageManager = "go"
+)
+
 // ForbiddenError represents a 403 Forbidden error.
 type ForbiddenError struct {
 	Message string
@@ -19,8 +28,8 @@ func NewForbiddenError() *ForbiddenError {
 	return &ForbiddenError{}
 }
 
-// IsForbiddenOutput verify the output is forbidden, each tech have its own forbidden output.
-func IsForbiddenOutput(tech string, cmdOutput string) bool {
+// IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.
+func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	switch tech {
 	case "npm":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----
Description:
After running "mvn <command>" and encountering an error, we examine the output from stderr. If the output includes a "403 Forbidden", we wrap the error with a specific error type for "Forbidden 403." This error type will be recognized later by post actions, such as curation.
