### PR TITLE
RTECO-992 - Added support for uv package manager

### DIFF
--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -271,9 +271,14 @@ func mergeArtifacts(mergeArtifacts *[]Artifact, intoArtifacts *[]Artifact) {
 	for _, newArtifact := range *mergeArtifacts {
 		exists := false
 
-		// PRIORITY 1: Check SHA1 - if checksums match, artifact already exists (skip it)
-		for _, existingArtifact := range *intoArtifacts {
+		// PRIORITY 1: Check SHA1 - if checksums match, prefer the artifact with a real path.
+		// path="." means the artifact was recorded locally before upload; a non-"." path
+		// means it was confirmed in Artifactory. Always keep the richer entry.
+		for i, existingArtifact := range *intoArtifacts {
 			if newArtifact.Sha1 == existingArtifact.Sha1 {
+				if existingArtifact.Path == "." && newArtifact.Path != "." {
+					(*intoArtifacts)[i] = newArtifact
+				}
 				exists = true
 				break
 			}

--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -46,6 +46,7 @@ const (
 	Terraform ModuleType = "terraform"
 	Helm      ModuleType = "helm"
 	Conan     ModuleType = "conan"
+	Uv        ModuleType = "uv"
 )
 
 type BuildInfo struct {

--- a/flexpack/flexpack.go
+++ b/flexpack/flexpack.go
@@ -70,6 +70,15 @@ type PoetryConfig struct {
 	IncludeDevDependencies bool
 }
 
+// UvConfig holds configuration specific to UV operations
+type UvConfig struct {
+	// WorkingDirectory is the directory where UV should operate
+	WorkingDirectory string
+
+	// IncludeDevDependencies indicates whether to include development dependencies
+	IncludeDevDependencies bool
+}
+
 // GradleConfig holds configuration specific to Gradle operations
 type GradleConfig struct {
 	// WorkingDirectory is the directory where Gradle should operate

--- a/flexpack/flexpack.go
+++ b/flexpack/flexpack.go
@@ -29,7 +29,7 @@ type FlexPackManager interface {
 	CalculateScopes() []string
 
 	// CalculateRequestedBy determines which dependencies requested a particular package
-	// Returns information about the dependency relationship hierarchy
+	// Returns information about the dependency relationship hierarchy.
 	CalculateRequestedBy() map[string][]string
 }
 
@@ -40,7 +40,7 @@ type DependencyInfo struct {
 	SHA256       string           `json:"sha256"`
 	MD5          string           `json:"md5"`
 	ID           string           `json:"id"`
-	Scopes       []string         `json:"scopes"`
+	Scopes       []string         `json:"scopes,omitempty"`
 	RequestedBy  []string         `json:"requestedBy,omitempty"`
 	Version      string           `json:"version"`
 	Name         string           `json:"name"`

--- a/flexpack/flexpack.go
+++ b/flexpack/flexpack.go
@@ -47,6 +47,9 @@ type DependencyInfo struct {
 	Path         string           `json:"path,omitempty"`
 	Repository   string           `json:"-"`
 	Dependencies []DependencyInfo `json:"dependencies,omitempty"`
+	// DirectURL is set for packages installed from a direct URL (not a registry).
+	// These packages are not in Artifactory so sha1/md5 enrichment is skipped.
+	DirectURL string `json:"-"`
 }
 
 // BuildInfoCollector defines methods for collecting build information
@@ -75,8 +78,26 @@ type UVConfig struct {
 	// WorkingDirectory is the directory where UV should operate
 	WorkingDirectory string
 
-	// IncludeDevDependencies indicates whether to include development dependencies
+	// IncludeDevDependencies indicates whether to include development dependencies.
+	// Only used when InstalledPackages is nil (e.g. for lock/build commands where no
+	// venv is available). When InstalledPackages is set this field is ignored.
 	IncludeDevDependencies bool
+
+	// InstalledPackages is the ground-truth set of what uv actually installed,
+	// keyed by normalised package name (lowercase, hyphens) → version string.
+	// When non-nil, only packages present in this map are included in build-info,
+	// which correctly handles --no-dev, --only-dev, --group, --no-group and all
+	// other uv sync flag combinations without any flag parsing on our side.
+	InstalledPackages map[string]string
+
+	// LockFilePath overrides the default uv.lock path. Used for PEP 723 inline scripts
+	// where the lock file is adjacent to the script (e.g. myscript.py.lock).
+	LockFilePath string
+
+	// ProjectName and ProjectVersion override the values read from pyproject.toml.
+	// Set these when there is no pyproject.toml (e.g. for standalone PEP 723 scripts).
+	ProjectName    string
+	ProjectVersion string
 }
 
 // GradleConfig holds configuration specific to Gradle operations

--- a/flexpack/flexpack.go
+++ b/flexpack/flexpack.go
@@ -70,8 +70,8 @@ type PoetryConfig struct {
 	IncludeDevDependencies bool
 }
 
-// UvConfig holds configuration specific to UV operations
-type UvConfig struct {
+// UVConfig holds configuration specific to UV operations
+type UVConfig struct {
 	// WorkingDirectory is the directory where UV should operate
 	WorkingDirectory string
 

--- a/flexpack/poetry_flexpack.go
+++ b/flexpack/poetry_flexpack.go
@@ -725,7 +725,7 @@ func (pf *PoetryFlexPack) CollectBuildInfo(buildName, buildNumber string) (*enti
 			},
 		}
 
-		// Add RequestedBy information
+		// Add RequestedBy information (wrap []string into [][]string per build-info spec)
 		if len(dep.RequestedBy) > 0 {
 			entityDep.RequestedBy = [][]string{dep.RequestedBy}
 		}

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // minimalPyproject returns a minimal valid PEP 621 pyproject.toml content.
-func minimalPyproject(name, version string) string {
-	return "[project]\nname = \"" + name + "\"\nversion = \"" + version + "\"\n"
+func minimalPyproject(name string) string {
+	return "[project]\nname = \"" + name + "\"\nversion = \"1.0.0\"\n"
 }
 
 // minimalUvLock returns a uv.lock with a virtual root and one registry package.
@@ -46,7 +46,7 @@ func writeTempFiles(t *testing.T, dir string, files map[string]string) {
 func TestNewUvFlexPack(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("test-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("test-app"),
 		"uv.lock":        minimalUvLock("test-app"),
 	})
 
@@ -71,7 +71,7 @@ func TestNewUvFlexPack(t *testing.T) {
 func TestUvCollectBuildInfoModuleType(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("test-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("test-app"),
 		"uv.lock":        minimalUvLock("test-app"),
 	})
 
@@ -113,7 +113,7 @@ hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
 size = 62574
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -158,7 +158,7 @@ hash = "sha256:aaaabbbbccccddddeeeeffffaaaabbbbccccddddeeeeffffaaaabbbbccccdddd"
 size = 158
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -195,7 +195,7 @@ version = "0.1.0"
 source = { git = "https://github.com/example/some-lib?tag=v0.1.0#abcdef1234567890abcdef1234567890abcdef12" }
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -261,7 +261,7 @@ size = 324467
 	t.Run("include dev deps", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+			"pyproject.toml": minimalPyproject("my-app"),
 			"uv.lock":        uvLockContent,
 		})
 
@@ -282,8 +282,9 @@ size = 324467
 		for _, dep := range deps {
 			if dep.Name == "pytest" {
 				found = true
-				if len(dep.Scopes) == 0 || dep.Scopes[0] != "test" {
-					t.Errorf("Expected scope 'test' for dev dep, got %v", dep.Scopes)
+				// No scopes — Python has no compile/runtime distinction (matches pip/pipenv)
+				if len(dep.Scopes) != 0 {
+					t.Errorf("Expected no scopes for dev dep (Python has no scope distinction), got %v", dep.Scopes)
 				}
 				break
 			}
@@ -296,7 +297,7 @@ size = 324467
 	t.Run("exclude dev deps", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+			"pyproject.toml": minimalPyproject("my-app"),
 			"uv.lock":        uvLockContent,
 		})
 
@@ -321,7 +322,7 @@ size = 324467
 	})
 }
 
-// TestUvWheelSelectionNoneAny verifies that bestHash/depFilename prefer the
+// TestUvWheelSelectionNoneAny verifies that bestHash/depFileType prefer the
 // pure-Python none-any wheel over platform-specific wheels, and fall back to
 // the first available wheel when none-any is absent.
 func TestUvWheelSelectionNoneAny(t *testing.T) {
@@ -354,7 +355,7 @@ hash = "sha256:windows0000000000000000000000000000000000000000000000000000000000
 size = 1100
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -370,9 +371,12 @@ size = 1100
 		t.Fatal("Expected at least one dependency")
 	}
 	dep := deps[0]
-	// The none-any wheel must be selected over platform-specific wheels
-	if dep.ID != "multiplatform_pkg-1.0.0-py3-none-any.whl" {
-		t.Errorf("Expected none-any wheel filename, got %q", dep.ID)
+	// ID is now name:version (pip format); sha256 still uses none-any wheel hash
+	if dep.ID != "multiplatform-pkg:1.0.0" {
+		t.Errorf("Expected name:version ID, got %q", dep.ID)
+	}
+	if dep.Type != "whl" {
+		t.Errorf("Expected type 'whl', got %q", dep.Type)
 	}
 	if dep.SHA256 != "noneany00000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Expected none-any sha256, got %q", dep.SHA256)
@@ -406,7 +410,7 @@ hash = "sha256:secondwheel00000000000000000000000000000000000000000000000000000"
 size = 2100
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -422,9 +426,12 @@ size = 2100
 		t.Fatal("Expected at least one dependency")
 	}
 	dep := deps[0]
-	// First wheel must be selected when no none-any wheel exists
-	if dep.ID != "platform_only_pkg-2.0.0-cp311-cp311-linux_x86_64.whl" {
-		t.Errorf("Expected first wheel filename as fallback, got %q", dep.ID)
+	// ID is name:version; type is the file extension of the selected wheel
+	if dep.ID != "platform-only-pkg:2.0.0" {
+		t.Errorf("Expected name:version ID, got %q", dep.ID)
+	}
+	if dep.Type != "whl" {
+		t.Errorf("Expected type 'whl', got %q", dep.Type)
 	}
 	if dep.SHA256 != "firstwheel000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Expected first wheel sha256, got %q", dep.SHA256)
@@ -453,7 +460,7 @@ hash = "sha256:sdist000000000000000000000000000000000000000000000000000000000000
 size = 5000
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -469,8 +476,12 @@ size = 5000
 		t.Fatal("Expected at least one dependency")
 	}
 	dep := deps[0]
-	if dep.ID != "sdist_only_pkg-3.0.0.tar.gz" {
-		t.Errorf("Expected sdist filename, got %q", dep.ID)
+	// ID is name:version; type is tar.gz for sdist
+	if dep.ID != "sdist-only-pkg:3.0.0" {
+		t.Errorf("Expected name:version ID, got %q", dep.ID)
+	}
+	if dep.Type != "tar.gz" {
+		t.Errorf("Expected type 'tar.gz', got %q", dep.Type)
 	}
 	if dep.SHA256 != "sdist000000000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Expected sdist sha256, got %q", dep.SHA256)
@@ -529,7 +540,7 @@ hash = "sha256:cccc000000000000000000000000000000000000000000000000000000000000"
 size = 100
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -537,53 +548,45 @@ size = 100
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
-	deps, err := uf.GetProjectDependencies()
-	if err != nil {
+	if _, err := uf.GetProjectDependencies(); err != nil {
 		t.Fatalf("GetProjectDependencies failed: %v", err)
 	}
 
-	depByName := make(map[string]flexpack.DependencyInfo)
-	for _, d := range deps {
-		depByName[d.Name] = d
-	}
+	// Use GetRequestedByChains() to inspect full [][]string chains (UV-specific).
+	// DependencyInfo.RequestedBy is []string (shared type); chains are stored separately.
+	chains := uf.GetRequestedByChains()
 
-	// pkgb must report pkga as its requester
-	pkgb, ok := depByName["pkgb"]
-	if !ok {
-		t.Fatal("Expected pkgb in dependencies")
-	}
-	if len(pkgb.RequestedBy) == 0 {
-		t.Error("pkgb.RequestedBy should be non-empty (requested by pkga)")
+	// pkgb must report pkga as its direct requester (chain: [pkga:1.0.0, my-app:1.0.0])
+	pkgbChains, ok := chains["pkgb:1.0.0"]
+	if !ok || len(pkgbChains) == 0 {
+		t.Error("pkgb:1.0.0 should have at least one requestedBy chain (requested by pkga)")
 	} else {
 		found := false
-		for _, rb := range pkgb.RequestedBy {
-			if rb == "pkga" {
+		for _, chain := range pkgbChains {
+			if len(chain) > 0 && chain[0] == "pkga:1.0.0" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("pkgb.RequestedBy should contain 'pkga', got %v", pkgb.RequestedBy)
+			t.Errorf("pkgb:1.0.0 requestedBy chains should start with 'pkga:1.0.0', got %v", pkgbChains)
 		}
 	}
 
-	// pkgc must report pkgb as its requester
-	pkgc, ok := depByName["pkgc"]
-	if !ok {
-		t.Fatal("Expected pkgc in dependencies")
-	}
-	if len(pkgc.RequestedBy) == 0 {
-		t.Error("pkgc.RequestedBy should be non-empty (requested by pkgb)")
+	// pkgc must report pkgb as its direct requester (chain: [pkgb:1.0.0, pkga:1.0.0, my-app:1.0.0])
+	pkgcChains, ok2 := chains["pkgc:1.0.0"]
+	if !ok2 || len(pkgcChains) == 0 {
+		t.Error("pkgc:1.0.0 should have at least one requestedBy chain (requested by pkgb)")
 	} else {
 		found := false
-		for _, rb := range pkgc.RequestedBy {
-			if rb == "pkgb" {
+		for _, chain := range pkgcChains {
+			if len(chain) > 0 && chain[0] == "pkgb:1.0.0" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("pkgc.RequestedBy should contain 'pkgb', got %v", pkgc.RequestedBy)
+			t.Errorf("pkgc:1.0.0 requestedBy chains should start with 'pkgb:1.0.0', got %v", pkgcChains)
 		}
 	}
 }
@@ -630,7 +633,7 @@ hash = "sha256:url00000000000000000000000000000000000000000000000000000000000000
 size = 124424
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -657,8 +660,9 @@ size = 124424
 	}
 }
 
-// TestUvScopeClassification verifies that direct production dependencies get
-// scope "compile" and direct dev dependencies get scope "test".
+// TestUvDevDepInclusion verifies that dev deps are excluded by default and
+// included when IncludeDevDependencies=true. No scopes are set (Python has no
+// compile/runtime distinction — matches pip/pipenv canonical format).
 func TestUvScopeClassification(t *testing.T) {
 	tempDir := t.TempDir()
 	uvLockContent := `version = 1
@@ -697,7 +701,7 @@ hash = "sha256:pytest00000000000000000000000000000000000000000000000000000000000
 size = 324467
 `
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"pyproject.toml": minimalPyproject("my-app"),
 		"uv.lock":        uvLockContent,
 	})
 
@@ -722,16 +726,21 @@ size = 324467
 	if !ok {
 		t.Fatal("Expected certifi in dependencies")
 	}
-	if len(certifi.Scopes) == 0 || certifi.Scopes[0] != "compile" {
-		t.Errorf("certifi (direct production dep) should have scope 'compile', got %v", certifi.Scopes)
+	// No scopes — Python has no compile/runtime distinction (matches pip/pipenv)
+	if len(certifi.Scopes) != 0 {
+		t.Errorf("certifi should have no scopes (Python has no compile/runtime distinction), got %v", certifi.Scopes)
+	}
+	if certifi.Type != "whl" {
+		t.Errorf("certifi type should be 'whl', got %q", certifi.Type)
 	}
 
 	pytest, ok := depByName["pytest"]
 	if !ok {
 		t.Fatal("Expected pytest in dependencies (IncludeDevDependencies=true)")
 	}
-	if len(pytest.Scopes) == 0 || pytest.Scopes[0] != "test" {
-		t.Errorf("pytest (dev dep) should have scope 'test', got %v", pytest.Scopes)
+	// Dev deps also have no scopes in the new format
+	if len(pytest.Scopes) != 0 {
+		t.Errorf("pytest should have no scopes, got %v", pytest.Scopes)
 	}
 }
 
@@ -758,7 +767,7 @@ func TestUvErrorHandling(t *testing.T) {
 	t.Run("pyproject.toml present but no uv.lock", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+			"pyproject.toml": minimalPyproject("my-app"),
 		})
 
 		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -50,7 +50,7 @@ func TestNewUvFlexPack(t *testing.T) {
 		"uv.lock":        minimalUvLock("test-app"),
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestUvCollectBuildInfoModuleType(t *testing.T) {
 		"uv.lock":        minimalUvLock("test-app"),
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -117,7 +117,7 @@ size = 62574
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -162,7 +162,7 @@ size = 158
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -199,7 +199,7 @@ source = { git = "https://github.com/example/some-lib?tag=v0.1.0#abcdef123456789
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -265,7 +265,7 @@ size = 324467
 			"uv.lock":        uvLockContent,
 		})
 
-		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 			WorkingDirectory:       tempDir,
 			IncludeDevDependencies: true,
 		})
@@ -301,7 +301,7 @@ size = 324467
 			"uv.lock":        uvLockContent,
 		})
 
-		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 			WorkingDirectory:       tempDir,
 			IncludeDevDependencies: false,
 		})
@@ -359,7 +359,7 @@ size = 1100
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -414,7 +414,7 @@ size = 2100
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -464,7 +464,7 @@ size = 5000
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -544,7 +544,7 @@ size = 100
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -637,7 +637,7 @@ size = 124424
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
 		t.Fatalf("NewUvFlexPack failed: %v", err)
 	}
@@ -706,7 +706,7 @@ size = 324467
 		"uv.lock":        uvLockContent,
 	})
 
-	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 		WorkingDirectory:       tempDir,
 		IncludeDevDependencies: true,
 	})
@@ -747,7 +747,7 @@ size = 324467
 
 func TestUvErrorHandling(t *testing.T) {
 	t.Run("non-existent dir", func(t *testing.T) {
-		_, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 			WorkingDirectory: "/non/existent/directory",
 		})
 		if err == nil {
@@ -757,7 +757,7 @@ func TestUvErrorHandling(t *testing.T) {
 
 	t.Run("dir with no pyproject.toml", func(t *testing.T) {
 		tempDir := t.TempDir()
-		_, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 			WorkingDirectory: tempDir,
 		})
 		if err == nil {
@@ -771,7 +771,7 @@ func TestUvErrorHandling(t *testing.T) {
 			"pyproject.toml": minimalPyproject("my-app"),
 		})
 
-		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
 			WorkingDirectory: tempDir,
 		})
 		if err != nil {

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -1,0 +1,779 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/build-info-go/flexpack"
+)
+
+// minimalPyproject returns a minimal valid PEP 621 pyproject.toml content.
+func minimalPyproject(name, version string) string {
+	return "[project]\nname = \"" + name + "\"\nversion = \"" + version + "\"\n"
+}
+
+// minimalUvLock returns a uv.lock with a virtual root and one registry package.
+func minimalUvLock(projectName string) string {
+	return `version = 1
+
+[[package]]
+name = "` + projectName + `"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl"
+hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+size = 62574
+`
+}
+
+func writeTempFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to write %s: %v", name, err)
+		}
+	}
+}
+
+func TestNewUvFlexPack(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("test-app", "1.0.0"),
+		"uv.lock":        minimalUvLock("test-app"),
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+
+	if len(buildInfo.Modules) == 0 {
+		t.Fatal("Expected at least one module")
+	}
+	if buildInfo.Modules[0].Id != "test-app:1.0.0" {
+		t.Errorf("Expected module ID 'test-app:1.0.0', got '%s'", buildInfo.Modules[0].Id)
+	}
+}
+
+func TestUvCollectBuildInfoModuleType(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("test-app", "1.0.0"),
+		"uv.lock":        minimalUvLock("test-app"),
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+
+	if len(buildInfo.Modules) == 0 {
+		t.Fatal("Expected at least one module")
+	}
+	if buildInfo.Modules[0].Type != "uv" {
+		t.Errorf("Expected module type 'uv', got '%s'", buildInfo.Modules[0].Type)
+	}
+}
+
+func TestUvHashExtraction(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl"
+hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+size = 62574
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	if len(deps) == 0 {
+		t.Fatal("Expected at least one dependency")
+	}
+
+	// SHA256 should be stripped of the "sha256:" prefix
+	expectedSHA256 := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	if deps[0].SHA256 != expectedSHA256 {
+		t.Errorf("Expected SHA256 '%s', got '%s'", expectedSHA256, deps[0].SHA256)
+	}
+}
+
+func TestUvVirtualSourceSkipped(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "certifi"
+version = "2023.7.22"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/certifi-2023.7.22-py3-none-any.whl"
+hash = "sha256:aaaabbbbccccddddeeeeffffaaaabbbbccccddddeeeeffffaaaabbbbccccdddd"
+size = 158
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	// my-app (virtual source) must not appear in deps
+	for _, dep := range deps {
+		if dep.Name == "my-app" {
+			t.Errorf("Virtual source package 'my-app' should not appear in dependencies")
+		}
+	}
+}
+
+func TestUvGitDependency(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "some-lib"
+version = "0.1.0"
+source = { git = "https://github.com/example/some-lib?tag=v0.1.0#abcdef1234567890abcdef1234567890abcdef12" }
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	found := false
+	for _, dep := range deps {
+		if dep.Name == "some-lib" {
+			found = true
+			if dep.SHA256 != "" {
+				t.Errorf("Expected empty SHA256 for git dependency, got '%s'", dep.SHA256)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected git dependency 'some-lib' to appear in dependencies")
+	}
+}
+
+func TestUvDevDependencies(t *testing.T) {
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl"
+hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+size = 62574
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/pytest-7.4.0-py3-none-any.whl"
+hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+size = 324467
+`
+
+	t.Run("include dev deps", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+			"uv.lock":        uvLockContent,
+		})
+
+		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+			WorkingDirectory:       tempDir,
+			IncludeDevDependencies: true,
+		})
+		if err != nil {
+			t.Fatalf("NewUvFlexPack failed: %v", err)
+		}
+
+		deps, err := uf.GetProjectDependencies()
+		if err != nil {
+			t.Fatalf("GetProjectDependencies failed: %v", err)
+		}
+
+		found := false
+		for _, dep := range deps {
+			if dep.Name == "pytest" {
+				found = true
+				if len(dep.Scopes) == 0 || dep.Scopes[0] != "test" {
+					t.Errorf("Expected scope 'test' for dev dep, got %v", dep.Scopes)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected 'pytest' dev dependency to be included when IncludeDevDependencies=true")
+		}
+	})
+
+	t.Run("exclude dev deps", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+			"uv.lock":        uvLockContent,
+		})
+
+		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+			WorkingDirectory:       tempDir,
+			IncludeDevDependencies: false,
+		})
+		if err != nil {
+			t.Fatalf("NewUvFlexPack failed: %v", err)
+		}
+
+		deps, err := uf.GetProjectDependencies()
+		if err != nil {
+			t.Fatalf("GetProjectDependencies failed: %v", err)
+		}
+
+		for _, dep := range deps {
+			if dep.Name == "pytest" {
+				t.Error("Expected 'pytest' dev dependency to be excluded when IncludeDevDependencies=false")
+			}
+		}
+	})
+}
+
+// TestUvWheelSelectionNoneAny verifies that bestHash/depFilename prefer the
+// pure-Python none-any wheel over platform-specific wheels, and fall back to
+// the first available wheel when none-any is absent.
+func TestUvWheelSelectionNoneAny(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "multiplatform-pkg"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/multiplatform_pkg-1.0.0-cp311-cp311-linux_x86_64.whl"
+hash = "sha256:linux000000000000000000000000000000000000000000000000000000000000"
+size = 1000
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/multiplatform_pkg-1.0.0-py3-none-any.whl"
+hash = "sha256:noneany00000000000000000000000000000000000000000000000000000000"
+size = 900
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/multiplatform_pkg-1.0.0-cp311-cp311-win_amd64.whl"
+hash = "sha256:windows0000000000000000000000000000000000000000000000000000000000"
+size = 1100
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatal("Expected at least one dependency")
+	}
+	dep := deps[0]
+	// The none-any wheel must be selected over platform-specific wheels
+	if dep.ID != "multiplatform_pkg-1.0.0-py3-none-any.whl" {
+		t.Errorf("Expected none-any wheel filename, got %q", dep.ID)
+	}
+	if dep.SHA256 != "noneany00000000000000000000000000000000000000000000000000000000" {
+		t.Errorf("Expected none-any sha256, got %q", dep.SHA256)
+	}
+}
+
+// TestUvWheelSelectionFirstFallback verifies that when there is no none-any wheel,
+// the first wheel in the list is used as a fallback.
+func TestUvWheelSelectionFirstFallback(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "platform-only-pkg"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/platform_only_pkg-2.0.0-cp311-cp311-linux_x86_64.whl"
+hash = "sha256:firstwheel000000000000000000000000000000000000000000000000000000"
+size = 2000
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/platform_only_pkg-2.0.0-cp311-cp311-win_amd64.whl"
+hash = "sha256:secondwheel00000000000000000000000000000000000000000000000000000"
+size = 2100
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatal("Expected at least one dependency")
+	}
+	dep := deps[0]
+	// First wheel must be selected when no none-any wheel exists
+	if dep.ID != "platform_only_pkg-2.0.0-cp311-cp311-linux_x86_64.whl" {
+		t.Errorf("Expected first wheel filename as fallback, got %q", dep.ID)
+	}
+	if dep.SHA256 != "firstwheel000000000000000000000000000000000000000000000000000000" {
+		t.Errorf("Expected first wheel sha256, got %q", dep.SHA256)
+	}
+}
+
+// TestUvWheelSelectionSdistFallback verifies that when no wheels are present,
+// the sdist entry is used as a fallback.
+func TestUvWheelSelectionSdistFallback(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "sdist-only-pkg"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[package.sdist]
+url = "https://files.pythonhosted.org/packages/sdist_only_pkg-3.0.0.tar.gz"
+hash = "sha256:sdist000000000000000000000000000000000000000000000000000000000000"
+size = 5000
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatal("Expected at least one dependency")
+	}
+	dep := deps[0]
+	if dep.ID != "sdist_only_pkg-3.0.0.tar.gz" {
+		t.Errorf("Expected sdist filename, got %q", dep.ID)
+	}
+	if dep.SHA256 != "sdist000000000000000000000000000000000000000000000000000000000000" {
+		t.Errorf("Expected sdist sha256, got %q", dep.SHA256)
+	}
+}
+
+// TestUvRequestedByChain verifies that the requestedBy inverse mapping is
+// constructed correctly from a transitive dependency chain: root→A→B→C.
+// C.requestedBy should contain B, B.requestedBy should contain A.
+func TestUvRequestedByChain(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package.dependencies]]
+name = "pkga"
+
+[[package]]
+name = "pkga"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.dependencies]]
+name = "pkgb"
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/pkga-1.0.0-py3-none-any.whl"
+hash = "sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+size = 100
+
+[[package]]
+name = "pkgb"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.dependencies]]
+name = "pkgc"
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/pkgb-1.0.0-py3-none-any.whl"
+hash = "sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+size = 100
+
+[[package]]
+name = "pkgc"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/pkgc-1.0.0-py3-none-any.whl"
+hash = "sha256:cccc000000000000000000000000000000000000000000000000000000000000"
+size = 100
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	depByName := make(map[string]flexpack.DependencyInfo)
+	for _, d := range deps {
+		depByName[d.Name] = d
+	}
+
+	// pkgb must report pkga as its requester
+	pkgb, ok := depByName["pkgb"]
+	if !ok {
+		t.Fatal("Expected pkgb in dependencies")
+	}
+	if len(pkgb.RequestedBy) == 0 {
+		t.Error("pkgb.RequestedBy should be non-empty (requested by pkga)")
+	} else {
+		found := false
+		for _, rb := range pkgb.RequestedBy {
+			if rb == "pkga" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("pkgb.RequestedBy should contain 'pkga', got %v", pkgb.RequestedBy)
+		}
+	}
+
+	// pkgc must report pkgb as its requester
+	pkgc, ok := depByName["pkgc"]
+	if !ok {
+		t.Fatal("Expected pkgc in dependencies")
+	}
+	if len(pkgc.RequestedBy) == 0 {
+		t.Error("pkgc.RequestedBy should be non-empty (requested by pkgb)")
+	} else {
+		found := false
+		for _, rb := range pkgc.RequestedBy {
+			if rb == "pkgb" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("pkgc.RequestedBy should contain 'pkgb', got %v", pkgc.RequestedBy)
+		}
+	}
+}
+
+// TestUvMultipleDependencies verifies that all direct dependencies declared in
+// pyproject.toml appear in the build info with correct count.
+func TestUvMultipleDependencies(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "certifi"
+version = "2024.2.2"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/certifi-2024.2.2-py3-none-any.whl"
+hash = "sha256:cert00000000000000000000000000000000000000000000000000000000000000"
+size = 163674
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl"
+hash = "sha256:reqs00000000000000000000000000000000000000000000000000000000000000"
+size = 62574
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/urllib3-2.0.7-py3-none-any.whl"
+hash = "sha256:url000000000000000000000000000000000000000000000000000000000000000"
+size = 124424
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	if len(deps) != 3 {
+		t.Errorf("Expected 3 dependencies (certifi, requests, urllib3), got %d", len(deps))
+	}
+	names := make(map[string]bool)
+	for _, d := range deps {
+		names[d.Name] = true
+	}
+	for _, expected := range []string{"certifi", "requests", "urllib3"} {
+		if !names[expected] {
+			t.Errorf("Expected dependency %q not found in: %v", expected, deps)
+		}
+	}
+}
+
+// TestUvScopeClassification verifies that direct production dependencies get
+// scope "compile" and direct dev dependencies get scope "test".
+func TestUvScopeClassification(t *testing.T) {
+	tempDir := t.TempDir()
+	uvLockContent := `version = 1
+
+[[package]]
+name = "my-app"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package.dependencies]]
+name = "certifi"
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[[package]]
+name = "certifi"
+version = "2024.2.2"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/certifi-2024.2.2-py3-none-any.whl"
+hash = "sha256:cert00000000000000000000000000000000000000000000000000000000000000"
+size = 163674
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package.wheels]]
+url = "https://files.pythonhosted.org/packages/pytest-7.4.0-py3-none-any.whl"
+hash = "sha256:pytest00000000000000000000000000000000000000000000000000000000000"
+size = 324467
+`
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		"uv.lock":        uvLockContent,
+	})
+
+	uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+		WorkingDirectory:       tempDir,
+		IncludeDevDependencies: true,
+	})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		t.Fatalf("GetProjectDependencies failed: %v", err)
+	}
+
+	depByName := make(map[string]flexpack.DependencyInfo)
+	for _, d := range deps {
+		depByName[d.Name] = d
+	}
+
+	certifi, ok := depByName["certifi"]
+	if !ok {
+		t.Fatal("Expected certifi in dependencies")
+	}
+	if len(certifi.Scopes) == 0 || certifi.Scopes[0] != "compile" {
+		t.Errorf("certifi (direct production dep) should have scope 'compile', got %v", certifi.Scopes)
+	}
+
+	pytest, ok := depByName["pytest"]
+	if !ok {
+		t.Fatal("Expected pytest in dependencies (IncludeDevDependencies=true)")
+	}
+	if len(pytest.Scopes) == 0 || pytest.Scopes[0] != "test" {
+		t.Errorf("pytest (dev dep) should have scope 'test', got %v", pytest.Scopes)
+	}
+}
+
+func TestUvErrorHandling(t *testing.T) {
+	t.Run("non-existent dir", func(t *testing.T) {
+		_, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+			WorkingDirectory: "/non/existent/directory",
+		})
+		if err == nil {
+			t.Error("Expected error for non-existent directory")
+		}
+	})
+
+	t.Run("dir with no pyproject.toml", func(t *testing.T) {
+		tempDir := t.TempDir()
+		_, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+			WorkingDirectory: tempDir,
+		})
+		if err == nil {
+			t.Error("Expected error when pyproject.toml is missing")
+		}
+	})
+
+	t.Run("pyproject.toml present but no uv.lock", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": minimalPyproject("my-app", "1.0.0"),
+		})
+
+		uf, err := flexpack.NewUvFlexPack(flexpack.UvConfig{
+			WorkingDirectory: tempDir,
+		})
+		if err != nil {
+			t.Fatalf("Expected constructor to succeed without uv.lock, got: %v", err)
+		}
+
+		deps, err := uf.GetProjectDependencies()
+		if err != nil {
+			t.Fatalf("GetProjectDependencies failed: %v", err)
+		}
+		if len(deps) != 0 {
+			t.Errorf("Expected empty dependency list without uv.lock, got %d deps", len(deps))
+		}
+	})
+}

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -660,9 +660,10 @@ size = 124424
 	}
 }
 
-// TestUvDevDepInclusion verifies that dev deps are excluded by default and
-// included when IncludeDevDependencies=true. No scopes are set (Python has no
-// compile/runtime distinction — matches pip/pipenv canonical format).
+// TestUvScopeClassification verifies that no scope field is set on any dependency
+// (neither main nor dev), because Python has no compile/runtime distinction —
+// matches pip/pipenv canonical format. Dev dep inclusion behaviour is covered by
+// TestUvDevDependencies.
 func TestUvScopeClassification(t *testing.T) {
 	tempDir := t.TempDir()
 	uvLockContent := `version = 1

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -13,26 +13,26 @@ import (
 	"github.com/jfrog/gofrog/log"
 )
 
-// UvLockFile represents the top-level structure of uv.lock
-type UvLockFile struct {
+// UVLockFile represents the top-level structure of uv.lock
+type UVLockFile struct {
 	Version  int          `toml:"version"`
 	Revision int          `toml:"revision"`
-	Packages []UvPackage  `toml:"package"`
+	Packages []UVPackage  `toml:"package"`
 }
 
-// UvPackage represents a [[package]] entry in uv.lock
-type UvPackage struct {
-	Name            string                        `toml:"name"`
-	Version         string                        `toml:"version"`
-	Source          UvSource                      `toml:"source"`
-	Dependencies    []UvDependencyEdge            `toml:"dependencies"`
-	DevDependencies map[string][]UvDependencyEdge `toml:"dev-dependencies"`
-	Sdist           *UvArtifact                   `toml:"sdist"`
-	Wheels          []UvArtifact                  `toml:"wheels"`
+// UVPackage represents a [[package]] entry in uv.lock
+type UVPackage struct {
+	Name            string                         `toml:"name"`
+	Version         string                         `toml:"version"`
+	Source          UVSource                       `toml:"source"`
+	Dependencies    []UVDependencyEdge             `toml:"dependencies"`
+	DevDependencies map[string][]UVDependencyEdge  `toml:"dev-dependencies"`
+	Sdist           *UVArtifact                    `toml:"sdist"`
+	Wheels          []UVArtifact                   `toml:"wheels"`
 }
 
-// UvSource is an inline table with exactly one key identifying the source type.
-type UvSource struct {
+// UVSource is an inline table with exactly one key identifying the source type.
+type UVSource struct {
 	Registry  string `toml:"registry"`
 	Virtual   string `toml:"virtual"`
 	Editable  string `toml:"editable"`
@@ -42,12 +42,12 @@ type UvSource struct {
 }
 
 // IsWorkspacePackage returns true if this source represents a local workspace package.
-func (s UvSource) IsWorkspacePackage() bool {
+func (s UVSource) IsWorkspacePackage() bool {
 	return s.Virtual != "" || s.Editable != "" || s.Directory != ""
 }
 
-// UvArtifact represents an sdist or wheel entry in uv.lock
-type UvArtifact struct {
+// UVArtifact represents an sdist or wheel entry in uv.lock
+type UVArtifact struct {
 	URL        string `toml:"url"`
 	Path       string `toml:"path"`
 	Hash       string `toml:"hash"`        // "sha256:<hex>"; absent for git
@@ -55,27 +55,27 @@ type UvArtifact struct {
 	UploadTime string `toml:"upload-time"` // ISO 8601; may be absent (revision < 3)
 }
 
-// UvDependencyEdge represents a dependency reference inside a [[package]] entry
-type UvDependencyEdge struct {
+// UVDependencyEdge represents a dependency reference inside a [[package]] entry
+type UVDependencyEdge struct {
 	Name    string   `toml:"name"`
 	Marker  string   `toml:"marker"`
 	Extra   []string `toml:"extra"`
 	Version string   `toml:"version"`
 }
 
-// UvPyProjectToml reads only [project] (PEP 621) — UV format, not Poetry
-type UvPyProjectToml struct {
+// UVPyProjectToml reads only [project] (PEP 621) — UV format, not Poetry
+type UVPyProjectToml struct {
 	Project struct {
 		Name    string `toml:"name"`
 		Version string `toml:"version"`
 	} `toml:"project"`
 }
 
-// UvFlexPack implements FlexPackManager and BuildInfoCollector for the UV package manager
-type UvFlexPack struct {
-	config            UvConfig
-	lockFileData      *UvLockFile
-	pyprojectData     *UvPyProjectToml
+// UVFlexPack implements FlexPackManager and BuildInfoCollector for the UV package manager
+type UVFlexPack struct {
+	config            UVConfig
+	lockFileData      *UVLockFile
+	pyprojectData     *UVPyProjectToml
 	projectName       string
 	projectVersion    string
 	parsed            bool
@@ -84,9 +84,9 @@ type UvFlexPack struct {
 	requestedByChains map[string][][]string // dep ID -> full chains back to root (UV-specific)
 }
 
-// NewUvFlexPack creates a new UvFlexPack instance.
-func NewUvFlexPack(config UvConfig) (*UvFlexPack, error) {
-	uf := &UvFlexPack{
+// NewUVFlexPack creates a new UVFlexPack instance.
+func NewUVFlexPack(config UVConfig) (*UVFlexPack, error) {
+	uf := &UVFlexPack{
 		config:            config,
 		dependencies:      []DependencyInfo{},
 		depGraph:          make(map[string][]string),
@@ -102,13 +102,13 @@ func NewUvFlexPack(config UvConfig) (*UvFlexPack, error) {
 }
 
 // loadPyProjectToml reads and parses pyproject.toml using PEP 621 [project] section.
-func (uf *UvFlexPack) loadPyProjectToml() error {
+func (uf *UVFlexPack) loadPyProjectToml() error {
 	pyprojectPath := filepath.Join(uf.config.WorkingDirectory, "pyproject.toml")
 	data, err := os.ReadFile(pyprojectPath)
 	if err != nil {
 		return fmt.Errorf("failed to read pyproject.toml: %w", err)
 	}
-	uf.pyprojectData = &UvPyProjectToml{}
+	uf.pyprojectData = &UVPyProjectToml{}
 	if err := toml.Unmarshal(data, uf.pyprojectData); err != nil {
 		return fmt.Errorf("failed to parse pyproject.toml: %w", err)
 	}
@@ -124,13 +124,13 @@ func (uf *UvFlexPack) loadPyProjectToml() error {
 }
 
 // loadUvLock reads and parses uv.lock.
-func (uf *UvFlexPack) loadUvLock() error {
+func (uf *UVFlexPack) loadUvLock() error {
 	lockPath := filepath.Join(uf.config.WorkingDirectory, "uv.lock")
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
 		return fmt.Errorf("failed to read uv.lock: %w", err)
 	}
-	uf.lockFileData = &UvLockFile{}
+	uf.lockFileData = &UVLockFile{}
 	if err := toml.Unmarshal(data, uf.lockFileData); err != nil {
 		return fmt.Errorf("failed to parse uv.lock: %w", err)
 	}
@@ -151,7 +151,7 @@ func extractSHA256(hash string) string {
 
 // bestHash returns the best available hash for a package.
 // Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
-func bestHash(pkg UvPackage) string {
+func bestHash(pkg UVPackage) string {
 	for _, w := range pkg.Wheels {
 		if strings.Contains(w.URL, "none-any") && w.Hash != "" {
 			return w.Hash
@@ -171,7 +171,7 @@ func bestHash(pkg UvPackage) string {
 // depFileType returns the file extension type for a package artifact.
 // Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
 // Matches pip/pipenv behavior: "whl", "tar.gz", "zip", etc.
-func depFileType(pkg UvPackage) string {
+func depFileType(pkg UVPackage) string {
 	bestURL := ""
 	for _, w := range pkg.Wheels {
 		if strings.Contains(w.URL, "none-any") && w.URL != "" {
@@ -204,7 +204,7 @@ func depFileType(pkg UvPackage) string {
 }
 
 // ensureParsed calls parseDependencies exactly once.
-func (uf *UvFlexPack) ensureParsed() {
+func (uf *UVFlexPack) ensureParsed() {
 	if uf.parsed {
 		return
 	}
@@ -219,66 +219,91 @@ func (uf *UvFlexPack) ensureParsed() {
 //   - requestedBy: full chain back to root module (e.g. [["requests:2.33.1","myapp:0.1.0"]])
 //   - direct deps: requestedBy = [["myapp:0.1.0"]]
 //   - no scopes (Python has no compile/runtime distinction; matches pip/pipenv)
-func (uf *UvFlexPack) parseDependencies() {
+func (uf *UVFlexPack) parseDependencies() {
 	if uf.lockFileData == nil {
 		return
 	}
 
 	moduleID := fmt.Sprintf("%s:%s", uf.projectName, uf.projectVersion)
-
-	// Build name->package map
-	pkgByName := make(map[string]*UvPackage)
-	for i := range uf.lockFileData.Packages {
-		pkg := &uf.lockFileData.Packages[i]
-		pkgByName[normalizeName(pkg.Name)] = pkg
-	}
-
-	// Find root workspace package
-	var rootPkg *UvPackage
-	for i := range uf.lockFileData.Packages {
-		pkg := &uf.lockFileData.Packages[i]
-		if pkg.Source.Virtual == "." || pkg.Source.Editable == "." || pkg.Source.Directory == "." {
-			rootPkg = pkg
-			break
-		}
-	}
-
-	// Collect direct main and dev dep names
-	directMainDeps := make(map[string]bool)
-	directDevDeps := make(map[string]bool)
-	if rootPkg != nil {
-		for _, edge := range rootPkg.Dependencies {
-			directMainDeps[normalizeName(edge.Name)] = true
-		}
-		for _, edges := range rootPkg.DevDependencies {
-			for _, edge := range edges {
-				directDevDeps[normalizeName(edge.Name)] = true
-			}
-		}
-	}
+	pkgByName := buildPackageMap(uf.lockFileData.Packages)
+	rootPkg := findRootPackage(uf.lockFileData.Packages)
+	mainDeps, devDeps := collectDirectDeps(rootPkg)
 
 	// When excluding dev deps and the project has BOTH main deps and dev deps declared,
-	// compute the reachable set from main deps via BFS. This excludes transitive-only dev deps
-	// (e.g. pytest's dependencies like pluggy, iniconfig) — not just the direct dev dep itself.
-	// If only one side is present (no main deps or no dev deps), fall back to the simple check.
+	// compute the reachable set from main deps via BFS to exclude dev-only transitive deps.
 	var mainReachable map[string]bool
 	if !uf.config.IncludeDevDependencies && rootPkg != nil &&
-		len(directMainDeps) > 0 && len(directDevDeps) > 0 {
-		mainReachable = computeMainReachable(directMainDeps, pkgByName)
+		len(mainDeps) > 0 && len(devDeps) > 0 {
+		mainReachable = computeMainReachable(mainDeps, pkgByName)
 	}
 
-	// Build depInfo map: normalizedName -> *DependencyInfo
-	// Only non-workspace packages. Exclusion logic when IncludeDevDependencies=false:
-	//   - With reachability analysis: skip anything not reachable from main deps
-	//   - Without (no dev deps or no main deps declared): skip direct dev deps only
+	depInfoMap := buildDepInfoMap(uf.lockFileData.Packages, uf.config.IncludeDevDependencies, mainReachable, devDeps)
+	fwdGraph := buildForwardGraph(depInfoMap, pkgByName, uf.depGraph)
+	rootChildren := collectRootChildren(rootPkg, depInfoMap, uf.config.IncludeDevDependencies)
+
+	// Build requestedBy chains using pip's recursive DFS approach.
+	// Results go into uf.requestedByChains (map[string][][]string), NOT into DependencyInfo.RequestedBy.
+	// This keeps the shared DependencyInfo type ([]string) unchanged for poetry/maven.
+	buildUvRequestedBy(moduleID, []string{}, rootChildren, depInfoMap, fwdGraph, uf.requestedByChains, entities.RequestedByMaxLength)
+
+	for _, dep := range depInfoMap {
+		uf.dependencies = append(uf.dependencies, *dep)
+	}
+}
+
+// buildPackageMap builds a normalizedName → *UVPackage lookup map.
+func buildPackageMap(packages []UVPackage) map[string]*UVPackage {
+	pkgByName := make(map[string]*UVPackage, len(packages))
+	for i := range packages {
+		pkg := &packages[i]
+		pkgByName[normalizeName(pkg.Name)] = pkg
+	}
+	return pkgByName
+}
+
+// findRootPackage returns the workspace root package (source.virtual/editable/directory == ".").
+func findRootPackage(packages []UVPackage) *UVPackage {
+	for i := range packages {
+		pkg := &packages[i]
+		if pkg.Source.Virtual == "." || pkg.Source.Editable == "." || pkg.Source.Directory == "." {
+			return pkg
+		}
+	}
+	return nil
+}
+
+// collectDirectDeps returns the direct main and dev dep normalised names from the root package.
+func collectDirectDeps(rootPkg *UVPackage) (mainDeps, devDeps map[string]bool) {
+	mainDeps = make(map[string]bool)
+	devDeps = make(map[string]bool)
+	if rootPkg == nil {
+		return
+	}
+	for _, edge := range rootPkg.Dependencies {
+		mainDeps[normalizeName(edge.Name)] = true
+	}
+	for _, edges := range rootPkg.DevDependencies {
+		for _, edge := range edges {
+			devDeps[normalizeName(edge.Name)] = true
+		}
+	}
+	return
+}
+
+// buildDepInfoMap builds normalizedName → *DependencyInfo for non-workspace packages,
+// applying dev-dep exclusion logic.
+// Exclusion logic when includeDevDeps=false:
+//   - With reachability analysis (mainReachable != nil): skip anything not reachable from main deps
+//   - Without (no dev deps or no main deps declared): skip direct dev deps only
+func buildDepInfoMap(packages []UVPackage, includeDevDeps bool, mainReachable map[string]bool, directDevDeps map[string]bool) map[string]*DependencyInfo {
 	depInfoMap := make(map[string]*DependencyInfo)
-	for i := range uf.lockFileData.Packages {
-		pkg := &uf.lockFileData.Packages[i]
+	for i := range packages {
+		pkg := &packages[i]
 		if pkg.Source.IsWorkspacePackage() {
 			continue
 		}
 		normalizedName := normalizeName(pkg.Name)
-		if !uf.config.IncludeDevDependencies {
+		if !includeDevDeps {
 			if mainReachable != nil {
 				if !mainReachable[normalizedName] {
 					continue // reachability analysis: exclude dev-only transitive deps
@@ -295,9 +320,13 @@ func (uf *UvFlexPack) parseDependencies() {
 			SHA256:  extractSHA256(bestHash(*pkg)),
 		}
 	}
+	return depInfoMap
+}
 
-	// Build forward dep graph: normalizedName -> []normalizedName (children present in depInfoMap)
-	fwdGraph := make(map[string][]string)
+// buildForwardGraph builds the normalizedName forward graph and returns it.
+// Also populates idGraph with ID-keyed edges.
+func buildForwardGraph(depInfoMap map[string]*DependencyInfo, pkgByName map[string]*UVPackage, idGraph map[string][]string) map[string][]string {
+	fwdGraph := make(map[string][]string, len(depInfoMap))
 	for normalizedName := range depInfoMap {
 		pkg := pkgByName[normalizedName]
 		if pkg == nil {
@@ -311,7 +340,7 @@ func (uf *UvFlexPack) parseDependencies() {
 			}
 		}
 		fwdGraph[normalizedName] = children
-		uf.depGraph[depInfoMap[normalizedName].ID] = func() []string {
+		idGraph[depInfoMap[normalizedName].ID] = func() []string {
 			var ids []string
 			for _, c := range children {
 				ids = append(ids, depInfoMap[c].ID)
@@ -319,46 +348,42 @@ func (uf *UvFlexPack) parseDependencies() {
 			return ids
 		}()
 	}
+	return fwdGraph
+}
 
-	// Collect direct children of root (main deps; optionally dev deps)
-	var rootChildren []string
-	if rootPkg != nil {
-		for _, edge := range rootPkg.Dependencies {
-			n := normalizeName(edge.Name)
-			if _, ok := depInfoMap[n]; ok {
-				rootChildren = append(rootChildren, n)
-			}
-		}
-		if uf.config.IncludeDevDependencies {
-			for _, edges := range rootPkg.DevDependencies {
-				for _, edge := range edges {
-					n := normalizeName(edge.Name)
-					if _, ok := depInfoMap[n]; ok {
-						rootChildren = append(rootChildren, n)
-					}
-				}
-			}
-		}
-	} else {
+// collectRootChildren returns normalised child names reachable from root that are in depInfoMap.
+func collectRootChildren(rootPkg *UVPackage, depInfoMap map[string]*DependencyInfo, includeDevDeps bool) []string {
+	if rootPkg == nil {
 		// No lockfile root found — treat all non-workspace packages as direct deps
+		rootChildren := make([]string, 0, len(depInfoMap))
 		for n := range depInfoMap {
 			rootChildren = append(rootChildren, n)
 		}
+		return rootChildren
 	}
-
-	// Build requestedBy chains using pip's recursive DFS approach.
-	// Results go into uf.requestedByChains (map[string][][]string), NOT into DependencyInfo.RequestedBy.
-	// This keeps the shared DependencyInfo type ([]string) unchanged for poetry/maven.
-	buildUvRequestedBy(moduleID, []string{}, rootChildren, depInfoMap, fwdGraph, uf.requestedByChains, entities.RequestedByMaxLength)
-
-	for _, dep := range depInfoMap {
-		uf.dependencies = append(uf.dependencies, *dep)
+	var rootChildren []string
+	for _, edge := range rootPkg.Dependencies {
+		n := normalizeName(edge.Name)
+		if _, ok := depInfoMap[n]; ok {
+			rootChildren = append(rootChildren, n)
+		}
 	}
+	if includeDevDeps {
+		for _, edges := range rootPkg.DevDependencies {
+			for _, edge := range edges {
+				n := normalizeName(edge.Name)
+				if _, ok := depInfoMap[n]; ok {
+					rootChildren = append(rootChildren, n)
+				}
+			}
+		}
+	}
+	return rootChildren
 }
 
 // computeMainReachable returns the set of normalizedNames reachable from main (non-dev) deps
 // via BFS through the forward dependency graph. Used to exclude dev-only transitive deps.
-func computeMainReachable(directMainDeps map[string]bool, pkgByName map[string]*UvPackage) map[string]bool {
+func computeMainReachable(directMainDeps map[string]bool, pkgByName map[string]*UVPackage) map[string]bool {
 	reachable := make(map[string]bool)
 	queue := make([]string, 0, len(directMainDeps))
 	for name := range directMainDeps {
@@ -413,7 +438,7 @@ func buildUvRequestedBy(parentID string, parentChain []string, children []string
 // ===== FlexPackManager Interface =====
 
 // GetDependency returns a formatted string with dependency information.
-func (uf *UvFlexPack) GetDependency() string {
+func (uf *UVFlexPack) GetDependency() string {
 	uf.ensureParsed()
 	var result strings.Builder
 	fmt.Fprintf(&result, "Project: %s:%s\n", uf.projectName, uf.projectVersion)
@@ -425,7 +450,7 @@ func (uf *UvFlexPack) GetDependency() string {
 }
 
 // ParseDependencyToList returns a list of "name:version" strings for all dependencies.
-func (uf *UvFlexPack) ParseDependencyToList() []string {
+func (uf *UVFlexPack) ParseDependencyToList() []string {
 	uf.ensureParsed()
 	var depList []string
 	for _, dep := range uf.dependencies {
@@ -435,7 +460,7 @@ func (uf *UvFlexPack) ParseDependencyToList() []string {
 }
 
 // CalculateChecksum returns checksum maps for all dependencies.
-func (uf *UvFlexPack) CalculateChecksum() []map[string]interface{} {
+func (uf *UVFlexPack) CalculateChecksum() []map[string]interface{} {
 	uf.ensureParsed()
 	var checksums []map[string]interface{}
 	for _, dep := range uf.dependencies {
@@ -455,7 +480,7 @@ func (uf *UvFlexPack) CalculateChecksum() []map[string]interface{} {
 }
 
 // CalculateScopes returns the unique set of scopes across all dependencies.
-func (uf *UvFlexPack) CalculateScopes() []string {
+func (uf *UVFlexPack) CalculateScopes() []string {
 	uf.ensureParsed()
 	scopesMap := make(map[string]bool)
 	for _, dep := range uf.dependencies {
@@ -473,7 +498,7 @@ func (uf *UvFlexPack) CalculateScopes() []string {
 // CalculateRequestedBy returns the direct parent for each dependency ID.
 // Satisfies the FlexPackManager interface (returns map[string][]string).
 // For the full [][]string chains, see requestedByChains.
-func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
+func (uf *UVFlexPack) CalculateRequestedBy() map[string][]string {
 	uf.ensureParsed()
 	// Flatten each chain to its first element (direct parent) for the []string interface.
 	result := make(map[string][]string)
@@ -492,7 +517,7 @@ func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
 // GetRequestedByChains returns the full [][]string requestedBy chains for each dependency.
 // Each inner slice is a path from the immediate parent back to the root module.
 // Use this when you need the complete chain (e.g. in tests or build-info consumers).
-func (uf *UvFlexPack) GetRequestedByChains() map[string][][]string {
+func (uf *UVFlexPack) GetRequestedByChains() map[string][][]string {
 	uf.ensureParsed()
 	return uf.requestedByChains
 }
@@ -500,7 +525,7 @@ func (uf *UvFlexPack) GetRequestedByChains() map[string][][]string {
 // ===== BuildInfoCollector Interface =====
 
 // CollectBuildInfo builds a complete entities.BuildInfo for this UV project.
-func (uf *UvFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities.BuildInfo, error) {
+func (uf *UVFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities.BuildInfo, error) {
 	buildInfo := &entities.BuildInfo{
 		Name:   buildName,
 		Number: buildNumber,
@@ -541,19 +566,19 @@ func (uf *UvFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities
 }
 
 // GetProjectDependencies returns all project dependencies with full details.
-func (uf *UvFlexPack) GetProjectDependencies() ([]DependencyInfo, error) {
+func (uf *UVFlexPack) GetProjectDependencies() ([]DependencyInfo, error) {
 	uf.ensureParsed()
 	return uf.dependencies, nil
 }
 
 // GetDependencyGraph returns the complete dependency graph.
-func (uf *UvFlexPack) GetDependencyGraph() (map[string][]string, error) {
+func (uf *UVFlexPack) GetDependencyGraph() (map[string][]string, error) {
 	uf.ensureParsed()
 	return uf.depGraph, nil
 }
 
 // getUvVersion returns the installed UV version string.
-func (uf *UvFlexPack) getUvVersion() string {
+func (uf *UVFlexPack) getUvVersion() string {
 	cmd := exec.Command("uv", "--version")
 	output, err := cmd.Output()
 	if err != nil {

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -103,6 +103,13 @@ func NewUVFlexPack(config UVConfig) (*UVFlexPack, error) {
 
 // loadPyProjectToml reads and parses pyproject.toml using PEP 621 [project] section.
 func (uf *UVFlexPack) loadPyProjectToml() error {
+	// When ProjectName is supplied via config (e.g. for PEP 723 inline scripts that
+	// have no pyproject.toml), skip file loading and use the overrides directly.
+	if uf.config.ProjectName != "" {
+		uf.projectName = uf.config.ProjectName
+		uf.projectVersion = uf.config.ProjectVersion
+		return nil
+	}
 	pyprojectPath := filepath.Join(uf.config.WorkingDirectory, "pyproject.toml")
 	data, err := os.ReadFile(pyprojectPath)
 	if err != nil {
@@ -123,9 +130,13 @@ func (uf *UVFlexPack) loadPyProjectToml() error {
 	return nil
 }
 
-// loadUvLock reads and parses uv.lock.
+// loadUvLock reads and parses the lock file. Uses LockFilePath if set (for PEP 723
+// inline scripts whose lock file is adjacent to the script), otherwise uv.lock.
 func (uf *UVFlexPack) loadUvLock() error {
-	lockPath := filepath.Join(uf.config.WorkingDirectory, "uv.lock")
+	lockPath := uf.config.LockFilePath
+	if lockPath == "" {
+		lockPath = filepath.Join(uf.config.WorkingDirectory, "uv.lock")
+	}
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
 		return fmt.Errorf("failed to read uv.lock: %w", err)
@@ -191,6 +202,10 @@ func depFileType(pkg UVPackage) string {
 		bestURL = pkg.Sdist.URL
 	}
 	if bestURL == "" {
+		// Git deps have no archive — return "git" so build-info reflects the source type.
+		if pkg.Source.Git != "" {
+			return "git"
+		}
 		return ""
 	}
 	base := filepath.Base(bestURL)
@@ -227,19 +242,29 @@ func (uf *UVFlexPack) parseDependencies() {
 	moduleID := fmt.Sprintf("%s:%s", uf.projectName, uf.projectVersion)
 	pkgByName := buildPackageMap(uf.lockFileData.Packages)
 	rootPkg := findRootPackage(uf.lockFileData.Packages)
-	mainDeps, devDeps := collectDirectDeps(rootPkg)
 
-	// When excluding dev deps and the project has BOTH main deps and dev deps declared,
-	// compute the reachable set from main deps via BFS to exclude dev-only transitive deps.
-	var mainReachable map[string]bool
-	if !uf.config.IncludeDevDependencies && rootPkg != nil &&
-		len(mainDeps) > 0 && len(devDeps) > 0 {
-		mainReachable = computeMainReachable(mainDeps, pkgByName)
+	var depInfoMap map[string]*DependencyInfo
+	var rootChildren []string
+
+	if uf.config.InstalledPackages != nil {
+		// Ground-truth path: only include packages that uv actually installed.
+		// This correctly handles --no-dev, --only-dev, --group, --no-group and all
+		// other flag combinations without any flag parsing on our side.
+		depInfoMap = buildDepInfoMapFromInstalled(uf.lockFileData.Packages, uf.config.InstalledPackages)
+		rootChildren = collectRootChildrenFromInstalled(rootPkg, depInfoMap)
+	} else {
+		// Fallback path (lock/build/publish — no venv): use IncludeDevDependencies flag.
+		mainDeps, devDeps := collectDirectDeps(rootPkg)
+		var mainReachable map[string]bool
+		if !uf.config.IncludeDevDependencies && rootPkg != nil &&
+			len(mainDeps) > 0 && len(devDeps) > 0 {
+			mainReachable = computeMainReachable(mainDeps, pkgByName)
+		}
+		depInfoMap = buildDepInfoMap(uf.lockFileData.Packages, uf.config.IncludeDevDependencies, mainReachable, devDeps)
+		rootChildren = collectRootChildren(rootPkg, depInfoMap, uf.config.IncludeDevDependencies)
 	}
 
-	depInfoMap := buildDepInfoMap(uf.lockFileData.Packages, uf.config.IncludeDevDependencies, mainReachable, devDeps)
 	fwdGraph := buildForwardGraph(depInfoMap, pkgByName, uf.depGraph)
-	rootChildren := collectRootChildren(rootPkg, depInfoMap, uf.config.IncludeDevDependencies)
 
 	// Build requestedBy chains using pip's recursive DFS approach.
 	// Results go into uf.requestedByChains (map[string][][]string), NOT into DependencyInfo.RequestedBy.
@@ -312,12 +337,19 @@ func buildDepInfoMap(packages []UVPackage, includeDevDeps bool, mainReachable ma
 				continue // simple fallback: exclude direct dev deps only
 			}
 		}
+		// DirectURL is set for deps not from a registry: direct URL or git.
+		// Both are not in Artifactory so AQL enrichment is skipped for them.
+		directURL := pkg.Source.URL
+		if directURL == "" {
+			directURL = pkg.Source.Git
+		}
 		depInfoMap[normalizedName] = &DependencyInfo{
-			ID:      fmt.Sprintf("%s:%s", pkg.Name, pkg.Version),
-			Name:    pkg.Name,
-			Version: pkg.Version,
-			Type:    depFileType(*pkg),
-			SHA256:  extractSHA256(bestHash(*pkg)),
+			ID:        fmt.Sprintf("%s:%s", pkg.Name, pkg.Version),
+			Name:      pkg.Name,
+			Version:   pkg.Version,
+			Type:      depFileType(*pkg),
+			SHA256:    extractSHA256(bestHash(*pkg)),
+			DirectURL: directURL,
 		}
 	}
 	return depInfoMap
@@ -352,6 +384,63 @@ func buildForwardGraph(depInfoMap map[string]*DependencyInfo, pkgByName map[stri
 }
 
 // collectRootChildren returns normalised child names reachable from root that are in depInfoMap.
+// buildDepInfoMapFromInstalled builds depInfoMap using the ground-truth installed set
+// from `uv pip list`. Only packages whose normalised name appears in installedPkgs are included.
+func buildDepInfoMapFromInstalled(packages []UVPackage, installedPkgs map[string]string) map[string]*DependencyInfo {
+	depInfoMap := make(map[string]*DependencyInfo)
+	for i := range packages {
+		pkg := &packages[i]
+		if pkg.Source.IsWorkspacePackage() {
+			continue
+		}
+		normName := normalizeName(pkg.Name)
+		if _, ok := installedPkgs[normName]; !ok {
+			continue // not installed by this uv invocation
+		}
+		directURL := pkg.Source.URL
+		if directURL == "" {
+			directURL = pkg.Source.Git
+		}
+		depInfoMap[normName] = &DependencyInfo{
+			ID:        fmt.Sprintf("%s:%s", pkg.Name, pkg.Version),
+			Name:      pkg.Name,
+			Version:   pkg.Version,
+			Type:      depFileType(*pkg),
+			SHA256:    extractSHA256(bestHash(*pkg)),
+			DirectURL: directURL,
+		}
+	}
+	return depInfoMap
+}
+
+// collectRootChildrenFromInstalled returns root's direct children that are in depInfoMap,
+// scanning both main and dev dependency edges (since InstalledPackages already filtered the set).
+func collectRootChildrenFromInstalled(rootPkg *UVPackage, depInfoMap map[string]*DependencyInfo) []string {
+	if rootPkg == nil {
+		var all []string
+		for n := range depInfoMap {
+			all = append(all, n)
+		}
+		return all
+	}
+	var children []string
+	for _, edge := range rootPkg.Dependencies {
+		n := normalizeName(edge.Name)
+		if _, ok := depInfoMap[n]; ok {
+			children = append(children, n)
+		}
+	}
+	for _, edges := range rootPkg.DevDependencies {
+		for _, edge := range edges {
+			n := normalizeName(edge.Name)
+			if _, ok := depInfoMap[n]; ok {
+				children = append(children, n)
+			}
+		}
+	}
+	return children
+}
+
 func collectRootChildren(rootPkg *UVPackage, depInfoMap map[string]*DependencyInfo, includeDevDeps bool) []string {
 	if rootPkg == nil {
 		// No lockfile root found — treat all non-workspace packages as direct deps
@@ -569,6 +658,20 @@ func (uf *UVFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities
 func (uf *UVFlexPack) GetProjectDependencies() ([]DependencyInfo, error) {
 	uf.ensureParsed()
 	return uf.dependencies, nil
+}
+
+// GetDirectURLDeps returns a map of dep ID ("name:version") → source URL for all
+// dependencies that were installed from a direct URL rather than from a registry.
+// These deps are not in Artifactory so sha1/md5 enrichment via AQL should be skipped.
+func (uf *UVFlexPack) GetDirectURLDeps() map[string]string {
+	uf.ensureParsed()
+	result := make(map[string]string)
+	for _, dep := range uf.dependencies {
+		if dep.DirectURL != "" {
+			result[dep.ID] = dep.DirectURL
+		}
+	}
+	return result
 }
 
 // GetDependencyGraph returns the complete dependency graph.

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -1,0 +1,443 @@
+package flexpack
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/gofrog/log"
+)
+
+// UvLockFile represents the top-level structure of uv.lock
+type UvLockFile struct {
+	Version  int          `toml:"version"`
+	Revision int          `toml:"revision"`
+	Packages []UvPackage  `toml:"package"`
+}
+
+// UvPackage represents a [[package]] entry in uv.lock
+type UvPackage struct {
+	Name            string                        `toml:"name"`
+	Version         string                        `toml:"version"`
+	Source          UvSource                      `toml:"source"`
+	Dependencies    []UvDependencyEdge            `toml:"dependencies"`
+	DevDependencies map[string][]UvDependencyEdge `toml:"dev-dependencies"`
+	Sdist           *UvArtifact                   `toml:"sdist"`
+	Wheels          []UvArtifact                  `toml:"wheels"`
+}
+
+// UvSource is an inline table with exactly one key identifying the source type.
+type UvSource struct {
+	Registry  string `toml:"registry"`
+	Virtual   string `toml:"virtual"`
+	Editable  string `toml:"editable"`
+	Directory string `toml:"directory"`
+	Git       string `toml:"git"`
+	URL       string `toml:"url"`
+}
+
+// IsWorkspacePackage returns true if this source represents a local workspace package.
+func (s UvSource) IsWorkspacePackage() bool {
+	return s.Virtual != "" || s.Editable != "" || s.Directory != ""
+}
+
+// HasArtifacts returns true if this source type provides sdist/wheel artifacts.
+func (s UvSource) HasArtifacts() bool {
+	return s.Registry != "" || s.URL != ""
+}
+
+// UvArtifact represents an sdist or wheel entry in uv.lock
+type UvArtifact struct {
+	URL        string `toml:"url"`
+	Path       string `toml:"path"`
+	Hash       string `toml:"hash"`        // "sha256:<hex>"; absent for git
+	Size       int64  `toml:"size"`
+	UploadTime string `toml:"upload-time"` // ISO 8601; may be absent (revision < 3)
+}
+
+// UvDependencyEdge represents a dependency reference inside a [[package]] entry
+type UvDependencyEdge struct {
+	Name    string   `toml:"name"`
+	Marker  string   `toml:"marker"`
+	Extra   []string `toml:"extra"`
+	Version string   `toml:"version"`
+}
+
+// UvPyProjectToml reads only [project] (PEP 621) — UV format, not Poetry
+type UvPyProjectToml struct {
+	Project struct {
+		Name    string `toml:"name"`
+		Version string `toml:"version"`
+	} `toml:"project"`
+}
+
+// UvFlexPack implements FlexPackManager and BuildInfoCollector for the UV package manager
+type UvFlexPack struct {
+	config         UvConfig
+	lockFileData   *UvLockFile
+	pyprojectData  *UvPyProjectToml
+	projectName    string
+	projectVersion string
+	dependencies   []DependencyInfo
+	depGraph       map[string][]string // normalized-name -> []normalized-name
+}
+
+// NewUvFlexPack creates a new UvFlexPack instance.
+func NewUvFlexPack(config UvConfig) (*UvFlexPack, error) {
+	uf := &UvFlexPack{
+		config:       config,
+		dependencies: []DependencyInfo{},
+		depGraph:     make(map[string][]string),
+	}
+	if err := uf.loadPyProjectToml(); err != nil {
+		return nil, fmt.Errorf("failed to load pyproject.toml: %w", err)
+	}
+	if err := uf.loadUvLock(); err != nil {
+		log.Debug("Failed to load uv.lock, dependency collection will be empty: " + err.Error())
+	}
+	return uf, nil
+}
+
+// loadPyProjectToml reads and parses pyproject.toml using PEP 621 [project] section.
+func (uf *UvFlexPack) loadPyProjectToml() error {
+	pyprojectPath := filepath.Join(uf.config.WorkingDirectory, "pyproject.toml")
+	data, err := os.ReadFile(pyprojectPath)
+	if err != nil {
+		return fmt.Errorf("failed to read pyproject.toml: %w", err)
+	}
+	uf.pyprojectData = &UvPyProjectToml{}
+	if err := toml.Unmarshal(data, uf.pyprojectData); err != nil {
+		return fmt.Errorf("failed to parse pyproject.toml: %w", err)
+	}
+	uf.projectName = uf.pyprojectData.Project.Name
+	uf.projectVersion = uf.pyprojectData.Project.Version
+	if uf.projectName == "" {
+		return fmt.Errorf("project name not found in pyproject.toml (checked [project.name])")
+	}
+	if uf.projectVersion == "" {
+		return fmt.Errorf("project version not found in pyproject.toml (checked [project.version])")
+	}
+	return nil
+}
+
+// loadUvLock reads and parses uv.lock.
+func (uf *UvFlexPack) loadUvLock() error {
+	lockPath := filepath.Join(uf.config.WorkingDirectory, "uv.lock")
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return fmt.Errorf("failed to read uv.lock: %w", err)
+	}
+	uf.lockFileData = &UvLockFile{}
+	if err := toml.Unmarshal(data, uf.lockFileData); err != nil {
+		return fmt.Errorf("failed to parse uv.lock: %w", err)
+	}
+	return nil
+}
+
+// normalizeName converts package names to lowercase with hyphens.
+func normalizeName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+}
+
+// extractSHA256 strips the "sha256:" prefix from a hash string.
+func extractSHA256(hash string) string {
+	return strings.TrimPrefix(hash, "sha256:")
+}
+
+// bestHash returns the best available hash for a package.
+// Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
+func bestHash(pkg UvPackage) string {
+	for _, w := range pkg.Wheels {
+		if strings.Contains(w.URL, "none-any") && w.Hash != "" {
+			return w.Hash
+		}
+	}
+	for _, w := range pkg.Wheels {
+		if w.Hash != "" {
+			return w.Hash
+		}
+	}
+	if pkg.Sdist != nil && pkg.Sdist.Hash != "" {
+		return pkg.Sdist.Hash
+	}
+	return ""
+}
+
+// depFilename returns the filename-based ID for a package.
+// Prefers pure-Python wheel filename, falls back to first wheel filename, then sdist filename.
+// Falls back to "name-version" if no artifacts are present.
+func depFilename(pkg UvPackage) string {
+	for _, w := range pkg.Wheels {
+		if strings.Contains(w.URL, "none-any") && w.URL != "" {
+			return filepath.Base(w.URL)
+		}
+	}
+	for _, w := range pkg.Wheels {
+		if w.URL != "" {
+			return filepath.Base(w.URL)
+		}
+	}
+	if pkg.Sdist != nil && pkg.Sdist.URL != "" {
+		return filepath.Base(pkg.Sdist.URL)
+	}
+	return fmt.Sprintf("%s-%s", pkg.Name, pkg.Version)
+}
+
+// parseDependencies populates uf.dependencies and uf.depGraph from the lock file.
+func (uf *UvFlexPack) parseDependencies() {
+	if uf.lockFileData == nil {
+		return
+	}
+
+	// Build a name->package map (last-write-wins for resolver forks)
+	pkgByName := make(map[string]*UvPackage)
+	for i := range uf.lockFileData.Packages {
+		pkg := &uf.lockFileData.Packages[i]
+		pkgByName[normalizeName(pkg.Name)] = pkg
+	}
+
+	// Find the root workspace package (virtual or editable at ".")
+	var rootPkg *UvPackage
+	for i := range uf.lockFileData.Packages {
+		pkg := &uf.lockFileData.Packages[i]
+		if pkg.Source.Virtual == "." || pkg.Source.Editable == "." {
+			rootPkg = pkg
+			break
+		}
+	}
+
+	// Collect direct main and dev dep names (always collect both for exclusion logic)
+	directMainDeps := make(map[string]bool)
+	directDevDeps := make(map[string]bool)
+	if rootPkg != nil {
+		for _, edge := range rootPkg.Dependencies {
+			directMainDeps[normalizeName(edge.Name)] = true
+		}
+		for _, edges := range rootPkg.DevDependencies {
+			for _, edge := range edges {
+				directDevDeps[normalizeName(edge.Name)] = true
+			}
+		}
+	}
+
+	// Build inverse RequestedBy map: depName -> []parentName
+	inverse := make(map[string][]string)
+	for _, pkg := range uf.lockFileData.Packages {
+		if pkg.Source.IsWorkspacePackage() {
+			continue
+		}
+		parentName := normalizeName(pkg.Name)
+		for _, edge := range pkg.Dependencies {
+			childName := normalizeName(edge.Name)
+			inverse[childName] = append(inverse[childName], parentName)
+		}
+	}
+
+	// Build dep graph and dependency list
+	for _, pkg := range uf.lockFileData.Packages {
+		if pkg.Source.IsWorkspacePackage() {
+			continue
+		}
+		normalizedName := normalizeName(pkg.Name)
+
+		// Determine scope
+		var scope string
+		if directMainDeps[normalizedName] {
+			scope = "compile"
+		} else if directDevDeps[normalizedName] {
+			scope = "test"
+		} else {
+			// Transitive: use "compile" as default
+			scope = "compile"
+		}
+
+		// Skip dev deps if not including them
+		if !uf.config.IncludeDevDependencies && directDevDeps[normalizedName] {
+			continue
+		}
+
+		// Build dep graph entry
+		var childNames []string
+		for _, edge := range pkg.Dependencies {
+			childNames = append(childNames, normalizeName(edge.Name))
+		}
+		uf.depGraph[normalizedName] = childNames
+
+		dep := DependencyInfo{
+			ID:          depFilename(pkg),
+			Name:        pkg.Name,
+			Version:     pkg.Version,
+			Type:        "pypi",
+			SHA256:      extractSHA256(bestHash(pkg)),
+			SHA1:        "",
+			MD5:         "",
+			Scopes:      []string{scope},
+			RequestedBy: inverse[normalizedName],
+		}
+		uf.dependencies = append(uf.dependencies, dep)
+	}
+}
+
+// ===== FlexPackManager Interface =====
+
+// GetDependency returns a formatted string with dependency information.
+func (uf *UvFlexPack) GetDependency() string {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	var result strings.Builder
+	fmt.Fprintf(&result, "Project: %s:%s\n", uf.projectName, uf.projectVersion)
+	result.WriteString("Dependencies:\n")
+	for _, dep := range uf.dependencies {
+		fmt.Fprintf(&result, "  - %s:%s [%s]\n", dep.Name, dep.Version, dep.Type)
+	}
+	return result.String()
+}
+
+// ParseDependencyToList returns a list of "name:version" strings for all dependencies.
+func (uf *UvFlexPack) ParseDependencyToList() []string {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	var depList []string
+	for _, dep := range uf.dependencies {
+		depList = append(depList, fmt.Sprintf("%s:%s", dep.Name, dep.Version))
+	}
+	return depList
+}
+
+// CalculateChecksum returns checksum maps for all dependencies.
+func (uf *UvFlexPack) CalculateChecksum() []map[string]interface{} {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	var checksums []map[string]interface{}
+	for _, dep := range uf.dependencies {
+		checksumMap := map[string]interface{}{
+			"type":    dep.Type,
+			"sha1":    dep.SHA1,
+			"sha256":  dep.SHA256,
+			"md5":     dep.MD5,
+			"id":      dep.ID,
+			"scopes":  dep.Scopes,
+			"name":    dep.Name,
+			"version": dep.Version,
+		}
+		checksums = append(checksums, checksumMap)
+	}
+	return checksums
+}
+
+// CalculateScopes returns the unique set of scopes across all dependencies.
+func (uf *UvFlexPack) CalculateScopes() []string {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	scopesMap := make(map[string]bool)
+	for _, dep := range uf.dependencies {
+		for _, scope := range dep.Scopes {
+			scopesMap[scope] = true
+		}
+	}
+	var scopes []string
+	for scope := range scopesMap {
+		scopes = append(scopes, scope)
+	}
+	return scopes
+}
+
+// CalculateRequestedBy returns a map from dependency ID to the list of packages that request it.
+func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	result := make(map[string][]string)
+	for _, dep := range uf.dependencies {
+		if len(dep.RequestedBy) > 0 {
+			result[dep.ID] = dep.RequestedBy
+		}
+	}
+	return result
+}
+
+// ===== BuildInfoCollector Interface =====
+
+// CollectBuildInfo builds a complete entities.BuildInfo for this UV project.
+func (uf *UvFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities.BuildInfo, error) {
+	buildInfo := &entities.BuildInfo{
+		Name:   buildName,
+		Number: buildNumber,
+		Agent: &entities.Agent{
+			Name:    "uv",
+			Version: uf.getUvVersion(),
+		},
+		BuildAgent: &entities.Agent{Name: "Generic", Version: "1.0"},
+		Modules:    []entities.Module{},
+	}
+
+	module := entities.Module{
+		Id:   fmt.Sprintf("%s:%s", uf.projectName, uf.projectVersion),
+		Type: entities.Uv,
+	}
+
+	deps, err := uf.GetProjectDependencies()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dep := range deps {
+		entityDep := entities.Dependency{
+			Id:     dep.ID,
+			Type:   dep.Type,
+			Scopes: dep.Scopes,
+			Checksum: entities.Checksum{
+				Sha1:   dep.SHA1,
+				Sha256: dep.SHA256,
+				Md5:    dep.MD5,
+			},
+		}
+		if len(dep.RequestedBy) > 0 {
+			entityDep.RequestedBy = [][]string{dep.RequestedBy}
+		}
+		module.Dependencies = append(module.Dependencies, entityDep)
+	}
+
+	buildInfo.Modules = append(buildInfo.Modules, module)
+	return buildInfo, nil
+}
+
+// GetProjectDependencies returns all project dependencies with full details.
+func (uf *UvFlexPack) GetProjectDependencies() ([]DependencyInfo, error) {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	return uf.dependencies, nil
+}
+
+// GetDependencyGraph returns the complete dependency graph.
+func (uf *UvFlexPack) GetDependencyGraph() (map[string][]string, error) {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	return uf.depGraph, nil
+}
+
+// getUvVersion returns the installed UV version string.
+func (uf *UvFlexPack) getUvVersion() string {
+	cmd := exec.Command("uv", "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		log.Debug("Failed to get UV version: " + err.Error())
+		return "unknown"
+	}
+	version := strings.TrimSpace(string(output))
+	// UV version output format: "uv 0.4.10"
+	if parts := strings.Fields(version); len(parts) >= 2 {
+		return parts[1]
+	}
+	return version
+}

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -77,21 +77,23 @@ type UvPyProjectToml struct {
 
 // UvFlexPack implements FlexPackManager and BuildInfoCollector for the UV package manager
 type UvFlexPack struct {
-	config         UvConfig
-	lockFileData   *UvLockFile
-	pyprojectData  *UvPyProjectToml
-	projectName    string
-	projectVersion string
-	dependencies   []DependencyInfo
-	depGraph       map[string][]string // normalized-name -> []normalized-name
+	config            UvConfig
+	lockFileData      *UvLockFile
+	pyprojectData     *UvPyProjectToml
+	projectName       string
+	projectVersion    string
+	dependencies      []DependencyInfo
+	depGraph          map[string][]string  // normalized-name -> []normalized-name
+	requestedByChains map[string][][]string // dep ID -> full chains back to root (UV-specific)
 }
 
 // NewUvFlexPack creates a new UvFlexPack instance.
 func NewUvFlexPack(config UvConfig) (*UvFlexPack, error) {
 	uf := &UvFlexPack{
-		config:       config,
-		dependencies: []DependencyInfo{},
-		depGraph:     make(map[string][]string),
+		config:            config,
+		dependencies:      []DependencyInfo{},
+		depGraph:          make(map[string][]string),
+		requestedByChains: make(map[string][][]string),
 	}
 	if err := uf.loadPyProjectToml(); err != nil {
 		return nil, fmt.Errorf("failed to load pyproject.toml: %w", err)
@@ -167,40 +169,63 @@ func bestHash(pkg UvPackage) string {
 	return ""
 }
 
-// depFilename returns the filename-based ID for a package.
-// Prefers pure-Python wheel filename, falls back to first wheel filename, then sdist filename.
-// Falls back to "name-version" if no artifacts are present.
-func depFilename(pkg UvPackage) string {
+// depFileType returns the file extension type for a package artifact.
+// Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
+// Matches pip/pipenv behavior: "whl", "tar.gz", "zip", etc.
+func depFileType(pkg UvPackage) string {
+	bestURL := ""
 	for _, w := range pkg.Wheels {
 		if strings.Contains(w.URL, "none-any") && w.URL != "" {
-			return filepath.Base(w.URL)
+			bestURL = w.URL
+			break
 		}
 	}
-	for _, w := range pkg.Wheels {
-		if w.URL != "" {
-			return filepath.Base(w.URL)
+	if bestURL == "" {
+		for _, w := range pkg.Wheels {
+			if w.URL != "" {
+				bestURL = w.URL
+				break
+			}
 		}
 	}
-	if pkg.Sdist != nil && pkg.Sdist.URL != "" {
-		return filepath.Base(pkg.Sdist.URL)
+	if bestURL == "" && pkg.Sdist != nil && pkg.Sdist.URL != "" {
+		bestURL = pkg.Sdist.URL
 	}
-	return fmt.Sprintf("%s-%s", pkg.Name, pkg.Version)
+	if bestURL == "" {
+		return ""
+	}
+	base := filepath.Base(bestURL)
+	if strings.HasSuffix(base, ".tar.gz") {
+		return "tar.gz"
+	}
+	if i := strings.LastIndex(base, "."); i != -1 {
+		return base[i+1:]
+	}
+	return ""
 }
 
 // parseDependencies populates uf.dependencies and uf.depGraph from the lock file.
+// ID format and requestedBy chains match the pip/pipenv canonical build-info format:
+//   - dep ID:  "name:version"  (e.g. "certifi:2026.2.25")
+//   - dep type: file extension (e.g. "whl", "tar.gz")
+//   - requestedBy: full chain back to root module (e.g. [["requests:2.33.1","myapp:0.1.0"]])
+//   - direct deps: requestedBy = [["myapp:0.1.0"]]
+//   - no scopes (Python has no compile/runtime distinction; matches pip/pipenv)
 func (uf *UvFlexPack) parseDependencies() {
 	if uf.lockFileData == nil {
 		return
 	}
 
-	// Build a name->package map (last-write-wins for resolver forks)
+	moduleID := fmt.Sprintf("%s:%s", uf.projectName, uf.projectVersion)
+
+	// Build name->package map
 	pkgByName := make(map[string]*UvPackage)
 	for i := range uf.lockFileData.Packages {
 		pkg := &uf.lockFileData.Packages[i]
 		pkgByName[normalizeName(pkg.Name)] = pkg
 	}
 
-	// Find the root workspace package (virtual or editable at ".")
+	// Find root workspace package
 	var rootPkg *UvPackage
 	for i := range uf.lockFileData.Packages {
 		pkg := &uf.lockFileData.Packages[i]
@@ -210,7 +235,7 @@ func (uf *UvFlexPack) parseDependencies() {
 		}
 	}
 
-	// Collect direct main and dev dep names (always collect both for exclusion logic)
+	// Collect direct main and dev dep names
 	directMainDeps := make(map[string]bool)
 	directDevDeps := make(map[string]bool)
 	if rootPkg != nil {
@@ -224,61 +249,156 @@ func (uf *UvFlexPack) parseDependencies() {
 		}
 	}
 
-	// Build inverse RequestedBy map: depName -> []parentName
-	inverse := make(map[string][]string)
-	for _, pkg := range uf.lockFileData.Packages {
-		if pkg.Source.IsWorkspacePackage() {
-			continue
-		}
-		parentName := normalizeName(pkg.Name)
-		for _, edge := range pkg.Dependencies {
-			childName := normalizeName(edge.Name)
-			inverse[childName] = append(inverse[childName], parentName)
-		}
+	// When excluding dev deps and the project has BOTH main deps and dev deps declared,
+	// compute the reachable set from main deps via BFS. This excludes transitive-only dev deps
+	// (e.g. pytest's dependencies like pluggy, iniconfig) — not just the direct dev dep itself.
+	// If only one side is present (no main deps or no dev deps), fall back to the simple check.
+	var mainReachable map[string]bool
+	if !uf.config.IncludeDevDependencies && rootPkg != nil &&
+		len(directMainDeps) > 0 && len(directDevDeps) > 0 {
+		mainReachable = computeMainReachable(directMainDeps, pkgByName)
 	}
 
-	// Build dep graph and dependency list
-	for _, pkg := range uf.lockFileData.Packages {
+	// Build depInfo map: normalizedName -> *DependencyInfo
+	// Only non-workspace packages. Exclusion logic when IncludeDevDependencies=false:
+	//   - With reachability analysis: skip anything not reachable from main deps
+	//   - Without (no dev deps or no main deps declared): skip direct dev deps only
+	depInfoMap := make(map[string]*DependencyInfo)
+	for i := range uf.lockFileData.Packages {
+		pkg := &uf.lockFileData.Packages[i]
 		if pkg.Source.IsWorkspacePackage() {
 			continue
 		}
 		normalizedName := normalizeName(pkg.Name)
-
-		// Determine scope
-		var scope string
-		if directMainDeps[normalizedName] {
-			scope = "compile"
-		} else if directDevDeps[normalizedName] {
-			scope = "test"
-		} else {
-			// Transitive: use "compile" as default
-			scope = "compile"
+		if !uf.config.IncludeDevDependencies {
+			if mainReachable != nil {
+				if !mainReachable[normalizedName] {
+					continue // reachability analysis: exclude dev-only transitive deps
+				}
+			} else if directDevDeps[normalizedName] {
+				continue // simple fallback: exclude direct dev deps only
+			}
 		}
+		depInfoMap[normalizedName] = &DependencyInfo{
+			ID:      fmt.Sprintf("%s:%s", pkg.Name, pkg.Version),
+			Name:    pkg.Name,
+			Version: pkg.Version,
+			Type:    depFileType(*pkg),
+			SHA256:  extractSHA256(bestHash(*pkg)),
+		}
+	}
 
-		// Skip dev deps if not including them
-		if !uf.config.IncludeDevDependencies && directDevDeps[normalizedName] {
+	// Build forward dep graph: normalizedName -> []normalizedName (children present in depInfoMap)
+	fwdGraph := make(map[string][]string)
+	for normalizedName := range depInfoMap {
+		pkg := pkgByName[normalizedName]
+		if pkg == nil {
 			continue
 		}
-
-		// Build dep graph entry
-		var childNames []string
+		var children []string
 		for _, edge := range pkg.Dependencies {
-			childNames = append(childNames, normalizeName(edge.Name))
+			childName := normalizeName(edge.Name)
+			if _, ok := depInfoMap[childName]; ok {
+				children = append(children, childName)
+			}
 		}
-		uf.depGraph[normalizedName] = childNames
+		fwdGraph[normalizedName] = children
+		uf.depGraph[depInfoMap[normalizedName].ID] = func() []string {
+			var ids []string
+			for _, c := range children {
+				ids = append(ids, depInfoMap[c].ID)
+			}
+			return ids
+		}()
+	}
 
-		dep := DependencyInfo{
-			ID:          depFilename(pkg),
-			Name:        pkg.Name,
-			Version:     pkg.Version,
-			Type:        "pypi",
-			SHA256:      extractSHA256(bestHash(pkg)),
-			SHA1:        "",
-			MD5:         "",
-			Scopes:      []string{scope},
-			RequestedBy: inverse[normalizedName],
+	// Collect direct children of root (main deps; optionally dev deps)
+	var rootChildren []string
+	if rootPkg != nil {
+		for _, edge := range rootPkg.Dependencies {
+			n := normalizeName(edge.Name)
+			if _, ok := depInfoMap[n]; ok {
+				rootChildren = append(rootChildren, n)
+			}
 		}
-		uf.dependencies = append(uf.dependencies, dep)
+		if uf.config.IncludeDevDependencies {
+			for _, edges := range rootPkg.DevDependencies {
+				for _, edge := range edges {
+					n := normalizeName(edge.Name)
+					if _, ok := depInfoMap[n]; ok {
+						rootChildren = append(rootChildren, n)
+					}
+				}
+			}
+		}
+	} else {
+		// No lockfile root found — treat all non-workspace packages as direct deps
+		for n := range depInfoMap {
+			rootChildren = append(rootChildren, n)
+		}
+	}
+
+	// Build requestedBy chains using pip's recursive DFS approach.
+	// Results go into uf.requestedByChains (map[string][][]string), NOT into DependencyInfo.RequestedBy.
+	// This keeps the shared DependencyInfo type ([]string) unchanged for poetry/maven.
+	buildUvRequestedBy(moduleID, []string{}, rootChildren, depInfoMap, fwdGraph, uf.requestedByChains, entities.RequestedByMaxLength)
+
+	for _, dep := range depInfoMap {
+		uf.dependencies = append(uf.dependencies, *dep)
+	}
+}
+
+// computeMainReachable returns the set of normalizedNames reachable from main (non-dev) deps
+// via BFS through the forward dependency graph. Used to exclude dev-only transitive deps.
+func computeMainReachable(directMainDeps map[string]bool, pkgByName map[string]*UvPackage) map[string]bool {
+	reachable := make(map[string]bool)
+	queue := make([]string, 0, len(directMainDeps))
+	for name := range directMainDeps {
+		queue = append(queue, name)
+	}
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if reachable[name] {
+			continue
+		}
+		reachable[name] = true
+		if pkg, ok := pkgByName[name]; ok {
+			for _, edge := range pkg.Dependencies {
+				childName := normalizeName(edge.Name)
+				if !reachable[childName] {
+					queue = append(queue, childName)
+				}
+			}
+		}
+	}
+	return reachable
+}
+
+// buildUvRequestedBy recursively builds requestedBy chains matching pip/pipenv format.
+// Results are written into chains (dep ID → [][]string), not into DependencyInfo.
+// parentID is the current parent's "name:version" ID.
+// parentChain is the chain from parentID back to the root (not including parentID itself).
+func buildUvRequestedBy(parentID string, parentChain []string, children []string, depInfoMap map[string]*DependencyInfo, fwdGraph map[string][]string, chains map[string][][]string, maxDepth int) {
+	for _, childName := range children {
+		child, ok := depInfoMap[childName]
+		if !ok {
+			continue
+		}
+		if len(chains[child.ID]) >= maxDepth {
+			continue
+		}
+		// New chain entry: [parentID, ...parentChain]
+		newChain := append([]string{parentID}, parentChain...)
+		// Cycle check: if child's own ID already appears in the chain, skip
+		for _, id := range newChain {
+			if id == child.ID {
+				goto next
+			}
+		}
+		chains[child.ID] = append(chains[child.ID], newChain)
+		buildUvRequestedBy(child.ID, newChain, fwdGraph[childName], depInfoMap, fwdGraph, chains, maxDepth)
+	next:
 	}
 }
 
@@ -350,18 +470,35 @@ func (uf *UvFlexPack) CalculateScopes() []string {
 	return scopes
 }
 
-// CalculateRequestedBy returns a map from dependency ID to the list of packages that request it.
+// CalculateRequestedBy returns the direct parent for each dependency ID.
+// Satisfies the FlexPackManager interface (returns map[string][]string).
+// For the full [][]string chains, see requestedByChains.
 func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
 	if len(uf.dependencies) == 0 {
 		uf.parseDependencies()
 	}
+	// Flatten each chain to its first element (direct parent) for the []string interface.
 	result := make(map[string][]string)
-	for _, dep := range uf.dependencies {
-		if len(dep.RequestedBy) > 0 {
-			result[dep.ID] = dep.RequestedBy
+	for depID, chains := range uf.requestedByChains {
+		seen := make(map[string]bool)
+		for _, chain := range chains {
+			if len(chain) > 0 && !seen[chain[0]] {
+				result[depID] = append(result[depID], chain[0])
+				seen[chain[0]] = true
+			}
 		}
 	}
 	return result
+}
+
+// GetRequestedByChains returns the full [][]string requestedBy chains for each dependency.
+// Each inner slice is a path from the immediate parent back to the root module.
+// Use this when you need the complete chain (e.g. in tests or build-info consumers).
+func (uf *UvFlexPack) GetRequestedByChains() map[string][][]string {
+	if len(uf.dependencies) == 0 {
+		uf.parseDependencies()
+	}
+	return uf.requestedByChains
 }
 
 // ===== BuildInfoCollector Interface =====
@@ -391,17 +528,14 @@ func (uf *UvFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities
 
 	for _, dep := range deps {
 		entityDep := entities.Dependency{
-			Id:     dep.ID,
-			Type:   dep.Type,
-			Scopes: dep.Scopes,
+			Id:          dep.ID,
+			Type:        dep.Type,
+			RequestedBy: uf.requestedByChains[dep.ID], // full [][]string chains (UV-specific field)
 			Checksum: entities.Checksum{
 				Sha1:   dep.SHA1,
 				Sha256: dep.SHA256,
 				Md5:    dep.MD5,
 			},
-		}
-		if len(dep.RequestedBy) > 0 {
-			entityDep.RequestedBy = [][]string{dep.RequestedBy}
 		}
 		module.Dependencies = append(module.Dependencies, entityDep)
 	}

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -107,6 +107,7 @@ func (uf *UVFlexPack) loadPyProjectToml() error {
 	// have no pyproject.toml), skip file loading and use the overrides directly.
 	if uf.config.ProjectName != "" {
 		uf.projectName = uf.config.ProjectName
+		// ProjectVersion may be empty for PEP 723 inline scripts; results in "name:" module ID which is acceptable
 		uf.projectVersion = uf.config.ProjectVersion
 		return nil
 	}
@@ -160,18 +161,23 @@ func extractSHA256(hash string) string {
 	return strings.TrimPrefix(hash, "sha256:")
 }
 
-// bestHash returns the best available hash for a package.
+// selectPackageHash returns the best available hash for a package.
 // Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
-func bestHash(pkg UVPackage) string {
+func selectPackageHash(pkg UVPackage) string {
+	var firstWheelHash string
 	for _, w := range pkg.Wheels {
-		if strings.Contains(w.URL, "none-any") && w.Hash != "" {
-			return w.Hash
+		if w.Hash == "" {
+			continue
+		}
+		if strings.Contains(w.URL, "none-any") {
+			return w.Hash // universal wheel — best choice
+		}
+		if firstWheelHash == "" {
+			firstWheelHash = w.Hash
 		}
 	}
-	for _, w := range pkg.Wheels {
-		if w.Hash != "" {
-			return w.Hash
-		}
+	if firstWheelHash != "" {
+		return firstWheelHash
 	}
 	if pkg.Sdist != nil && pkg.Sdist.Hash != "" {
 		return pkg.Sdist.Hash
@@ -183,32 +189,29 @@ func bestHash(pkg UVPackage) string {
 // Prefers pure-Python wheel (none-any), falls back to first wheel, then sdist.
 // Matches pip/pipenv behavior: "whl", "tar.gz", "zip", etc.
 func depFileType(pkg UVPackage) string {
-	bestURL := ""
+	var selectedURL string
 	for _, w := range pkg.Wheels {
-		if strings.Contains(w.URL, "none-any") && w.URL != "" {
-			bestURL = w.URL
-			break
+		if w.URL == "" {
+			continue
+		}
+		if strings.Contains(w.URL, "none-any") {
+			selectedURL = w.URL
+			break // universal wheel — best choice
+		}
+		if selectedURL == "" {
+			selectedURL = w.URL // first platform wheel as fallback
 		}
 	}
-	if bestURL == "" {
-		for _, w := range pkg.Wheels {
-			if w.URL != "" {
-				bestURL = w.URL
-				break
-			}
-		}
+	if selectedURL == "" && pkg.Sdist != nil && pkg.Sdist.URL != "" {
+		selectedURL = pkg.Sdist.URL
 	}
-	if bestURL == "" && pkg.Sdist != nil && pkg.Sdist.URL != "" {
-		bestURL = pkg.Sdist.URL
-	}
-	if bestURL == "" {
-		// Git deps have no archive — return "git" so build-info reflects the source type.
+	if selectedURL == "" {
 		if pkg.Source.Git != "" {
 			return "git"
 		}
 		return ""
 	}
-	base := filepath.Base(bestURL)
+	base := filepath.Base(selectedURL)
 	if strings.HasSuffix(base, ".tar.gz") {
 		return "tar.gz"
 	}
@@ -329,12 +332,10 @@ func buildDepInfoMap(packages []UVPackage, includeDevDeps bool, mainReachable ma
 		}
 		normalizedName := normalizeName(pkg.Name)
 		if !includeDevDeps {
-			if mainReachable != nil {
-				if !mainReachable[normalizedName] {
-					continue // reachability analysis: exclude dev-only transitive deps
-				}
-			} else if directDevDeps[normalizedName] {
-				continue // simple fallback: exclude direct dev deps only
+			excluded := (mainReachable != nil && !mainReachable[normalizedName]) ||
+				(mainReachable == nil && directDevDeps[normalizedName])
+			if excluded {
+				continue
 			}
 		}
 		// DirectURL is set for deps not from a registry: direct URL or git.
@@ -348,7 +349,7 @@ func buildDepInfoMap(packages []UVPackage, includeDevDeps bool, mainReachable ma
 			Name:      pkg.Name,
 			Version:   pkg.Version,
 			Type:      depFileType(*pkg),
-			SHA256:    extractSHA256(bestHash(*pkg)),
+			SHA256:    extractSHA256(selectPackageHash(*pkg)),
 			DirectURL: directURL,
 		}
 	}
@@ -359,7 +360,7 @@ func buildDepInfoMap(packages []UVPackage, includeDevDeps bool, mainReachable ma
 // Also populates idGraph with ID-keyed edges.
 func buildForwardGraph(depInfoMap map[string]*DependencyInfo, pkgByName map[string]*UVPackage, idGraph map[string][]string) map[string][]string {
 	fwdGraph := make(map[string][]string, len(depInfoMap))
-	for normalizedName := range depInfoMap {
+	for normalizedName, info := range depInfoMap {
 		pkg := pkgByName[normalizedName]
 		if pkg == nil {
 			continue
@@ -372,7 +373,7 @@ func buildForwardGraph(depInfoMap map[string]*DependencyInfo, pkgByName map[stri
 			}
 		}
 		fwdGraph[normalizedName] = children
-		idGraph[depInfoMap[normalizedName].ID] = func() []string {
+		idGraph[info.ID] = func() []string {
 			var ids []string
 			for _, c := range children {
 				ids = append(ids, depInfoMap[c].ID)
@@ -406,7 +407,7 @@ func buildDepInfoMapFromInstalled(packages []UVPackage, installedPkgs map[string
 			Name:      pkg.Name,
 			Version:   pkg.Version,
 			Type:      depFileType(*pkg),
-			SHA256:    extractSHA256(bestHash(*pkg)),
+			SHA256:    extractSHA256(selectPackageHash(*pkg)),
 			DirectURL: directURL,
 		}
 	}
@@ -513,14 +514,17 @@ func buildUvRequestedBy(parentID string, parentChain []string, children []string
 		// New chain entry: [parentID, ...parentChain]
 		newChain := append([]string{parentID}, parentChain...)
 		// Cycle check: if child's own ID already appears in the chain, skip
+		hasCycle := false
 		for _, id := range newChain {
 			if id == child.ID {
-				goto next
+				hasCycle = true
+				break
 			}
 		}
-		chains[child.ID] = append(chains[child.ID], newChain)
-		buildUvRequestedBy(child.ID, newChain, fwdGraph[childName], depInfoMap, fwdGraph, chains, maxDepth)
-	next:
+		if !hasCycle {
+			chains[child.ID] = append(chains[child.ID], newChain)
+			buildUvRequestedBy(child.ID, newChain, fwdGraph[childName], depInfoMap, fwdGraph, chains, maxDepth)
+		}
 	}
 }
 

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -45,11 +46,6 @@ func (s UvSource) IsWorkspacePackage() bool {
 	return s.Virtual != "" || s.Editable != "" || s.Directory != ""
 }
 
-// HasArtifacts returns true if this source type provides sdist/wheel artifacts.
-func (s UvSource) HasArtifacts() bool {
-	return s.Registry != "" || s.URL != ""
-}
-
 // UvArtifact represents an sdist or wheel entry in uv.lock
 type UvArtifact struct {
 	URL        string `toml:"url"`
@@ -82,8 +78,9 @@ type UvFlexPack struct {
 	pyprojectData     *UvPyProjectToml
 	projectName       string
 	projectVersion    string
+	parsed            bool
 	dependencies      []DependencyInfo
-	depGraph          map[string][]string  // normalized-name -> []normalized-name
+	depGraph          map[string][]string   // dep ID ("name:version") -> []dep IDs
 	requestedByChains map[string][][]string // dep ID -> full chains back to root (UV-specific)
 }
 
@@ -140,9 +137,11 @@ func (uf *UvFlexPack) loadUvLock() error {
 	return nil
 }
 
-// normalizeName converts package names to lowercase with hyphens.
+var pep503Re = regexp.MustCompile(`[-_.]+`)
+
+// normalizeName converts package names to lowercase with hyphens per PEP 503.
 func normalizeName(name string) string {
-	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+	return pep503Re.ReplaceAllString(strings.ToLower(name), "-")
 }
 
 // extractSHA256 strips the "sha256:" prefix from a hash string.
@@ -204,6 +203,15 @@ func depFileType(pkg UvPackage) string {
 	return ""
 }
 
+// ensureParsed calls parseDependencies exactly once.
+func (uf *UvFlexPack) ensureParsed() {
+	if uf.parsed {
+		return
+	}
+	uf.parseDependencies()
+	uf.parsed = true
+}
+
 // parseDependencies populates uf.dependencies and uf.depGraph from the lock file.
 // ID format and requestedBy chains match the pip/pipenv canonical build-info format:
 //   - dep ID:  "name:version"  (e.g. "certifi:2026.2.25")
@@ -229,7 +237,7 @@ func (uf *UvFlexPack) parseDependencies() {
 	var rootPkg *UvPackage
 	for i := range uf.lockFileData.Packages {
 		pkg := &uf.lockFileData.Packages[i]
-		if pkg.Source.Virtual == "." || pkg.Source.Editable == "." {
+		if pkg.Source.Virtual == "." || pkg.Source.Editable == "." || pkg.Source.Directory == "." {
 			rootPkg = pkg
 			break
 		}
@@ -406,9 +414,7 @@ func buildUvRequestedBy(parentID string, parentChain []string, children []string
 
 // GetDependency returns a formatted string with dependency information.
 func (uf *UvFlexPack) GetDependency() string {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	var result strings.Builder
 	fmt.Fprintf(&result, "Project: %s:%s\n", uf.projectName, uf.projectVersion)
 	result.WriteString("Dependencies:\n")
@@ -420,9 +426,7 @@ func (uf *UvFlexPack) GetDependency() string {
 
 // ParseDependencyToList returns a list of "name:version" strings for all dependencies.
 func (uf *UvFlexPack) ParseDependencyToList() []string {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	var depList []string
 	for _, dep := range uf.dependencies {
 		depList = append(depList, fmt.Sprintf("%s:%s", dep.Name, dep.Version))
@@ -432,9 +436,7 @@ func (uf *UvFlexPack) ParseDependencyToList() []string {
 
 // CalculateChecksum returns checksum maps for all dependencies.
 func (uf *UvFlexPack) CalculateChecksum() []map[string]interface{} {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	var checksums []map[string]interface{}
 	for _, dep := range uf.dependencies {
 		checksumMap := map[string]interface{}{
@@ -454,9 +456,7 @@ func (uf *UvFlexPack) CalculateChecksum() []map[string]interface{} {
 
 // CalculateScopes returns the unique set of scopes across all dependencies.
 func (uf *UvFlexPack) CalculateScopes() []string {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	scopesMap := make(map[string]bool)
 	for _, dep := range uf.dependencies {
 		for _, scope := range dep.Scopes {
@@ -474,9 +474,7 @@ func (uf *UvFlexPack) CalculateScopes() []string {
 // Satisfies the FlexPackManager interface (returns map[string][]string).
 // For the full [][]string chains, see requestedByChains.
 func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	// Flatten each chain to its first element (direct parent) for the []string interface.
 	result := make(map[string][]string)
 	for depID, chains := range uf.requestedByChains {
@@ -495,9 +493,7 @@ func (uf *UvFlexPack) CalculateRequestedBy() map[string][]string {
 // Each inner slice is a path from the immediate parent back to the root module.
 // Use this when you need the complete chain (e.g. in tests or build-info consumers).
 func (uf *UvFlexPack) GetRequestedByChains() map[string][][]string {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	return uf.requestedByChains
 }
 
@@ -546,17 +542,13 @@ func (uf *UvFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities
 
 // GetProjectDependencies returns all project dependencies with full details.
 func (uf *UvFlexPack) GetProjectDependencies() ([]DependencyInfo, error) {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	return uf.dependencies, nil
 }
 
 // GetDependencyGraph returns the complete dependency graph.
 func (uf *UvFlexPack) GetDependencyGraph() (map[string][]string, error) {
-	if len(uf.dependencies) == 0 {
-		uf.parseDependencies()
-	}
+	uf.ensureParsed()
 	return uf.depGraph, nil
 }
 

--- a/utils/pythonutils/utils.go
+++ b/utils/pythonutils/utils.go
@@ -18,6 +18,7 @@ const (
 	Pipenv PythonTool = "pipenv"
 	Poetry PythonTool = "poetry"
 	Twine  PythonTool = "twine"
+	UV     PythonTool = "uv"
 
 	startDownloadingPattern = `^\s*Downloading\s`
 	downloadingCaptureGroup = `[^\s]*`


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Appropriate label is added to the PR for auto generate release notes.
---

Adds UV package manager support via the FlexPack pattern.

**New: `UVFlexPack`** — reads `uv.lock` (TOML) to collect dependency build-info without running any subprocess. Implements both `FlexPackManager` and `BuildInfoCollector` interfaces.

**Key behaviors:**
- Dependency IDs in `name:version` format; `sha256` from lock file hashes
- `requestedBy` chains built via BFS over the resolved dependency graph
- Dev dependencies excluded by default (`IncludeDevDependencies: false`); `InstalledPackages` map (from `uv pip list`) used as ground truth when available — correctly handles all `--no-dev`/`--only-dev`/`--group`/`--only-group` flag combinations without flag parsing
- Direct URL deps (`source = { url = "..." }`) and git deps (`source = { git = "..." }`) tracked with `DirectURL` field; `type` set to `"git"` for git sources; `GetDirectURLDeps()` exposes them so callers can skip Artifactory AQL enrichment for non-registry packages
- `LockFilePath` / `ProjectName` / `ProjectVersion` config overrides enable use with PEP 723 inline scripts (adjacent `script.py.lock` file, no `pyproject.toml`)
- `parseDependencies` split into focused helpers; `ensureParsed()` guard for idempotency; PEP 503 name normalization

**`mergeArtifacts` fix** (`entities/buildinfo.go`): when two artifacts share the same SHA1, prefer the one with a real Artifactory path over `path="."` — prevents build-step artifacts from blocking the correct path set by the publish step.