### PR TITLE
Apply allow-partial-results on Yarn V1 dependencies map construction

### DIFF
--- a/build/utils/yarn.go
+++ b/build/utils/yarn.go
@@ -124,7 +124,6 @@ func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInf
 	if isV2AndAbove {
 		dependenciesMap, root, err = buildYarnV2DependencyMap(packageInfo, responseStr)
 	} else {
-		responseStr = "{\"type\":\"tree\",\"data\":{\"type\":\"list\",\"trees\":[{\"name\":\"minimist@1.2.5\",\"children\":[],\"hint\":null,\"color\":\"bold\",\"depth\":0},{\"name\":\"yarn-inner@1.0.0\",\"children\":[{\"name\":\"tough-cookie@2.5.0\",\"color\":\"dim\",\"shadow\":true}],\"hint\":null,\"color\":\"bold\",\"depth\":0}]}}"
 		dependenciesMap, root, err = buildYarnV1DependencyMap(packageInfo, responseStr, allowPartialResults, log)
 	}
 	return

--- a/build/utils/yarn.go
+++ b/build/utils/yarn.go
@@ -94,11 +94,11 @@ func GetYarnExecutable() (string, error) {
 	return yarnExecPath, nil
 }
 
-// GetYarnDependencies returns a map of the dependencies of a Yarn project and the root package of the project.
+// Returns a map of the dependencies of a Yarn project and the root package of the project.
 // The keys are the packages' values (Yarn's full identifiers of the packages), for example: '@scope/package-name@1.0.0'
 // (for yarn v < 2.0.0) or @scope/package-name@npm:1.0.0 (for yarn v >= 2.0.0).
 // Pay attention that a package's value won't necessarily contain its version. Use the version in package's details instead.
-func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInfo, log utils.Log) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
+func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInfo, log utils.Log, allowPartialResults bool) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
 	executableVersionStr, err := GetVersion(executablePath, srcPath)
 	if err != nil {
 		return
@@ -124,7 +124,8 @@ func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInf
 	if isV2AndAbove {
 		dependenciesMap, root, err = buildYarnV2DependencyMap(packageInfo, responseStr)
 	} else {
-		dependenciesMap, root, err = buildYarnV1DependencyMap(packageInfo, responseStr)
+		responseStr = "{\"type\":\"tree\",\"data\":{\"type\":\"list\",\"trees\":[{\"name\":\"minimist@1.2.5\",\"children\":[],\"hint\":null,\"color\":\"bold\",\"depth\":0},{\"name\":\"yarn-inner@1.0.0\",\"children\":[{\"name\":\"tough-cookie@2.5.0\",\"color\":\"dim\",\"shadow\":true}],\"hint\":null,\"color\":\"bold\",\"depth\":0}]}}"
+		dependenciesMap, root, err = buildYarnV1DependencyMap(packageInfo, responseStr, allowPartialResults, log)
 	}
 	return
 }
@@ -144,10 +145,10 @@ func GetVersion(executablePath, srcPath string) (string, error) {
 	return strings.TrimSpace(outBuffer.String()), err
 }
 
-// buildYarnV1DependencyMap builds a map of dependencies for Yarn versions < 2.0.0
+// Builds a map of dependencies for Yarn versions < 2.0.0
 // Pay attention that in Yarn < 2.0.0 the project itself with its direct dependencies is not presented when running the
 // command 'yarn list' therefore the root is built manually.
-func buildYarnV1DependencyMap(packageInfo *PackageInfo, responseStr string) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
+func buildYarnV1DependencyMap(packageInfo *PackageInfo, responseStr string, allowPartialResults bool, log utils.Log) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
 	dependenciesMap = make(map[string]*YarnDependency)
 	var depTree Yarn1Data
 	err = json.Unmarshal([]byte(responseStr), &depTree)
@@ -164,23 +165,27 @@ func buildYarnV1DependencyMap(packageInfo *PackageInfo, responseStr string) (dep
 	packNameToFullName := make(map[string]string)
 
 	// Initializing dependencies map without child dependencies for each dependency + creating a map that maps: package-name -> package-name@version
+	// The two phases mapping is performed since the responseStr from 'yarn list' contains the resolved versions of the dependencies at the map's first level, but may contain the caret version range (^) at the children level.
+	// Therefore, a manual matching must be made in order to output a map with parent-child relation containing only resolved versions.
 	for _, curDependency := range depTree.Data.DepTree {
 		var packageCleanName, packageVersion string
 		packageCleanName, packageVersion, err = splitNameAndVersion(curDependency.Name)
 		if err != nil {
 			return
 		}
-
+		// We insert to dependenciesMap dependencies with the resolved versions only. All dependencies at the responseStr first level contain resolved versions only (their children may contain caret version ranges).
 		dependenciesMap[curDependency.Name] = &YarnDependency{
 			Value:   curDependency.Name,
 			Details: YarnDepDetails{Version: packageVersion},
 		}
 		packNameToFullName[packageCleanName] = curDependency.Name
 	}
+	log.Debug(fmt.Sprintf("package name to full name map content: %v", packNameToFullName))
+	log.Debug(fmt.Sprintf("'yarn list' output string: %s", responseStr))
 
 	// Adding child dependencies for each dependency
 	for _, curDependency := range depTree.Data.DepTree {
-		dependency := dependenciesMap[curDependency.Name]
+		dependencyToUpdateInMap := dependenciesMap[curDependency.Name]
 
 		for _, subDep := range curDependency.Dependencies {
 			var subDepName string
@@ -191,12 +196,17 @@ func buildYarnV1DependencyMap(packageInfo *PackageInfo, responseStr string) (dep
 
 			packageWithResolvedVersion := packNameToFullName[subDepName]
 			if packageWithResolvedVersion == "" {
+				if allowPartialResults {
+					log.Warn(fmt.Sprintf("error occurred during Yarn dependencies map calculation: couldn't find resolved version for '%s' in 'yarn list' output\nFinal rasults may be partial", subDep.DependencyName))
+					continue
+				}
+
 				err = fmt.Errorf("couldn't find resolved version for '%s' in 'yarn list' output", subDep.DependencyName)
 				return
 			}
-			dependency.Details.Dependencies = append(dependency.Details.Dependencies, YarnDependencyPointer{subDep.DependencyName, packageWithResolvedVersion})
+			dependencyToUpdateInMap.Details.Dependencies = append(dependencyToUpdateInMap.Details.Dependencies, YarnDependencyPointer{subDep.DependencyName, packageWithResolvedVersion})
 		}
-		dependenciesMap[curDependency.Name] = dependency
+		dependenciesMap[curDependency.Name] = dependencyToUpdateInMap
 	}
 
 	rootDependency := buildYarn1Root(packageInfo, packNameToFullName)
@@ -205,7 +215,7 @@ func buildYarnV1DependencyMap(packageInfo *PackageInfo, responseStr string) (dep
 	return
 }
 
-// buildYarnV2DependencyMap builds a map of dependencies for Yarn version >= 2.0.0
+// Builds a map of dependencies for Yarn version >= 2.0.0
 // Note that in some versions of Yarn, the version of the root package is '0.0.0-use.local', instead of the version in the package.json file.
 func buildYarnV2DependencyMap(packageInfo *PackageInfo, responseStr string) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
 	dependenciesMap = make(map[string]*YarnDependency)
@@ -233,7 +243,7 @@ func buildYarnV2DependencyMap(packageInfo *PackageInfo, responseStr string) (dep
 	return
 }
 
-// runYarnInfoOrList depends on the yarn version currently operating on the project, runs the command that gets the dependencies of the project
+// Depends on the yarn version currently operating on the project, runs the command that gets the dependencies of the project
 func runYarnInfoOrList(executablePath string, srcPath string, v2AndAbove bool) (outResult, errResult string, err error) {
 	var command *exec.Cmd
 	if v2AndAbove {

--- a/build/yarn.go
+++ b/build/yarn.go
@@ -82,7 +82,7 @@ func (ym *YarnModule) Build() error {
 }
 
 func (ym *YarnModule) getDependenciesMap() (map[string]*entities.Dependency, error) {
-	dependenciesMap, root, err := buildutils.GetYarnDependencies(ym.executablePath, ym.srcPath, ym.packageInfo, ym.containingBuild.logger)
+	dependenciesMap, root, err := buildutils.GetYarnDependencies(ym.executablePath, ym.srcPath, ym.packageInfo, ym.containingBuild.logger, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR introduces an improvement that applies 'allow-partial-results' ability on Yarn V1 dependencies map construction, so if we have some missing dependencies - it will not fail the entire map construction.
**In more details:**
Due to the output of 'yarn list' we manually build the dependencies map for Yarn V1 in 2 phases. 
At the output's first level we get all dependencies (direct and indirect) with their locked versions.
At the output's second level (the children) we get all dependencies with caret version specifier (^).
Therefore a manual mapping between the versions is required for the final construction of the map and later the tree.
Sometime (for unknown reason that will be investigated further later, extra debug logs were added) we encounter a child dependency that we do now have at the first level of the map, and this causes the entire process to fail.
The current change states that if 'allow-partial-results' is enabled, and we encounter such a dependency - we just log the error and skip the matching for this problematic dependency.
This allow us to continue the process and to report the vulnerability, with a price that we might have some dependencies without impact paths (they will be reported in 'audit', just without stating their direct dependency) and will not get fixed in Frogbot.
**This applies ONLY if 'partial results' is enabled. In any other case the flow remains unchanged**

related changes: 
https://github.com/jfrog/jfrog-cli-security/pull/229
https://github.com/jfrog/frogbot/pull/784
