### PR TITLE
Ignore node_modules in npm dependency tree calculation when skip-auto-install applied

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -104,10 +104,11 @@ func CalculateDependenciesMap(executablePath, srcPath, moduleId string, npmListP
 		return nil, err
 	}
 	var data []byte
-	// If we don't have node_modules, the function will use the package-lock dependencies.
-	if nodeModulesExist && !npmListParams.IgnoreNodeModules {
+	// When `skipInstall` is true, we aim to rely on the dependencies specified in the package-lock, so Frogbot will not execute 'npm ls' on modules that are unbuilt and lack lock files (which may still have incomplete node_modules that could cause errors).
+	if nodeModulesExist && !npmListParams.IgnoreNodeModules && !skipInstall {
 		data = runNpmLsWithNodeModules(executablePath, srcPath, npmListParams.Args, log)
 	} else {
+		// If we don't have node_modules, the function will use the package-lock dependencies.
 		data, err = runNpmLsWithoutNodeModules(executablePath, srcPath, npmListParams, log, npmVersion, skipInstall)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This addition forces the NPM dependency tree calculation to ignore node_modules existence, even if exists, when skip-auto-install is set to true (by Frogbot or the CLI)
Currently the skip-auto-install is a hidden flag and was created for WalkMe PoC, but later will be published as a feature.
The reason for this change is to better handle multi-module/multi-workspace scenarios.
In multi-workspaces/multi-modules scenarios we sometimes miss the lock files in the inner modules (as it should be), and we wish to skip every module without a lock file, where we know that all the dependencies are reflected in the root descriptor (the only one with a lock file). 
In this scenario if node_modules exists we will attempt to run 'npm ls' on this module, which will fail.
This improvement forces to ignore node_modules and work according to the lock file only when skip-auto-install is applied, which will allow us to skip these inner uninstalled modules
