### PR TITLE
Add verbose log level

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -456,7 +456,7 @@ func RunNpmCmd(executablePath, srcPath string, npmArgs []string, log utils.Log) 
 		err = fmt.Errorf("error while running '%s %s': %s\n%s", executablePath, strings.Join(args, " "), err.Error(), strings.TrimSpace(string(errResult)))
 		return
 	}
-	log.Debug("npm '" + strings.Join(args, " ") + "' standard output is:\n" + strings.TrimSpace(string(stdResult)))
+	log.Verbose("npm '" + strings.Join(args, " ") + "' standard output is:\n" + strings.TrimSpace(string(stdResult)))
 	return
 }
 

--- a/utils/goutils.go
+++ b/utils/goutils.go
@@ -171,7 +171,7 @@ func runDependenciesCmd(projectDir string, commandArgs []string, log Log) (outpu
 		output, errorOut, _, executionError = gofrogcmd.RunCmdWithOutputParser(goCmd, false)
 	}
 	if len(output) != 0 {
-		log.Debug(output)
+		log.Verbose(output)
 	}
 	if executionError != nil {
 		// If the command fails, the mod stays the same, therefore, don't need to be restored.

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -12,9 +12,11 @@ const (
 	WARN
 	INFO
 	DEBUG
+	VERBOSE
 )
 
 type Log interface {
+	Verbose(a ...interface{})
 	Debug(a ...interface{})
 	Info(a ...interface{})
 	Warn(a ...interface{})
@@ -24,6 +26,9 @@ type Log interface {
 
 // NullLog is a logger that does nothing
 type NullLog struct {
+}
+
+func (nl *NullLog) Verbose(...interface{}) {
 }
 
 func (nl *NullLog) Debug(...interface{}) {
@@ -42,12 +47,13 @@ func (nl *NullLog) Output(...interface{}) {
 }
 
 type defaultLogger struct {
-	logLevel  LevelType
-	outputLog *log.Logger
-	debugLog  *log.Logger
-	infoLog   *log.Logger
-	warnLog   *log.Logger
-	errorLog  *log.Logger
+	logLevel   LevelType
+	outputLog  *log.Logger
+	verboseLog *log.Logger
+	debugLog   *log.Logger
+	infoLog    *log.Logger
+	warnLog    *log.Logger
+	errorLog   *log.Logger
 }
 
 // NewDefaultLogger creates a new logger with a given LogLevel.
@@ -56,11 +62,18 @@ func NewDefaultLogger(logLevel LevelType) *defaultLogger {
 	logger := new(defaultLogger)
 	logger.logLevel = logLevel
 	logger.outputLog = log.New(os.Stdout, "", 0)
+	logger.verboseLog = log.New(os.Stderr, "[Verbose] ", 0)
 	logger.debugLog = log.New(os.Stderr, "[Debug] ", 0)
 	logger.infoLog = log.New(os.Stderr, "[Info] ", 0)
 	logger.warnLog = log.New(os.Stderr, "[Warn] ", 0)
 	logger.errorLog = log.New(os.Stderr, "[Error] ", 0)
 	return logger
+}
+
+func (logger defaultLogger) Verbose(a ...interface{}) {
+	if logger.logLevel >= VERBOSE {
+		logger.verboseLog.Println(a...)
+	}
 }
 
 func (logger defaultLogger) Debug(a ...interface{}) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

Add new log level `verbose` lower than `Debug`.
Make some of the pacakge manager commands output logs to be in the new level to prevent big logs in debug level