### PR TITLE
Added pnpm package support to recognise 403 Forbidden output

### DIFF
--- a/utils/error.go
+++ b/utils/error.go
@@ -14,6 +14,7 @@ const (
 	Go     PackageManager = "go"
 	Poetry PackageManager = "poetry"
 	Yarn   PackageManager = "yarn"
+	Pnpm   PackageManager = "pnpm"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -44,6 +45,10 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	switch tech {
 	case "npm":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
+	case "pnpm":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
+			strings.Contains(strings.ToLower(cmdOutput), "forbidden - 403") ||
+			strings.Contains(strings.ToLower(cmdOutput), "err_pnpm_fetch_403")
 	case "yarn":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 (forbidden)") ||
 			strings.Contains(strings.ToLower(cmdOutput), "response code: 403")


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
Extends IsForbiddenOutput (utils/error.go) to recognize 403 Forbidden output for pnpm, so we can see clearer auth errors instead of silently passing them through.