### PR TITLE
Add `allowInsecureConnections` field to Nuget config file format

### DIFF
--- a/build/utils/dotnet/configfiletemplate.go
+++ b/build/utils/dotnet/configfiletemplate.go
@@ -11,7 +11,7 @@ const ConfigFileTemplate = `<?xml version="1.0" encoding="utf-8"?>
 const ConfigFileFormat = `<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="JFrogCli" value="%s" protocolVersion="%s" />
+    <add key="JFrogCli" value="%s" protocolVersion="%s" allowInsecureConnections="%v"/>
   </packageSources>
   <packageSourceCredentials>
     <JFrogCli>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The [latest .NET 6 release](https://versionsof.net/core/6.0/6.0.36/) introduces changes to NuGet that now restrict the use of insecure connections for package sources unless a specific flag is enabled.