### PR TITLE
Added poetry and yarn package support to recognize 403 Forbidden output

### DIFF
--- a/build/yarn.go
+++ b/build/yarn.go
@@ -1,10 +1,12 @@
 package build
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	buildutils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/build-info-go/entities"
@@ -222,11 +224,16 @@ func validateYarnVersion(executablePath, srcPath string) (string, error) {
 func RunYarnCommand(executablePath, srcPath string, args ...string) error {
 	command := exec.Command(executablePath, args...)
 	command.Dir = srcPath
-	command.Stdout = os.Stderr
-	command.Stderr = os.Stderr
+	outBuffer := bytes.NewBuffer([]byte{})
+	command.Stdout = outBuffer
+	errBuffer := bytes.NewBuffer([]byte{})
+	command.Stderr = errBuffer
 	err := command.Run()
-	if _, ok := err.(*exec.ExitError); ok {
-		err = errors.New(err.Error())
+	if err != nil {
+		err = fmt.Errorf("error while running '%s %s': %s\n%s\n%s",
+			executablePath, strings.Join(args, " "), err.Error(),
+			strings.TrimSpace(outBuffer.String()),
+			strings.TrimSpace(errBuffer.String()))
 	}
 	return err
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -43,7 +43,6 @@ func (err *ErrProjectNotInstalled) Error() string {
 
 // IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.
 func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
-	log.Debug("Checking forbidden output for package manager:", tech)
 	switch tech {
 	case "npm", "yarn":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")

--- a/utils/error.go
+++ b/utils/error.go
@@ -42,6 +42,7 @@ func (err *ErrProjectNotInstalled) Error() string {
 
 // IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.
 func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
+	log.Debug("Checking forbidden output for package manager:", tech)
 	switch tech {
 	case "npm":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")

--- a/utils/error.go
+++ b/utils/error.go
@@ -15,6 +15,7 @@ const (
 	Pip    PackageManager = "pip"
 	Go     PackageManager = "go"
 	Poetry PackageManager = "poetry"
+	Yarn   PackageManager = "yarn"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -44,7 +45,7 @@ func (err *ErrProjectNotInstalled) Error() string {
 func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	log.Debug("Checking forbidden output for package manager:", tech)
 	switch tech {
-	case "npm":
+	case "npm", "yarn":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
 	case "maven":
 		return strings.Contains(cmdOutput, "status code: 403") ||

--- a/utils/error.go
+++ b/utils/error.go
@@ -59,8 +59,7 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 			strings.Contains(strings.ToLower(cmdOutput), " 403")
 	case "poetry":
 		return strings.Contains(strings.ToLower(cmdOutput), "http error 403") ||
-			strings.Contains(strings.ToLower(cmdOutput), "403 client error") ||
-			strings.Contains(strings.ToLower(cmdOutput), "version solving failed")
+			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
 	}
 	return false
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"strings"
-
 )
 
 type PackageManager string
@@ -43,8 +42,11 @@ func (err *ErrProjectNotInstalled) Error() string {
 // IsForbiddenOutput checks whether the provided output includes a 403 Forbidden. The various package managers have their own forbidden output formats.
 func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	switch tech {
-	case "npm", "yarn":
+	case "npm":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
+	case "yarn":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 (forbidden)") ||
+			strings.Contains(strings.ToLower(cmdOutput), "response code: 403")
 	case "maven":
 		return strings.Contains(cmdOutput, "status code: 403") ||
 			strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
@@ -57,7 +59,8 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 			strings.Contains(strings.ToLower(cmdOutput), " 403")
 	case "poetry":
 		return strings.Contains(strings.ToLower(cmdOutput), "http error 403") ||
-			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
+			strings.Contains(strings.ToLower(cmdOutput), "403 client error") ||
+			strings.Contains(strings.ToLower(cmdOutput), "version solving failed")
 	}
 	return false
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -3,15 +3,18 @@ package utils
 import (
 	"fmt"
 	"strings"
+
+	"github.com/jfrog/gofrog/log"
 )
 
 type PackageManager string
 
 const (
-	Npm   PackageManager = "npm"
-	Maven PackageManager = "maven"
-	Pip   PackageManager = "pip"
-	Go    PackageManager = "go"
+	Npm    PackageManager = "npm"
+	Maven  PackageManager = "maven"
+	Pip    PackageManager = "pip"
+	Go     PackageManager = "go"
+	Poetry PackageManager = "poetry"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -52,6 +55,19 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	case "go":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
 			strings.Contains(strings.ToLower(cmdOutput), " 403")
+	case "poetry":
+		lower := strings.ToLower(cmdOutput)
+		switch {
+		case strings.Contains(lower, "http error 403"):
+			log.Debug("Poetry forbidden output matched pattern: 'http error 403'")
+			return true
+		case strings.Contains(lower, "403 client error"):
+			log.Debug("Poetry forbidden output matched pattern: '403 client error'")
+			return true
+		case strings.Contains(lower, "403 forbidden"):
+			log.Debug("Poetry forbidden output matched pattern: '403 forbidden'")
+			return true
+		}
 	}
 	return false
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jfrog/gofrog/log"
 )
 
 type PackageManager string
@@ -57,18 +56,8 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
 			strings.Contains(strings.ToLower(cmdOutput), " 403")
 	case "poetry":
-		lower := strings.ToLower(cmdOutput)
-		switch {
-		case strings.Contains(lower, "http error 403"):
-			log.Debug("Poetry forbidden output matched pattern: 'http error 403'")
-			return true
-		case strings.Contains(lower, "403 client error"):
-			log.Debug("Poetry forbidden output matched pattern: '403 client error'")
-			return true
-		case strings.Contains(lower, "403 forbidden"):
-			log.Debug("Poetry forbidden output matched pattern: '403 forbidden'")
-			return true
-		}
+		return strings.Contains(strings.ToLower(cmdOutput), "http error 403") ||
+			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
 	}
 	return false
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
## Summary
Extends `IsForbiddenOutput` (`utils/error.go`) to recognize **403 Forbidden** output from two more package managers, so we can see clearer auth errors instead of silently passing them through.
## Packages added:
- `Poetry`, `Yarn`.
