### PR TITLE
Enhance Yarn module to support workspace projects and non-registry de…

### DIFF
--- a/build/utils/yarn.go
+++ b/build/utils/yarn.go
@@ -105,12 +105,20 @@ func GetYarnExecutable() (string, error) {
 // log - The logger.
 // allowPartialResults - If true, the function will allow some errors to occur without failing the flow and will generate partial results.
 func GetYarnDependencies(executablePath, srcPath string, packageInfo *PackageInfo, log utils.Log, allowPartialResults bool) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
-	executableVersionStr, err := GetVersion(executablePath, srcPath)
-	if err != nil {
-		return
+	return GetYarnDependenciesWithVersion(executablePath, srcPath, packageInfo, "", log, allowPartialResults)
+}
+
+// GetYarnDependenciesWithVersion is the same as GetYarnDependencies but accepts a pre-fetched
+// yarn version string to avoid re-running 'yarn --version'. Pass an empty string to fetch it.
+func GetYarnDependenciesWithVersion(executablePath, srcPath string, packageInfo *PackageInfo, yarnVersion string, log utils.Log, allowPartialResults bool) (dependenciesMap map[string]*YarnDependency, root *YarnDependency, err error) {
+	if yarnVersion == "" {
+		yarnVersion, err = GetVersion(executablePath, srcPath)
+		if err != nil {
+			return
+		}
 	}
 
-	isV2AndAbove := version.NewVersion(executableVersionStr).Compare(yarnV2Version) <= 0
+	isV2AndAbove := version.NewVersion(yarnVersion).Compare(yarnV2Version) <= 0
 
 	// Run 'yarn info or list'
 	responseStr, errStr, err := runYarnInfoOrList(executablePath, srcPath, isV2AndAbove)
@@ -264,6 +272,29 @@ func buildYarnV2DependencyMap(packageInfo *PackageInfo, responseStr string) (dep
 }
 
 // Depending on the Yarn version currently in use for the project, this function runs the command that retrieves the project's dependencies
+// IsYarnWorkspaceProject returns true when the project at srcPath is a yarn workspace
+// (monorepo). It runs `yarn workspaces list --json` and checks whether the output
+// contains more than one entry — a workspace project always lists the root plus at
+// least one member, while a plain project lists only the root.
+// Only meaningful for yarn v2+; v1 does not support the command.
+func IsYarnWorkspaceProject(executablePath, srcPath string) (bool, error) {
+	command := exec.Command(executablePath, "workspaces", "list", "--json")
+	command.Dir = srcPath
+	var outBuffer, errBuffer bytes.Buffer
+	command.Stdout = &outBuffer
+	command.Stderr = &errBuffer
+	if err := command.Run(); err != nil {
+		stderr := strings.TrimSpace(errBuffer.String())
+		if stderr != "" {
+			return false, fmt.Errorf("failed to run 'yarn workspaces list': %w\nstderr: %s", err, stderr)
+		}
+		return false, fmt.Errorf("failed to run 'yarn workspaces list': %w", err)
+	}
+	output := strings.TrimSpace(outBuffer.String())
+	lines := strings.Split(output, "\n")
+	return len(lines) > 1, nil
+}
+
 func runYarnInfoOrList(executablePath string, srcPath string, v2AndAbove bool) (outResult, errResult string, err error) {
 	var command *exec.Cmd
 	if v2AndAbove {
@@ -409,4 +440,54 @@ type YarnDepDetails struct {
 type YarnDependencyPointer struct {
 	Descriptor string `json:"descriptor,omitempty"`
 	Locator    string `json:"locator,omitempty"`
+}
+
+// extractLocatorProtocol returns the protocol portion of a yarn locator, e.g. "npm",
+// "workspace", "link", "file", "portal", "patch", "git+https", "https".
+// Locator format: <name>@<protocol>:<rest>  (scoped: @scope/name@<protocol>:<rest>)
+func extractLocatorProtocol(locator string) string {
+	if len(locator) < 2 {
+		return ""
+	}
+	// skip leading '@' for scoped packages — find second '@'
+	atIdx := strings.Index(locator[1:], "@")
+	if atIdx < 0 {
+		return ""
+	}
+	after := locator[atIdx+2:] // everything after the version-separator '@'
+	colonIdx := strings.Index(after, ":")
+	if colonIdx < 0 {
+		return after
+	}
+	return after[:colonIdx]
+}
+
+// IsWorkspaceLocator reports whether locator points to a local yarn workspace member.
+func IsWorkspaceLocator(locator string) bool {
+	return extractLocatorProtocol(locator) == "workspace"
+}
+
+// nonRegistryProtocols lists yarn locator protocols that resolve from local disk or
+// VCS rather than an npm registry / Artifactory.
+var nonRegistryProtocols = map[string]bool{
+	"workspace": true,
+	"link":      true,
+	"file":      true,
+	"portal":    true,
+	"patch":     true,
+	"git+https": true,
+	"git+ssh":   true,
+	"https":     true, // raw URL dep
+}
+
+// IsNonRegistryLocator returns true when locator resolves from a source other than
+// an npm registry (e.g. local path, git, patch). Such deps have no Artifactory
+// checksum and should be excluded from build-info emission.
+func IsNonRegistryLocator(locator string) bool {
+	return nonRegistryProtocols[extractLocatorProtocol(locator)]
+}
+
+// ExtractLocatorProtocol is the exported form for use in log messages.
+func ExtractLocatorProtocol(locator string) string {
+	return extractLocatorProtocol(locator)
 }

--- a/build/utils/yarn_test.go
+++ b/build/utils/yarn_test.go
@@ -239,3 +239,70 @@ func TestSplitNameAndVersion(t *testing.T) {
 	_, _, err := splitNameAndVersion(incorrectFormatPackageName)
 	assert.Error(t, err)
 }
+
+func TestIsYarnWorkspaceProject(t *testing.T) {
+	executablePath, err := GetYarnExecutable()
+	assert.NoError(t, err)
+
+	testDataPath := filepath.Join("..", "testdata", "yarn")
+
+	// v2 project is a plain (non-workspace) project — expects false.
+	nonWorkspacePath := filepath.Join(testDataPath, "v2", "project")
+	isWorkspace, err := IsYarnWorkspaceProject(executablePath, nonWorkspacePath)
+	assert.NoError(t, err)
+	assert.False(t, isWorkspace, "plain yarn project should not be detected as workspace")
+}
+
+func TestExtractLocatorProtocol(t *testing.T) {
+	testCases := []struct {
+		locator          string
+		expectedProtocol string
+	}{
+		{"xml@npm:1.0.1", "npm"},
+		{"pkg-a@workspace:packages/pkg-a", "workspace"},
+		{"@scope/pkg@workspace:.", "workspace"},
+		{"local-lib@link:./local-lib", "link"},
+		{"filelib@file:./filelib.tgz", "file"},
+		{"portallib@portal:./portallib", "portal"},
+		{"left-pad@patch:left-pad@npm%3A1.3.0#./patch.patch", "patch"},
+		{"left-pad@https://github.com/stevemao/left-pad.git#commit=abc", "https"},
+		{"left-pad@git+https://github.com/stevemao/left-pad.git#commit=abc", "git+https"},
+	}
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedProtocol, extractLocatorProtocol(tc.locator), "locator: %s", tc.locator)
+	}
+}
+
+func TestIsWorkspaceLocator(t *testing.T) {
+	assert.True(t, IsWorkspaceLocator("pkg-a@workspace:packages/pkg-a"))
+	assert.True(t, IsWorkspaceLocator("@scope/pkg@workspace:."))
+	assert.True(t, IsWorkspaceLocator("root@workspace:."))
+	assert.False(t, IsWorkspaceLocator("xml@npm:1.0.1"))
+	assert.False(t, IsWorkspaceLocator("local-lib@link:./local-lib"))
+	assert.False(t, IsWorkspaceLocator(""))
+	assert.False(t, IsWorkspaceLocator("x"))
+}
+
+func TestIsNonRegistryLocator(t *testing.T) {
+	registryCases := []string{
+		"xml@npm:1.0.1",
+		"@babel/highlight@npm:7.14.0",
+	}
+	for _, l := range registryCases {
+		assert.False(t, IsNonRegistryLocator(l), "expected registry: %s", l)
+	}
+
+	nonRegistryCases := []string{
+		"pkg-a@workspace:packages/pkg-a",
+		"local-lib@link:./local-lib",
+		"filelib@file:./filelib.tgz",
+		"portallib@portal:./portallib",
+		"left-pad@patch:left-pad@npm%3A1.3.0#./p.patch",
+		"left-pad@git+https://github.com/stevemao/left-pad.git#commit=abc",
+		"pkg@git+ssh://github.com/org/repo",
+		"left-pad@https://github.com/stevemao/left-pad.git#commit=abc",
+	}
+	for _, l := range nonRegistryCases {
+		assert.True(t, IsNonRegistryLocator(l), "expected non-registry: %s", l)
+	}
+}

--- a/build/yarn.go
+++ b/build/yarn.go
@@ -20,6 +20,7 @@ type YarnModule struct {
 	name                     string
 	srcPath                  string
 	executablePath           string
+	yarnVersion              string
 	yarnArgs                 []string
 	traverseDependenciesFunc func(dependency *entities.Dependency) (bool, error)
 	threads                  int
@@ -33,7 +34,7 @@ func newYarnModule(srcPath string, containingBuild *Build) (*YarnModule, error) 
 		return nil, err
 	}
 	containingBuild.logger.Debug("Found Yarn executable at:", executablePath)
-	err = validateYarnVersion(executablePath, srcPath)
+	yarnVersion, err := validateYarnVersion(executablePath, srcPath)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func newYarnModule(srcPath string, containingBuild *Build) (*YarnModule, error) 
 	}
 	name := packageInfo.BuildInfoModuleId()
 
-	return &YarnModule{name: name, srcPath: srcPath, containingBuild: containingBuild, executablePath: executablePath, threads: 3, packageInfo: packageInfo, yarnArgs: []string{"install"}}, nil
+	return &YarnModule{name: name, srcPath: srcPath, containingBuild: containingBuild, executablePath: executablePath, yarnVersion: yarnVersion, threads: 3, packageInfo: packageInfo, yarnArgs: []string{"install"}}, nil
 }
 
 // Build builds the project, collects its dependencies and saves them in the build-info module.
@@ -82,13 +83,39 @@ func (ym *YarnModule) Build() error {
 }
 
 func (ym *YarnModule) getDependenciesMap() (map[string]*entities.Dependency, error) {
-	dependenciesMap, root, err := buildutils.GetYarnDependencies(ym.executablePath, ym.srcPath, ym.packageInfo, ym.containingBuild.logger, false)
+	dependenciesMap, root, err := buildutils.GetYarnDependenciesWithVersion(ym.executablePath, ym.srcPath, ym.packageInfo, ym.yarnVersion, ym.containingBuild.logger, false)
 	if err != nil {
 		return nil, err
 	}
 	buildInfoDependencies := make(map[string]*entities.Dependency)
-	err = ym.appendDependencyRecursively(root, []string{}, dependenciesMap, buildInfoDependencies)
-	return buildInfoDependencies, err
+	if err = ym.appendDependencyRecursively(root, []string{}, dependenciesMap, buildInfoDependencies); err != nil {
+		return nil, err
+	}
+
+	// Workspace root projects (monorepos) have no dependency edges on the root node in
+	// `yarn info` output. Use `yarn workspaces list` to detect this case explicitly, then
+	// seed an additional walk from each workspace member so their deps are captured.
+	isWorkspace, err := buildutils.IsYarnWorkspaceProject(ym.executablePath, ym.srcPath)
+	if err != nil {
+		ym.containingBuild.logger.Warn("Could not determine workspace project status: " + err.Error())
+	}
+	if isWorkspace {
+		rootName, err := root.Name()
+		if err != nil {
+			return nil, err
+		}
+		rootId := rootName + ":" + root.Details.Version
+		for _, dep := range dependenciesMap {
+			if dep.Value != root.Value && buildutils.IsWorkspaceLocator(dep.Value) {
+				ym.containingBuild.logger.Debug(fmt.Sprintf(
+					"Workspace member '%s': seeding dependency walk", dep.Value))
+				if err = ym.appendDependencyRecursively(dep, []string{rootId}, dependenciesMap, buildInfoDependencies); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return buildInfoDependencies, nil
 }
 
 func (ym *YarnModule) appendDependencyRecursively(yarnDependency *buildutils.YarnDependency, pathToRoot []string, yarnDependenciesMap map[string]*buildutils.YarnDependency,
@@ -99,9 +126,29 @@ func (ym *YarnModule) appendDependencyRecursively(yarnDependency *buildutils.Yar
 	}
 	id := depName + ":" + yarnDependency.Details.Version
 
-	// To avoid infinite loops in case of circular dependencies, the dependency won't be added if it's already in pathToRoot
+	// Guard against circular dependencies.
 	if slices.Contains(pathToRoot, id) {
 		return nil
+	}
+
+	isNonRegistry := buildutils.IsNonRegistryLocator(yarnDependency.Value)
+	if isNonRegistry && len(pathToRoot) > 0 {
+		// Non-registry inner node (workspace sibling, link, file, portal, git dep).
+		// Log why it is skipped, then collapse it from the requestedBy chain (option B):
+		// pass parent's pathToRoot unchanged so the non-registry node does not appear
+		// as an intermediate in any descendant's requestedBy.
+		ym.containingBuild.logger.Debug(fmt.Sprintf(
+			"Skipping non-registry dependency '%s' (protocol: '%s'): local or non-Artifactory source",
+			id, buildutils.ExtractLocatorProtocol(yarnDependency.Value)))
+	}
+
+	// Determine the pathToRoot to pass to children.
+	// Root node (len==0): always extend so children record the module root in their chain.
+	// Non-registry inner node: collapse — pass parent pathToRoot unchanged.
+	// Registry inner node: extend normally.
+	childPath := pathToRoot
+	if len(pathToRoot) == 0 || !isNonRegistry {
+		childPath = append([]string{id}, pathToRoot...)
 	}
 
 	for _, dependencyPtr := range yarnDependency.Details.Dependencies {
@@ -110,15 +157,13 @@ func (ym *YarnModule) appendDependencyRecursively(yarnDependency *buildutils.Yar
 		if !exist {
 			return fmt.Errorf("an error occurred while creating dependencies tree: dependency %s was not found", dependencyPtr.Locator)
 		}
-		err = ym.appendDependencyRecursively(innerYarnDep, append([]string{id}, pathToRoot...), yarnDependenciesMap,
-			buildInfoDependencies)
-		if err != nil {
+		if err = ym.appendDependencyRecursively(innerYarnDep, childPath, yarnDependenciesMap, buildInfoDependencies); err != nil {
 			return err
 		}
 	}
 
-	// The root project should not be added to the dependencies list
-	if len(pathToRoot) == 0 {
+	// Root and non-registry nodes are not emitted as build-info dependencies.
+	if len(pathToRoot) == 0 || isNonRegistry {
 		return nil
 	}
 
@@ -128,8 +173,8 @@ func (ym *YarnModule) appendDependencyRecursively(yarnDependency *buildutils.Yar
 		buildInfoDependencies[id] = buildInfoDependency
 	}
 
-	// Limit requestedBy chains to prevent memory issues and excessive build-info size
-	// Following the same approach as Go, NuGet, and Python modules (see entities.RequestedByMaxLength)
+	// Limit requestedBy chains to prevent memory issues and excessive build-info size.
+	// Following the same approach as Go, NuGet, and Python modules (see entities.RequestedByMaxLength).
 	if len(buildInfoDependency.RequestedBy) < entities.RequestedByMaxLength {
 		buildInfoDependency.RequestedBy = append(buildInfoDependency.RequestedBy, pathToRoot)
 	}
@@ -160,16 +205,18 @@ func (ym *YarnModule) AddArtifacts(artifacts ...entities.Artifact) error {
 	return ym.containingBuild.AddArtifacts(ym.name, entities.Npm, artifacts...)
 }
 
-func validateYarnVersion(executablePath, srcPath string) error {
+// validateYarnVersion checks the installed yarn version against the minimum supported
+// version and returns the raw version string so callers can cache it.
+func validateYarnVersion(executablePath, srcPath string) (string, error) {
 	yarnVersionStr, err := buildutils.GetVersion(executablePath, srcPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	yarnVersion := version.NewVersion(yarnVersionStr)
 	if yarnVersion.Compare(minSupportedYarnVersion) > 0 {
-		return errors.New("Yarn must have version " + minSupportedYarnVersion + " or higher. The current version is: " + yarnVersionStr)
+		return "", errors.New("Yarn must have version " + minSupportedYarnVersion + " or higher. The current version is: " + yarnVersionStr)
 	}
-	return nil
+	return yarnVersionStr, nil
 }
 
 func RunYarnCommand(executablePath, srcPath string, args ...string) error {

--- a/build/yarn_test.go
+++ b/build/yarn_test.go
@@ -81,6 +81,80 @@ func TestAppendDependencyRecursively(t *testing.T) {
 	}
 }
 
+// TestAppendDependencyRecursively_NonRegistryCollapse verifies that non-registry locators
+// (workspace, link, file, portal, git) are excluded from build-info emission but their
+// transitive registry deps are still captured. The non-registry node is also collapsed
+// from the requestedBy chain (option B).
+func TestAppendDependencyRecursively_NonRegistryCollapse(t *testing.T) {
+	// Topology: root -> portal-dep (portal, non-registry) -> xml@npm (registry)
+	//                -> link-dep (link, non-registry)  [no transitive]
+	depMap := map[string]*buildutils.YarnDependency{
+		"xml@npm:1.0.1":                   {Value: "xml@npm:1.0.1", Details: buildutils.YarnDepDetails{Version: "1.0.1"}},
+		"portal-dep@portal:./portal-dep":  {Value: "portal-dep@portal:./portal-dep", Details: buildutils.YarnDepDetails{Version: "1.0.0", Dependencies: []buildutils.YarnDependencyPointer{{Locator: "xml@npm:1.0.1"}}}},
+		"link-dep@link:./link-dep":        {Value: "link-dep@link:./link-dep", Details: buildutils.YarnDepDetails{Version: "1.0.0"}},
+		"root@workspace:.":                {Value: "root@workspace:.", Details: buildutils.YarnDepDetails{Version: "1.0.0", Dependencies: []buildutils.YarnDependencyPointer{{Locator: "portal-dep@portal:./portal-dep"}, {Locator: "link-dep@link:./link-dep"}}}},
+	}
+	ym := &YarnModule{containingBuild: &Build{logger: &utils.NullLog{}}}
+	biDeps := make(map[string]*entities.Dependency)
+
+	// Walk from root (pathToRoot=[]) — simulates normal getDependenciesMap root walk.
+	err := ym.appendDependencyRecursively(depMap["root@workspace:."], []string{}, depMap, biDeps)
+	assert.NoError(t, err)
+
+	// Only xml should be emitted — portal-dep and link-dep are non-registry and dropped.
+	assert.Len(t, biDeps, 1)
+	assert.Contains(t, biDeps, "xml:1.0.1")
+	assert.NotContains(t, biDeps, "portal-dep:1.0.0")
+	assert.NotContains(t, biDeps, "link-dep:1.0.0")
+
+	// requestedBy for xml should be ["root:1.0.0"] — portal-dep collapsed from chain.
+	assert.Equal(t, [][]string{{"root:1.0.0"}}, biDeps["xml:1.0.1"].RequestedBy)
+}
+
+// TestGetDependenciesMap_WorkspaceRoot verifies that when IsYarnWorkspaceProject returns true,
+// getDependenciesMap seeds additional walks from each workspace member and captures their
+// registry deps even though the root node has no direct dependency edges in yarn info output.
+func TestGetDependenciesMap_WorkspaceRoot(t *testing.T) {
+	// Simulates: s1-root (workspace root, no deps) with two workspace members.
+	// pkg-a -> xml@npm:1.0.1
+	// pkg-b -> json@npm:9.0.6
+	depMap := map[string]*buildutils.YarnDependency{
+		"xml@npm:1.0.1":                          {Value: "xml@npm:1.0.1", Details: buildutils.YarnDepDetails{Version: "1.0.1"}},
+		"json@npm:9.0.6":                         {Value: "json@npm:9.0.6", Details: buildutils.YarnDepDetails{Version: "9.0.6"}},
+		"pkg-a@workspace:packages/pkg-a":         {Value: "pkg-a@workspace:packages/pkg-a", Details: buildutils.YarnDepDetails{Version: "1.0.0", Dependencies: []buildutils.YarnDependencyPointer{{Locator: "xml@npm:1.0.1"}}}},
+		"pkg-b@workspace:packages/pkg-b":         {Value: "pkg-b@workspace:packages/pkg-b", Details: buildutils.YarnDepDetails{Version: "1.0.0", Dependencies: []buildutils.YarnDependencyPointer{{Locator: "json@npm:9.0.6"}}}},
+		"s1-root@workspace:.":                    {Value: "s1-root@workspace:.", Details: buildutils.YarnDepDetails{Version: "0.0.0"}},
+	}
+	root := depMap["s1-root@workspace:."]
+
+	containingBuild := &Build{logger: &utils.NullLog{}}
+	ym := &YarnModule{containingBuild: containingBuild}
+
+	biDeps := make(map[string]*entities.Dependency)
+	// Normal root walk first (produces nothing — root has no edges).
+	err := ym.appendDependencyRecursively(root, []string{}, depMap, biDeps)
+	assert.NoError(t, err)
+	assert.Empty(t, biDeps)
+
+	// Simulate workspace seed (as getDependenciesMap does).
+	rootName, _ := root.Name()
+	rootId := rootName + ":" + root.Details.Version
+	for _, dep := range depMap {
+		if dep.Value != root.Value && buildutils.IsWorkspaceLocator(dep.Value) {
+			err = ym.appendDependencyRecursively(dep, []string{rootId}, depMap, biDeps)
+			assert.NoError(t, err)
+		}
+	}
+
+	assert.Len(t, biDeps, 2)
+	assert.Contains(t, biDeps, "xml:1.0.1")
+	assert.Contains(t, biDeps, "json:9.0.6")
+	assert.NotContains(t, biDeps, "pkg-a:1.0.0")
+	assert.NotContains(t, biDeps, "pkg-b:1.0.0")
+	assert.Equal(t, [][]string{{"s1-root:0.0.0"}}, biDeps["xml:1.0.1"].RequestedBy)
+	assert.Equal(t, [][]string{{"s1-root:0.0.0"}}, biDeps["json:9.0.6"].RequestedBy)
+}
+
 func TestGenerateBuildInfoForYarnProject(t *testing.T) {
 	// Copy the project directory to a temporary directory
 	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)


### PR DESCRIPTION
…pendencies. Added tests for workspace detection and locator protocols. Updated dependency retrieval to handle Yarn versioning more efficiently.

- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

RTECO-1035 — Fix yarn workspace and non-registry dependency collection                                                                                                              
                                                                                                                                                                                      
  Problem                                                                                                                                                                             
                                                                                                                                                                                      
  Three classes of build-info collection bugs affecting yarn v2+:                                                                                                                     
                                      
  1. Workspace monorepo root install produces empty build-info. yarn info --all --recursive --json emits all deps but the root locator (s1-root@workspace:.) has no Dependencies edges
   — the walker starts at root, finds nothing, terminates. All registry deps installed by member packages are unreachable.
  2. Non-registry locators emitted as ghost dependencies with misleading warning. Deps using link:, file:, portal:, git+https:, workspace:* protocols are local/VCS sources — they    
  don't exist in Artifactory. The walker attempted AQL lookup, failed, then printed "could not be found in Artifactory and therefore are not included in the build-info" for every    
  such dep. Warning is incorrect — these deps are intentionally excluded.
  3. yarn --version executed twice per build. newYarnModule calls validateYarnVersion → GetVersion, then getDependenciesMap → GetYarnDependencies → GetVersion again. Redundant       
  subprocess.