### PR TITLE
Add error when trying to copy directory to the same path

### DIFF
--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -394,9 +394,14 @@ func FindFileInDirAndParents(dirPath, fileName string) (string, error) {
 // includeDirs means to copy also the dirs if presented in the src folder.
 // excludeNames - Skip files/dirs in the src folder that match names in provided slice. ONLY excludes first layer (only in src folder).
 func CopyDir(fromPath, toPath string, includeDirs bool, excludeNames []string) error {
+	// Validate the the from path is not included in the to path.
 	if fromPath == toPath {
-		return fmt.Errorf("can't copy directory when source and destination paths are the same: %s", fromPath)
+		return fmt.Errorf("cannot copy directory from '%s' to '%s', because the source and destination are the same", fromPath, toPath)
 	}
+	if strings.HasPrefix(toPath, fromPath) {
+		return fmt.Errorf("cannot copy directory from '%s' to '%s', because the destination is a subdirectory of the source", fromPath, toPath)
+	}
+
 	err := CreateDirIfNotExist(toPath)
 	if err != nil {
 		return err

--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -394,6 +394,9 @@ func FindFileInDirAndParents(dirPath, fileName string) (string, error) {
 // includeDirs means to copy also the dirs if presented in the src folder.
 // excludeNames - Skip files/dirs in the src folder that match names in provided slice. ONLY excludes first layer (only in src folder).
 func CopyDir(fromPath, toPath string, includeDirs bool, excludeNames []string) error {
+	if fromPath == toPath {
+		return fmt.Errorf("can't copy directory when source and destination paths are the same: %s", fromPath)
+	}
 	err := CreateDirIfNotExist(toPath)
 	if err != nil {
 		return err

--- a/utils/fileutils_test.go
+++ b/utils/fileutils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,4 +70,117 @@ func TestCreateTempDir(t *testing.T) {
 
 		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
+}
+
+func TestCopyDir(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := CreateTempDir()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	// tmp/<unique-id>
+	// -- subdir
+	//    -- file1.txt
+	//    -- file2.txt
+	// -- file3.txt
+	// -- subdir2
+	//    -- subsubdir
+	//       -- subfile.txt
+	// -- target
+
+	// (VALID) 1. source = tmp/<unique-id>/subdir, target = tmp/<unique-id>/target
+	// (INVALID) 2. source = tmp/<unique-id>/subdir2, target = tmp/<unique-id>/subdir2
+	// (INVALID) 3. source = tmp/<unique-id>, target = tmp/<unique-id>/subdir2
+
+	// add subdirectory to the temp dir
+	tempSubDir := filepath.Join(tempDir, "subdir")
+	err = os.Mkdir(tempSubDir, 0755)
+	assert.NoError(t, err)
+	// add some files to the temp dir
+	tempFile1 := filepath.Join(tempSubDir, "file1.txt")
+	err = os.WriteFile(tempFile1, []byte("This is file 1"), 0644)
+	assert.NoError(t, err)
+	tempFile2 := filepath.Join(tempSubDir, "file2.txt")
+	err = os.WriteFile(tempFile2, []byte("This is file 2"), 0644)
+	assert.NoError(t, err)
+	// create a file in the temp dir
+	tempFile3 := filepath.Join(tempDir, "file3.txt")
+	err = os.WriteFile(tempFile3, []byte("This is file 3"), 0644)
+	assert.NoError(t, err)
+	// create a subdirectory in the temp dir
+	tempSubDir2 := filepath.Join(tempDir, "subdir2")
+	err = os.Mkdir(tempSubDir2, 0755)
+	assert.NoError(t, err)
+	// add a subdirectory to the temp subdirectory
+	tempSubSubDir := filepath.Join(tempSubDir2, "subsubdir")
+	err = os.Mkdir(tempSubSubDir, 0755)
+	assert.NoError(t, err)
+	// add a file to the temp subdirectory
+	tempSubFile := filepath.Join(tempSubSubDir, "subfile.txt")
+	err = os.WriteFile(tempSubFile, []byte("This is a subfile"), 0644)
+	assert.NoError(t, err)
+
+	targetDir := filepath.Join(tempDir, "target")
+	err = os.Mkdir(targetDir, 0755)
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		sourceDir     string
+		targetDir     string
+		expectedError error
+	}{
+		{
+			name:      "Valid copy",
+			sourceDir: tempSubDir,
+			targetDir: targetDir,
+		},
+		{
+			name:          "Source and target are the same",
+			sourceDir:     tempSubDir2,
+			targetDir:     tempSubDir2,
+			expectedError: fmt.Errorf("cannot copy directory from '%s' to '%s', because the source and destination are the same", tempSubDir2, tempSubDir2),
+		},
+		{
+			name:      "Source is a subdirectory of target",
+			sourceDir: tempSubDir2,
+			targetDir: tempDir,
+		},
+		{
+			name:          "Target is subdirectory of source",
+			sourceDir:     tempDir,
+			targetDir:     tempSubDir2,
+			expectedError: fmt.Errorf("cannot copy directory from '%s' to '%s', because the destination is a subdirectory of the source", tempDir, tempSubDir2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sourcePath := tc.sourceDir
+			targetPath := tc.targetDir
+
+			err := CopyDir(sourcePath, targetPath, true, nil)
+
+			if tc.expectedError != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+
+				// Verify that the target directory exists
+				_, err = os.Stat(targetPath)
+				assert.NoError(t, err)
+
+				// Verify that the contents of the source exists in the target directory after copying
+				sourceFiles, err := os.ReadDir(sourcePath)
+				assert.NoError(t, err)
+				targetFiles, err := os.ReadDir(targetPath)
+				assert.NoError(t, err)
+
+				assert.GreaterOrEqual(t, len(targetFiles), len(sourceFiles))
+			}
+		})
+	}
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

If a user trys to copy a directory to the same path, it causes recursion and results in recursion error:
```
15:46:14 [Error] open /tmp/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/jfrog.cli.temp.-1748187845-3235690346/Python-3.12.9/Lib/test/test_tomllib/data/invalid/multiline-basic-str/unclosed-ends-in-whitespace-escape.toml: file name too long
```

This PR detects this case and output a detailed error to notify the user about the issue when using this function