### PR TITLE
Skip install in dependencies map calculation if requested

### DIFF
--- a/build/testdata/npm/noBuildProject/package.json
+++ b/build/testdata/npm/noBuildProject/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm_test2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "lightweight": "^0.1.0",
+    "minimist": "^0.1.0",
+    "underscore": "^1.13.6",
+    "cors.js": "0.0.1-security"
+  }
+}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -234,31 +234,6 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
 }
 
-/*
-// This test case verifies that CalculateNpmDependenciesList correctly handles the exclusion of 'node_modules'
-// and updates 'package-lock.json' as required, based on the 'IgnoreNodeModules' and 'OverwritePackageLock' parameters.
-func TestDependencyPackageLockOnly(t *testing.T) {
-	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
-	require.NoError(t, err)
-	if !npmVersion.AtLeast("7.0.0") {
-		t.Skip("Running on npm v7 and above only, skipping...")
-	}
-	path, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
-	defer cleanup()
-	assert.NoError(t, utils.MoveFile(filepath.Join(path, "package-lock_test.json"), filepath.Join(path, "package-lock.json")))
-	// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
-	require.NoError(t, os.Chtimes(filepath.Join(path, "package.json"), time.Now(), time.Now().Add(time.Millisecond*20)))
-
-	// Calculate dependencies.
-	dependencies, err := CalculateDependenciesMap("npm", path, "jfrogtest",
-		NpmTreeDepListParam{Args: []string{}, IgnoreNodeModules: true, OverwritePackageLock: true}, logger, false)
-	assert.NoError(t, err)
-	var expectedRes = getExpectedRespForTestDependencyPackageLockOnly()
-	assert.Equal(t, expectedRes, dependencies)
-}
-
-*/
-
 func TestCalculateDependenciesMap(t *testing.T) {
 	testCases := []struct {
 		name                 string

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -234,64 +234,39 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
 }
 
-func TestCalculateDependenciesMap(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		path                 string
-		ignoreNodeModules    bool
-		overwritePackageLock bool
-		recalculateLockFile  bool
-		skipInstall          bool
-	}{
-		{
-			// This test case verifies that we correctly handles the exclusion of 'node_modules'
-			// and updates 'package-lock.json' as required, based on the 'IgnoreNodeModules' and 'OverwritePackageLock' parameters.
-			name:                 "exclude node_modules and update package-lock.json",
-			path:                 "testdata/npm/project6",
-			ignoreNodeModules:    true,
-			overwritePackageLock: true,
-			recalculateLockFile:  true,
-			skipInstall:          false,
-		},
-		{
-			name:                 "install required but forbidden",
-			path:                 "testdata/npm/noBuildProject",
-			ignoreNodeModules:    false,
-			overwritePackageLock: false,
-			recalculateLockFile:  false,
-			skipInstall:          true,
-		},
+// This test case verifies that CalculateDependenciesMap correctly handles the exclusion of 'node_modules'
+// and updates 'package-lock.json' as required, based on the 'IgnoreNodeModules' and 'OverwritePackageLock' parameters.
+func TestDependencyPackageLockOnly(t *testing.T) {
+	npmVersion, _, err := GetNpmVersionAndExecPath(logger)
+	require.NoError(t, err)
+	if !npmVersion.AtLeast("7.0.0") {
+		t.Skip("Running on npm v7 and above only, skipping...")
 	}
+	path, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata/npm/project6"))
+	defer cleanup()
+	assert.NoError(t, utils.MoveFile(filepath.Join(path, "package-lock_test.json"), filepath.Join(path, "package-lock.json")))
+	// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
+	require.NoError(t, os.Chtimes(filepath.Join(path, "package.json"), time.Now(), time.Now().Add(time.Millisecond*20)))
 
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			npmVersion, _, err := GetNpmVersionAndExecPath(logger)
-			require.NoError(t, err)
-			if !npmVersion.AtLeast("7.0.0") {
-				t.Skip("Running on npm v7 and above only, skipping...")
-			}
-			path, cleanup := tests.CreateTestProject(t, filepath.Join("..", test.path))
-			defer cleanup()
-			if test.recalculateLockFile {
-				assert.NoError(t, utils.MoveFile(filepath.Join(path, "package-lock_test.json"), filepath.Join(path, "package-lock.json")))
-				// sleep so the package.json modified time will be bigger than the package-lock.json, this make sure it will recalculate lock file.
-				require.NoError(t, os.Chtimes(filepath.Join(path, "package.json"), time.Now(), time.Now().Add(time.Millisecond*20)))
-			}
+	// Calculate dependencies.
+	dependencies, err := CalculateDependenciesMap("npm", path, "jfrogtest",
+		NpmTreeDepListParam{Args: []string{}, IgnoreNodeModules: true, OverwritePackageLock: true}, logger, false)
+	assert.NoError(t, err)
+	var expectedRes = getExpectedRespForTestDependencyPackageLockOnly()
+	assert.Equal(t, expectedRes, dependencies)
+}
 
-			dependencies, err := CalculateDependenciesMap("npm", path, "jfrogtest",
-				NpmTreeDepListParam{Args: []string{}, IgnoreNodeModules: test.ignoreNodeModules, OverwritePackageLock: test.overwritePackageLock}, logger, test.skipInstall)
+func TestCalculateDependenciesMapWithProhibitedInstallation(t *testing.T) {
+	path, cleanup := tests.CreateTestProject(t, filepath.Join("..", "testdata", "npm", "noBuildProject"))
+	defer cleanup()
 
-			if test.recalculateLockFile {
-				assert.NoError(t, err)
-				var expectedRes = getExpectedRespForTestDependencyPackageLockOnly()
-				assert.Equal(t, expectedRes, dependencies)
-			} else {
-				assert.Error(t, err)
-				var installForbiddenErr *utils.ErrInstallForbidden
-				assert.True(t, errors.As(err, &installForbiddenErr))
-			}
-		})
-	}
+	dependencies, err := CalculateDependenciesMap("npm", path, "jfrogtest",
+		NpmTreeDepListParam{Args: []string{}, IgnoreNodeModules: false, OverwritePackageLock: false}, logger, true)
+
+	assert.Nil(t, dependencies)
+	assert.Error(t, err)
+	var installForbiddenErr *utils.ErrProjectNotInstalled
+	assert.True(t, errors.As(err, &installForbiddenErr))
 }
 
 func getExpectedRespForTestDependencyPackageLockOnly() map[string]*dependencyInfo {

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -26,6 +27,14 @@ func (e *ForbiddenError) Error() string {
 // NewForbiddenError creates a new ForbiddenError with the given message.
 func NewForbiddenError() *ForbiddenError {
 	return &ForbiddenError{}
+}
+
+type ErrInstallForbidden struct {
+	UninstalledDir string
+}
+
+func (err *ErrInstallForbidden) Error() string {
+	return fmt.Sprintf("Directory '%s' is not installed, and installation is porhibited by the user. Skipping SCA scan in this directory...", err.UninstalledDir)
 }
 
 // IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.

--- a/utils/error.go
+++ b/utils/error.go
@@ -29,12 +29,12 @@ func NewForbiddenError() *ForbiddenError {
 	return &ForbiddenError{}
 }
 
-type ErrInstallForbidden struct {
+type ErrProjectNotInstalled struct {
 	UninstalledDir string
 }
 
-func (err *ErrInstallForbidden) Error() string {
-	return fmt.Sprintf("Directory '%s' is not installed, and installation is porhibited by the user. Skipping SCA scan in this directory...", err.UninstalledDir)
+func (err *ErrProjectNotInstalled) Error() string {
+	return fmt.Sprintf("Directory '%s' is not installed. Skipping SCA scan in this directory...", err.UninstalledDir)
 }
 
 // IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR contains changes to NPM installation process when calculating dependencies map.
We currently add a new ability to **skip installation** of a project if requested by the user.
This new functionality will be available through Frogbot and will currently apply only to Yarn and NPM (for WalkMe POC)
The changes reflected here are only in NPM files due to the way NPM dependencies map calculation is performed. In the near future we opt to re-write this logic and take the installation logic to cli-security and leave only the map construction in build-info-go.
Tests were added as well.
The new logic is as follows:
1) If the user has provided an 'install command' - we execute this command whether the project is installed or not (this is the logic we aim in all other PMs as well)
2) If there is no 'install command' and the project is not installed, while the user prohibited installation - we throw a new error to indicate that and handle this error later in the process
3) If there is no 'install command' and the project is not installed and the is no prohibition to install- we install using a default install command, as we do today
