### PR TITLE
Fix Pipenv graph invalid JSON

### DIFF
--- a/build/python.go
+++ b/build/python.go
@@ -33,7 +33,7 @@ func (pm *PythonModule) RunInstallAndCollectDependencies(commandArgs []string) e
 	if err != nil {
 		return err
 	}
-	dependenciesGraph, topLevelPackagesList, err := pythonutils.GetPythonDependencies(pm.tool, pm.srcPath, pm.localDependenciesPath)
+	dependenciesGraph, topLevelPackagesList, err := pythonutils.GetPythonDependencies(pm.tool, pm.srcPath, pm.localDependenciesPath, pm.containingBuild.logger)
 	if err != nil {
 		return fmt.Errorf("failed while attempting to get %s dependencies graph: %s", pm.tool, err.Error())
 	}

--- a/utils/pythonutils/pipenvutils.go
+++ b/utils/pythonutils/pipenvutils.go
@@ -42,5 +42,8 @@ func getPipenvDependencies(srcPath string, logger utils.Log) (dependenciesGraph 
 
 // Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshaling.
 func cleanJsonOutput(output []byte) []byte {
-	return bytes.ReplaceAll(bytes.ReplaceAll(output, windowsReplaceBytes, replacementBytes), unixReplaceBytes, replacementBytes)
+	// For Windows
+	output = bytes.ReplaceAll(output, windowsReplaceBytes, replacementBytes)
+	// For Unix
+	return bytes.ReplaceAll(output, unixReplaceBytes, replacementBytes)
 }

--- a/utils/pythonutils/pipenvutils.go
+++ b/utils/pythonutils/pipenvutils.go
@@ -25,7 +25,6 @@ func getPipenvDependencies(srcPath string, logger utils.Log) (dependenciesGraph 
 	logger.Debug("pipenv graph --json output:\n" + string(output))
 	// Parse into array.
 	packages := make([]pythonDependencyPackage, 0)
-	// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshalling.
 	err = json.Unmarshal(cleanJsonOutput(output), &packages)
 	if err != nil {
 		err = fmt.Errorf("failed to parse pipenv graph --json output: %s", err.Error())
@@ -35,7 +34,7 @@ func getPipenvDependencies(srcPath string, logger utils.Log) (dependenciesGraph 
 	return
 }
 
-// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshalling.
+// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshaling.
 func cleanJsonOutput(output []byte) []byte {
 	// For Windows
 	out := strings.ReplaceAll(string(output), "\r\n", "")

--- a/utils/pythonutils/pipenvutils.go
+++ b/utils/pythonutils/pipenvutils.go
@@ -1,12 +1,18 @@
 package pythonutils
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/io"
+)
+
+var (
+	windowsReplaceBytes = []byte("\r\n")
+	unixReplaceBytes    = []byte("\n")
+	replacementBytes    = []byte("")
 )
 
 // Executes pipenv graph.
@@ -36,8 +42,5 @@ func getPipenvDependencies(srcPath string, logger utils.Log) (dependenciesGraph 
 
 // Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshaling.
 func cleanJsonOutput(output []byte) []byte {
-	// For Windows
-	out := strings.ReplaceAll(string(output), "\r\n", "")
-	// For Unix
-	return []byte(strings.ReplaceAll(out, "\n", ""))
+	return bytes.ReplaceAll(bytes.ReplaceAll(output, windowsReplaceBytes, replacementBytes), unixReplaceBytes, replacementBytes)
 }

--- a/utils/pythonutils/pipenvutils.go
+++ b/utils/pythonutils/pipenvutils.go
@@ -2,6 +2,8 @@ package pythonutils
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/jfrog/gofrog/io"
 )
@@ -16,12 +18,15 @@ func getPipenvDependencies(srcPath string) (dependenciesGraph map[string][]strin
 	pipenvGraphCmd.Dir = srcPath
 	output, err := pipenvGraphCmd.RunWithOutput()
 	if err != nil {
+		err = fmt.Errorf("failed to run pipenv graph --json: %s", err.Error())
 		return
 	}
 	// Parse into array.
 	packages := make([]pythonDependencyPackage, 0)
-	err = json.Unmarshal(output, &packages)
+	// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshalling.
+	err = json.Unmarshal([]byte(strings.ReplaceAll(string(output), "\n", "")), &packages)
 	if err != nil {
+		err = fmt.Errorf("failed to parse pipenv graph --json output: %s", err.Error())
 		return
 	}
 	dependenciesGraph, topLevelDependencies, err = parseDependenciesToGraph(packages)

--- a/utils/pythonutils/pipenvutils.go
+++ b/utils/pythonutils/pipenvutils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/io"
 )
 
@@ -12,7 +13,7 @@ import (
 // Returns a dependency map of all the installed pipenv packages in the current environment and also another list of the top level dependencies
 // 'dependenciesGraph' - map between all parent modules and their child dependencies
 // 'topLevelPackagesList' - list of all top level dependencies ( root dependencies only)
-func getPipenvDependencies(srcPath string) (dependenciesGraph map[string][]string, topLevelDependencies []string, err error) {
+func getPipenvDependencies(srcPath string, logger utils.Log) (dependenciesGraph map[string][]string, topLevelDependencies []string, err error) {
 	// Run pipenv graph
 	pipenvGraphCmd := io.NewCommand("pipenv", "graph", []string{"--json"})
 	pipenvGraphCmd.Dir = srcPath
@@ -21,14 +22,23 @@ func getPipenvDependencies(srcPath string) (dependenciesGraph map[string][]strin
 		err = fmt.Errorf("failed to run pipenv graph --json: %s", err.Error())
 		return
 	}
+	logger.Debug("pipenv graph --json output:\n" + string(output))
 	// Parse into array.
 	packages := make([]pythonDependencyPackage, 0)
 	// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshalling.
-	err = json.Unmarshal([]byte(strings.ReplaceAll(string(output), "\n", "")), &packages)
+	err = json.Unmarshal(cleanJsonOutput(output), &packages)
 	if err != nil {
 		err = fmt.Errorf("failed to parse pipenv graph --json output: %s", err.Error())
 		return
 	}
 	dependenciesGraph, topLevelDependencies, err = parseDependenciesToGraph(packages)
 	return
+}
+
+// Sometimes, `pipenv graph --json` command returns output with new line characters in between (not valid json) So, we need to remove them before unmarshalling.
+func cleanJsonOutput(output []byte) []byte {
+	// For Windows
+	out := strings.ReplaceAll(string(output), "\r\n", "")
+	// For Unix
+	return []byte(strings.ReplaceAll(out, "\n", ""))
 }

--- a/utils/pythonutils/utils.go
+++ b/utils/pythonutils/utils.go
@@ -86,12 +86,12 @@ func GetPythonDependenciesFiles(tool PythonTool, args []string, buildName, build
 	}
 }
 
-func GetPythonDependencies(tool PythonTool, srcPath, localDependenciesPath string) (dependenciesGraph map[string][]string, topLevelDependencies []string, err error) {
+func GetPythonDependencies(tool PythonTool, srcPath, localDependenciesPath string, logger utils.Log) (dependenciesGraph map[string][]string, topLevelDependencies []string, err error) {
 	switch tool {
 	case Pip:
 		return getPipDependencies(srcPath, localDependenciesPath)
 	case Pipenv:
-		return getPipenvDependencies(srcPath)
+		return getPipenvDependencies(srcPath, logger)
 	case Poetry:
 		return getPoetryDependencies(srcPath)
 	default:


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

## Fix (Also add extend logs for debugging)

For some projects `pipenv graph --json` produce not valid json (added `\n`) prevents `Unmarshal` 

```
Error: 3 [Error] target '/tmp/jfrog.cli.temp.-1734955979-676905686 [pipenv]' errors:
Failed to build dependency tree: failed while building 'pipenv' dependency tree: failed to parse pipenv graph --json output: invalid character '\n' in string literal
```

![image](https://github.com/user-attachments/assets/607057b6-e858-414b-9888-404c655601a9)
