### PR TITLE
Use Python3 Exe if exists for pip dependencies

### DIFF
--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -19,7 +19,16 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	if err != nil {
 		return nil, nil, err
 	}
-	localPipdeptree := io.NewCommand("python", "", []string{localPipdeptreeScript, "--json"})
+	// Get the executable path of the python interpreter
+	var args []string
+	pythonExecutable, windowsPyArg := GetPython3Executable()
+	if windowsPyArg != "" {
+		args = append(args, windowsPyArg)
+	}
+	// Add the script path to the args
+	args = append(args, localPipdeptreeScript, "--json")
+
+	localPipdeptree := io.NewCommand(pythonExecutable, "", args)
 	localPipdeptree.Dir = srcPath
 	output, err := localPipdeptree.RunWithOutput()
 	if err != nil {

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -19,7 +19,7 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	if err != nil {
 		return nil, nil, err
 	}
-	// Get the executable path of the python interpreter
+	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
 	var args []string
 	pythonExecutable, windowsPyArg := GetPython3Executable()
 	if windowsPyArg != "" {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Add option to get pip dependencies using `Python3` and not only `python`