### PR TITLE
Bump Maven extractor to 2.43.9 and Gradle4 extractor to 4.35.9

### DIFF
--- a/build/gradle.go
+++ b/build/gradle.go
@@ -21,7 +21,7 @@ const (
 	gradleExtractorFileName           = "build-info-extractor-gradle-%s-uber.jar"
 	gradleInitScriptTemplate          = "gradle.init"
 	gradleExtractorRemotePath         = "org/jfrog/buildinfo/build-info-extractor-gradle/%s"
-	gradleExtractor4DependencyVersion = "4.35.5"
+	gradleExtractor4DependencyVersion = "4.35.9"
 	gradleExtractor5DependencyVersion = "5.2.5"
 	projectPropertiesFlag             = "-P"
 	systemPropertiesFlag              = "-D"

--- a/build/maven.go
+++ b/build/maven.go
@@ -22,7 +22,7 @@ const (
 	classworldsConfFileName         = "classworlds.conf"
 	PropertiesTempFolderName        = "properties"
 	MavenExtractorRemotePath        = "org/jfrog/buildinfo/build-info-extractor-maven3/%s"
-	MavenExtractorDependencyVersion = "2.43.6"
+	MavenExtractorDependencyVersion = "2.43.9"
 
 	ClassworldsConf = `main is org.apache.maven.cli.MavenCli from plexus.core
 


### PR DESCRIPTION
## Summary
- Bumps `MavenExtractorDependencyVersion` from `2.43.6` → `2.43.9` to align with the latest [build-info-extractor-2.43.9](https://github.com/jfrog/build-info/releases/tag/build-info-extractor-2.43.9) release
- Bumps `gradleExtractor4DependencyVersion` from `4.35.5` → `4.35.9` to align with the latest Gradle 4 extractor tag

## Test plan
- [ ] Maven build-info collection works with the updated extractor
- [ ] Gradle (< 6.8.1) build-info collection works with the updated extractor
- [ ] Existing unit tests pass