### PR TITLE
Use python and not py -3 when getting pip deps

### DIFF
--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -23,6 +23,10 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
 	pythonExecutable, _ := GetPython3Executable(false)
 	log.Debug("Getting pip dependencies using python executable: ", pythonExecutable)
+	if utils.IsWindows() && strings.Contains(pythonExecutable, "python3") {
+		log.Warn("Using python3 executable on Windows is not supported for getting pip dependencies. Please use 'python' instead.")
+		pythonExecutable = "python"
+	}
 	localPipdeptree := io.NewCommand(pythonExecutable, "", []string{localPipdeptreeScript, "--json"})
 	localPipdeptree.Dir = srcPath
 	output, err := localPipdeptree.RunWithOutput()

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -19,7 +19,9 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	if err != nil {
 		return nil, nil, err
 	}
-	localPipdeptree := io.NewCommand("python", "", []string{localPipdeptreeScript, "--json"})
+	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
+	pythonExecutable, _ := GetPython3Executable(false)
+	localPipdeptree := io.NewCommand(pythonExecutable, "", []string{localPipdeptreeScript, "--json"})
 	localPipdeptree.Dir = srcPath
 	output, err := localPipdeptree.RunWithOutput()
 	if err != nil {

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/io"
+	"github.com/jfrog/gofrog/log"
 )
 
 // Executes the pip-dependency-map script and returns a dependency map of all the installed pip packages in the current environment to and another list of the top level dependencies
@@ -21,6 +22,7 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	}
 	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
 	pythonExecutable, _ := GetPython3Executable(false)
+	log.Debug("Getting pip dependencies using python executable: ", pythonExecutable)
 	localPipdeptree := io.NewCommand(pythonExecutable, "", []string{localPipdeptreeScript, "--json"})
 	localPipdeptree.Dir = srcPath
 	output, err := localPipdeptree.RunWithOutput()

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -19,16 +19,7 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	if err != nil {
 		return nil, nil, err
 	}
-	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
-	var args []string
-	pythonExecutable, windowsPyArg := GetPython3Executable(false)
-	if windowsPyArg != "" {
-		args = append(args, windowsPyArg)
-	}
-	// Add the script path to the args
-	args = append(args, localPipdeptreeScript, "--json")
-
-	localPipdeptree := io.NewCommand(pythonExecutable, "", args)
+	localPipdeptree := io.NewCommand("python", "", []string{localPipdeptreeScript, "--json"})
 	localPipdeptree.Dir = srcPath
 	output, err := localPipdeptree.RunWithOutput()
 	if err != nil {

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -24,6 +24,7 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	pythonExecutable, _ := GetPython3Executable(false)
 	log.Debug("Getting pip dependencies using python executable: ", pythonExecutable)
 	if utils.IsWindows() && strings.Contains(pythonExecutable, "python3") {
+		// On Windows, python3 executing the script will fetch the global dependencies and not the local ones. investigation is needed.
 		log.Warn("Using python3 executable on Windows is not supported for getting pip dependencies. Please use 'python' instead.")
 		pythonExecutable = "python"
 	}

--- a/utils/pythonutils/piputils.go
+++ b/utils/pythonutils/piputils.go
@@ -21,7 +21,7 @@ func getPipDependencies(srcPath, dependenciesDirName string) (map[string][]strin
 	}
 	// Get the executable path of the python interpreter (python3 or py fallback to python if needed)
 	var args []string
-	pythonExecutable, windowsPyArg := GetPython3Executable()
+	pythonExecutable, windowsPyArg := GetPython3Executable(false)
 	if windowsPyArg != "" {
 		args = append(args, windowsPyArg)
 	}
@@ -129,7 +129,7 @@ func getEgginfoPkginfoContent(setuppyFilePath string) (output []byte, err error)
 
 	// Run python 'egg_info --egg-base <eggBase>' command.
 	var args []string
-	pythonExecutable, windowsPyArg := GetPython3Executable()
+	pythonExecutable, windowsPyArg := GetPython3Executable(true)
 	if windowsPyArg != "" {
 		args = append(args, windowsPyArg)
 	}
@@ -145,11 +145,11 @@ func getEgginfoPkginfoContent(setuppyFilePath string) (output []byte, err error)
 	return extractPackageNameFromEggBase(eggBase)
 }
 
-func GetPython3Executable() (string, string) {
+func GetPython3Executable(useWinPyLauncher bool) (string, string) {
 	windowsPyArg := ""
 	pythonExecutable, _ := exec.LookPath("python3")
 	if pythonExecutable == "" {
-		if utils.IsWindows() {
+		if utils.IsWindows() && useWinPyLauncher {
 			// If the OS is Windows try using Py Launcher: 'py -3'
 			pythonExecutable, _ = exec.LookPath("py")
 			if pythonExecutable != "" {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

On Windows, the py launcher (PEP 397) and the plain python command behave differently with active virtual environments.
When executing the scripts to get pip depenendices:

Invocation | Interpreter used | Dependencies seen by pipdeptree (example)
-- | -- | --
python pipdeptree.py (or python -m pipdeptree) | ...\<venv>\Scripts\python.exe (venv’s Python) | Only venv packages (e.g. PyYAML, Werkzeug, pip)
python3 pipdeptree.py | C:\Windows\py.exe → latest Python 3 exe (global) | Venv packages plus all global packages (e.g. Poetry, Conan, etc.)

This is not the intended usage, so there is a need to control when we want to use `python3` and when we don't.
Adding limitation of not using `python3` for getting pip dependencies on `windows` until more investigation and fixing the issue there