### PR TITLE
RTECO-1265 - Fixed Nuget bracket based dependency resolution

### DIFF
--- a/build/utils/dotnet/dependencies/assetsjson.go
+++ b/build/utils/dotnet/dependencies/assetsjson.go
@@ -67,16 +67,31 @@ func (extractor *assetsExtractor) new(dependenciesSource string, log utils.Log) 
 }
 
 func (assets *assets) getChildrenMap() map[string][]string {
-	// Key by name:version to preserve per-TFM entries; use a set to deduplicate children across TFMs
+	// Key by name:version to preserve per-TFM entries; use a set to deduplicate children across TFMs.
+	// Transitive version strings in targets/dependencies are the declared constraint (e.g. "[1.12.9, )"),
+	// not the resolved version. Build a per-TFM name->resolved-name:version map so child keys match
+	// the resolved versions used as keys in dependenciesMap (getAllDependencies).
 	dependenciesRelations := map[string]map[string]struct{}{}
 	for _, dependencies := range assets.Targets {
+		resolvedInTfm := map[string]string{}
+		for depId := range dependencies {
+			if idx := strings.Index(depId, "/"); idx != -1 {
+				resolvedInTfm[strings.ToLower(depId[:idx])] = strings.ToLower(getDependencyIdForBuildInfo(depId))
+			}
+		}
 		for dependencyId, targetDependencies := range dependencies {
 			dependencyKey := strings.ToLower(getDependencyIdForBuildInfo(dependencyId))
 			if _, ok := dependenciesRelations[dependencyKey]; !ok {
 				dependenciesRelations[dependencyKey] = map[string]struct{}{}
 			}
 			for transitiveName, transitiveVersion := range targetDependencies.Dependencies {
-				childKey := strings.ToLower(transitiveName + ":" + transitiveVersion)
+				// Prefer per-TFM resolved version (from library entry in the same target).
+				// Fall back to declared constraint when no library entry exists in this TFM —
+				// rare in real assets.json but kept for safety/back-compat.
+				childKey, ok := resolvedInTfm[strings.ToLower(transitiveName)]
+				if !ok {
+					childKey = strings.ToLower(transitiveName + ":" + transitiveVersion)
+				}
 				dependenciesRelations[dependencyKey][childKey] = struct{}{}
 			}
 		}

--- a/build/utils/dotnet/dependencies/assetsjson.go
+++ b/build/utils/dotnet/dependencies/assetsjson.go
@@ -12,6 +12,7 @@ import (
 	buildinfo "github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/crypto"
+	"github.com/jfrog/gofrog/log"
 )
 
 const (
@@ -72,7 +73,7 @@ func (assets *assets) getChildrenMap() map[string][]string {
 	// not the resolved version. Build a per-TFM name->resolved-name:version map so child keys match
 	// the resolved versions used as keys in dependenciesMap (getAllDependencies).
 	dependenciesRelations := map[string]map[string]struct{}{}
-	for _, dependencies := range assets.Targets {
+	for tfm, dependencies := range assets.Targets {
 		resolvedInTfm := map[string]string{}
 		for depId := range dependencies {
 			if idx := strings.Index(depId, "/"); idx != -1 {
@@ -87,10 +88,13 @@ func (assets *assets) getChildrenMap() map[string][]string {
 			for transitiveName, transitiveVersion := range targetDependencies.Dependencies {
 				// Prefer per-TFM resolved version (from library entry in the same target).
 				// Fall back to declared constraint when no library entry exists in this TFM —
-				// rare in real assets.json but kept for safety/back-compat.
+				// rare in real assets.json but kept for safety/back-compat. RequestedBy lookup
+				// may miss in this case because dependenciesMap is keyed by resolved version,
+				// so log the fallback for downstream debugging.
 				childKey, ok := resolvedInTfm[strings.ToLower(transitiveName)]
 				if !ok {
 					childKey = strings.ToLower(transitiveName + ":" + transitiveVersion)
+					log.Debug(fmt.Sprintf("getChildrenMap: no resolved library entry for transitive %q (declared %q) under parent %q in TFM %q; falling back to declared version — RequestedBy may not link.", transitiveName, transitiveVersion, dependencyId, tfm))
 				}
 				dependenciesRelations[dependencyKey][childKey] = struct{}{}
 			}

--- a/build/utils/dotnet/dependencies/assetsjson_test.go
+++ b/build/utils/dotnet/dependencies/assetsjson_test.go
@@ -324,4 +324,37 @@ func TestGetChildrenMapMixedCaseVersion(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(content, &assetsObj)) 
 	result := assetsObj.getChildrenMap()
 	assert.Equal(t, []string{"child:1.0.0-beta"}, result["parent:1.0.0"])
+}
+
+// TestGetChildrenMapBracketRangeVersion guards the RTECO-1265 regression: when
+// a parent .nuspec declares a child with a constraint expression (e.g. bracket
+// range "[1.12.9, )") instead of a plain version, getChildrenMap must still
+// produce a child key that matches the resolved library entry (e.g.
+// "popper.js:1.12.9"). Otherwise populateRequestedBy in solution.BuildInfo
+// silently misses and the transitive is dropped from the published build-info.
+func TestGetChildrenMapBracketRangeVersion(t *testing.T) {
+	content := []byte(`{
+  "version": 3,
+  "targets": {
+    ".NETFramework,Version=v4.5": {
+      "bootstrap/4.0.0": {
+        "dependencies": {
+          "jQuery": "3.0.0",
+          "popper.js": "[1.12.9, 2.0.0)"
+        }
+      },
+      "jQuery/3.0.0": {},
+      "popper.js/1.12.9": {}
+    }
+  },
+  "project": {
+    "restore": {"packagesPath": "unused"},
+    "frameworks": {}
   }
+}`)
+	var assetsObj assets
+	assert.NoError(t, json.Unmarshal(content, &assetsObj))
+	result := assetsObj.getChildrenMap()
+	// Both children must resolve to the library entry's version, NOT the declared constraint string.
+	assert.ElementsMatch(t, []string{"jquery:3.0.0", "popper.js:1.12.9"}, result["bootstrap:4.0.0"])
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----


## Summary

  Fix `getChildrenMap` in NuGet `project.assets.json` extractor so transitive dependencies survive `populateRequestedBy` when parent packages declare children
  with bracket-range version notation.

  ## What was wrong

  PR #381 (`RTECO-1265: preserve all per-TFM package versions`) rekeyed the NuGet dependency maps from `name` to `name:version` to support multi-TFM resolution.
  The implementation built `childrenMap` child keys from the **declared constraint string** found in `targets[tfm][parentId].dependencies`:

  ```go
  childKey := strings.ToLower(transitiveName + ":" + transitiveVersion)

  That value is whatever the parent's nuspec declared — sometimes a plain version ("1.0.1"), sometimes a range ("[1.12.9, )"). The dependencies map
  (getAllDependencies) is keyed by the resolved library version. When a parent used range notation, the two keys diverged:

  - childrenMap["bootstrap:4.0.0"] = ["jquery:[3.0.0, )", "popper.js:[1.12.9, )"]
  - dependenciesMap = [..., "jquery:3.0.0", "popper.js:1.12.9", ...]

  populateRequestedBy looked up dependenciesMap[childName] with childName = "popper.js:[1.12.9, )" → miss → child stayed with empty RequestedBy →
  solution.BuildInfo filtered it out via the len(dep.RequestedBy) > 0 guard.

  Net effect: any transitive whose parent declared a version range was dropped from the published build-info. Caught by TestNugetResolve / TestDotnetResolve in
  jfrog-cli, where bootstrap 4.0.0 declares jQuery + popper.js with brackets — both deps disappeared from every reference/multireference scenario.

  The existing unit tests passed because every fixture (assetsproject, multitfm, the synthetic TestGetChildrenMapDeterministic data) used plain version strings
  only — bracket-range case was uncovered.

  What this fixes

  getChildrenMap now resolves the child key against the same target's library entries:

  1. Per TFM, build resolvedInTfm[name] = "name:resolvedVersion" from each library id in that target.
  2. For each transitive dep, look up resolvedInTfm[transitiveName] and use that as childKey.
  3. If no library entry exists in the TFM (synthetic / malformed assets), fall back to declared name:version to preserve existing behavior.

  Result: childrenMap keys and dependenciesMap keys agree on the resolved version. populateRequestedBy finds every child. No transitive deps dropped.

  Multi-TFM correctness from PR #381 is preserved — resolvedInTfm is rebuilt per target, so different TFMs resolving the same name to different versions still
  produce distinct child keys.