### PR TITLE
RTECO-1365 Include e2e tests from jfrog cli to build-info-go

### DIFF
--- a/.github/actions/checkout-jfrog-repos/action.yml
+++ b/.github/actions/checkout-jfrog-repos/action.yml
@@ -2,38 +2,11 @@ name: 'Checkout JFrog Repositories'
 description: 'Checkout jfrog-cli and optional dependency repositories. build-info-go stays at root.'
 
 inputs:
-  jfrog_cli_repo:
-    description: 'Repository for jfrog-cli override'
-    required: false
-    default: ''
-  jfrog_cli_ref:
-    description: 'Ref for jfrog-cli override'
-    required: false
-    default: ''
-  jfrog_cli_artifactory_repo:
-    description: 'Repository for jfrog-cli-artifactory override'
-    required: false
-    default: ''
-  jfrog_cli_artifactory_ref:
-    description: 'Ref for jfrog-cli-artifactory override'
-    required: false
-    default: ''
-  jfrog_client_go_repo:
-    description: 'Repository for jfrog-client-go override'
-    required: false
-    default: ''
-  jfrog_client_go_ref:
-    description: 'Ref for jfrog-client-go override'
-    required: false
-    default: ''
-  jfrog_cli_core_repo:
-    description: 'Repository for jfrog-cli-core override'
-    required: false
-    default: ''
-  jfrog_cli_core_ref:
-    description: 'Ref for jfrog-cli-core override'
-    required: false
-    default: ''
+  deps:
+    description: >-
+      JSON object produced by the detect-deps tool, holding every repo/ref override
+      (e.g. {"jfrog_cli_repo":"...","jfrog_cli_ref":"...", ...}).
+    required: true
 
 runs:
   using: 'composite'
@@ -41,30 +14,30 @@ runs:
     - name: Checkout jfrog-cli
       uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.jfrog_cli_repo != '' && inputs.jfrog_cli_repo || 'jfrog/jfrog-cli' }}
-        ref: ${{ inputs.jfrog_cli_ref != '' && inputs.jfrog_cli_ref || 'master' }}
+        repository: ${{ fromJson(inputs.deps).jfrog_cli_repo != '' && fromJson(inputs.deps).jfrog_cli_repo || 'jfrog/jfrog-cli' }}
+        ref: ${{ fromJson(inputs.deps).jfrog_cli_ref != '' && fromJson(inputs.deps).jfrog_cli_ref || 'master' }}
         path: jfrog-cli
 
     - name: Checkout jfrog-cli-artifactory
-      if: inputs.jfrog_cli_artifactory_repo != ''
+      if: fromJson(inputs.deps).jfrog_cli_artifactory_repo != ''
       uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.jfrog_cli_artifactory_repo }}
-        ref: ${{ inputs.jfrog_cli_artifactory_ref }}
+        repository: ${{ fromJson(inputs.deps).jfrog_cli_artifactory_repo }}
+        ref: ${{ fromJson(inputs.deps).jfrog_cli_artifactory_ref }}
         path: jfrog-cli-artifactory
 
     - name: Checkout jfrog-client-go
-      if: inputs.jfrog_client_go_repo != ''
+      if: fromJson(inputs.deps).jfrog_client_go_repo != ''
       uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.jfrog_client_go_repo }}
-        ref: ${{ inputs.jfrog_client_go_ref }}
+        repository: ${{ fromJson(inputs.deps).jfrog_client_go_repo }}
+        ref: ${{ fromJson(inputs.deps).jfrog_client_go_ref }}
         path: jfrog-client-go
 
     - name: Checkout jfrog-cli-core
-      if: inputs.jfrog_cli_core_repo != ''
+      if: fromJson(inputs.deps).jfrog_cli_core_repo != ''
       uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.jfrog_cli_core_repo }}
-        ref: ${{ inputs.jfrog_cli_core_ref }}
+        repository: ${{ fromJson(inputs.deps).jfrog_cli_core_repo }}
+        ref: ${{ fromJson(inputs.deps).jfrog_cli_core_ref }}
         path: jfrog-cli-core

--- a/.github/actions/checkout-jfrog-repos/action.yml
+++ b/.github/actions/checkout-jfrog-repos/action.yml
@@ -1,0 +1,70 @@
+name: 'Checkout JFrog Repositories'
+description: 'Checkout jfrog-cli and optional dependency repositories. build-info-go stays at root.'
+
+inputs:
+  jfrog_cli_repo:
+    description: 'Repository for jfrog-cli override'
+    required: false
+    default: ''
+  jfrog_cli_ref:
+    description: 'Ref for jfrog-cli override'
+    required: false
+    default: ''
+  jfrog_cli_artifactory_repo:
+    description: 'Repository for jfrog-cli-artifactory override'
+    required: false
+    default: ''
+  jfrog_cli_artifactory_ref:
+    description: 'Ref for jfrog-cli-artifactory override'
+    required: false
+    default: ''
+  jfrog_client_go_repo:
+    description: 'Repository for jfrog-client-go override'
+    required: false
+    default: ''
+  jfrog_client_go_ref:
+    description: 'Ref for jfrog-client-go override'
+    required: false
+    default: ''
+  jfrog_cli_core_repo:
+    description: 'Repository for jfrog-cli-core override'
+    required: false
+    default: ''
+  jfrog_cli_core_ref:
+    description: 'Ref for jfrog-cli-core override'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout jfrog-cli
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.jfrog_cli_repo != '' && inputs.jfrog_cli_repo || 'jfrog/jfrog-cli' }}
+        ref: ${{ inputs.jfrog_cli_ref != '' && inputs.jfrog_cli_ref || 'master' }}
+        path: jfrog-cli
+
+    - name: Checkout jfrog-cli-artifactory
+      if: inputs.jfrog_cli_artifactory_repo != ''
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.jfrog_cli_artifactory_repo }}
+        ref: ${{ inputs.jfrog_cli_artifactory_ref }}
+        path: jfrog-cli-artifactory
+
+    - name: Checkout jfrog-client-go
+      if: inputs.jfrog_client_go_repo != ''
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.jfrog_client_go_repo }}
+        ref: ${{ inputs.jfrog_client_go_ref }}
+        path: jfrog-client-go
+
+    - name: Checkout jfrog-cli-core
+      if: inputs.jfrog_cli_core_repo != ''
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.jfrog_cli_core_repo }}
+        ref: ${{ inputs.jfrog_cli_core_ref }}
+        path: jfrog-cli-core

--- a/.github/actions/setup-go-workspace/action.yml
+++ b/.github/actions/setup-go-workspace/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup Go Workspace'
+description: 'Initializes Go workspace for Unix and Windows to use local module overrides'
+
+inputs:
+  os_name:
+    description: 'The operating system name (ubuntu or windows)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go workspace (Unix)
+      if: inputs.os_name == 'ubuntu'
+      shell: bash
+      run: |
+        go work init
+        go work use .
+        go work use ./jfrog-cli
+        [ -d "./jfrog-cli-artifactory" ] && go work use ./jfrog-cli-artifactory || true
+        [ -d "./jfrog-cli-core" ] && go work use ./jfrog-cli-core || true
+        [ -d "./jfrog-client-go" ] && go work use ./jfrog-client-go || true
+        cat go.work
+
+    - name: Setup Go workspace (Windows)
+      if: inputs.os_name == 'windows'
+      shell: pwsh
+      run: |
+        go work init
+        go work use .
+        go work use ./jfrog-cli
+        if (Test-Path "./jfrog-cli-artifactory") { go work use ./jfrog-cli-artifactory }
+        if (Test-Path "./jfrog-cli-core") { go work use ./jfrog-cli-core }
+        if (Test-Path "./jfrog-client-go") { go work use ./jfrog-client-go }
+        Get-Content go.work

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Test Environment'
+description: 'Checks out the JFrog dependency repositories and prepares the Go build/workspace. Shared by every integration-test job.'
+
+inputs:
+  deps:
+    description: 'JSON object produced by the detect-deps tool with every repo/ref override.'
+    required: true
+  os_name:
+    description: 'The operating system name (ubuntu or windows).'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout all JFrog repositories
+      uses: ./.github/actions/checkout-jfrog-repos
+      with:
+        deps: ${{ inputs.deps }}
+
+    - name: Setup Go with cache
+      uses: jfrog/.github/actions/install-go-with-cache@main
+
+    - name: Setup Go workspace
+      uses: ./.github/actions/setup-go-workspace
+      with:
+        os_name: ${{ inputs.os_name }}

--- a/.github/tools/detect-deps/main.go
+++ b/.github/tools/detect-deps/main.go
@@ -8,6 +8,34 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/jfrog/gofrog/log"
+)
+
+const (
+	// currentBranchEnvVar is the environment variable holding the branch under test.
+	currentBranchEnvVar = "CURRENT_BRANCH"
+	// githubOutputEnvVar is the environment variable pointing to the GitHub Actions output file.
+	githubOutputEnvVar = "GITHUB_OUTPUT"
+	// defaultBranch is used when no branch is provided via the environment.
+	defaultBranch = "main"
+	// masterBranch is the default ref the dependency repositories fall back to.
+	masterBranch = "master"
+
+	// githubBaseURL is the base URL for cloning GitHub repositories.
+	githubBaseURL = "https://github.com"
+	// githubAPIBaseURL is the base URL for the GitHub REST API.
+	githubAPIBaseURL = "https://api.github.com"
+	// jfrogOrg is the GitHub organization that hosts the dependency repositories.
+	jfrogOrg = "jfrog"
+
+	// githubSHAFullLength is the length of a full Git commit SHA.
+	githubSHAFullLength = 40
+	// githubSHAShortMinLength is the minimum length of an abbreviated commit SHA.
+	githubSHAShortMinLength = 7
+
+	// githubOutputFilePerm is the permission used when opening the GitHub output file.
+	githubOutputFilePerm = 0644
 )
 
 // GoMod represents the JSON structure from `go mod edit -json`
@@ -62,15 +90,15 @@ var jfrogDependencies = map[string]string{
 
 func main() {
 	// Get current branch from environment
-	currentBranch := os.Getenv("CURRENT_BRANCH")
+	currentBranch := os.Getenv(currentBranchEnvVar)
 	if currentBranch == "" {
-		currentBranch = "main"
+		currentBranch = defaultBranch
 	}
 
 	// Parse go.mod
 	goMod, err := parseGoMod()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error parsing go.mod: %v\n", err)
+		log.Error(fmt.Sprintf("Error parsing go.mod: %v", err))
 		os.Exit(1)
 	}
 
@@ -81,23 +109,30 @@ func main() {
 	}
 
 	// Open GITHUB_OUTPUT file for writing outputs
-	outputFile := os.Getenv("GITHUB_OUTPUT")
+	outputFile := os.Getenv(githubOutputEnvVar)
 	var output *os.File
 	if outputFile != "" {
 		var err error
 		cleanOutputFile := filepath.Clean(outputFile)
-		output, err = os.OpenFile(cleanOutputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644) // #nosec G703 -- GitHub Actions env var
+		output, err = os.OpenFile(cleanOutputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, githubOutputFilePerm) // #nosec G703 -- GitHub Actions env var
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening GITHUB_OUTPUT: %v\n", err)
+			log.Error(fmt.Sprintf("Error opening %s: %v", githubOutputEnvVar, err))
 			os.Exit(1)
 		}
 		defer output.Close()
 	}
 
-	// Process each dependency
+	// Collect every resolved repo/ref pair into a single map so the workflow can
+	// consume one JSON "deps" output instead of repeating per-dependency declarations.
+	deps := make(map[string]string)
 	for name, modulePath := range jfrogDependencies {
 		info := detectDependency(name, modulePath, replaces, currentBranch)
-		writeOutput(output, name, info)
+		collectDependency(deps, name, info)
+	}
+
+	if err := writeDeps(output, deps); err != nil {
+		log.Error(fmt.Sprintf("Error writing dependency output: %v", err))
+		os.Exit(1)
 	}
 }
 
@@ -132,7 +167,7 @@ func detectDependency(name, modulePath string, replaces map[string]Replace, curr
 			if ref != "" {
 				// Prefer the current branch if it exists on the forked repo,
 				if branchExists(repo, currentBranch) {
-					fmt.Printf("Found replace directive: %s => %s, branch '%s' exists, using it\n", name, repo, currentBranch)
+					log.Info(fmt.Sprintf("Found replace directive: %s => %s, branch '%s' exists, using it", name, repo, currentBranch))
 					return &DependencyInfo{
 						Name:       name,
 						ModulePath: modulePath,
@@ -145,11 +180,11 @@ func detectDependency(name, modulePath string, replaces map[string]Replace, curr
 				ref = extractCommitFromPseudoVersion(ref)
 				fullSHA := resolveFullSHA(repo, ref)
 				if fullSHA == "" {
-					fmt.Fprintf(os.Stderr, "Error: could not resolve commit %s to full SHA in %s\n", ref, repo)
+					log.Error(fmt.Sprintf("Error: could not resolve commit %s to full SHA in %s", ref, repo))
 					os.Exit(1)
 				}
 				ref = fullSHA
-				fmt.Printf("Found replace directive: %s => %s @ %s\n", name, repo, ref)
+				log.Info(fmt.Sprintf("Found replace directive: %s => %s @ %s", name, repo, ref))
 				return &DependencyInfo{
 					Name:       name,
 					ModulePath: modulePath,
@@ -161,11 +196,11 @@ func detectDependency(name, modulePath string, replaces map[string]Replace, curr
 	}
 
 	// No replace directive found, check if current branch exists in the dependency repo
-	repo := fmt.Sprintf("jfrog/%s", name)
+	repo := fmt.Sprintf("%s/%s", jfrogOrg, name)
 
 	// Check if the current branch exists in the repo
 	if branchExists(repo, currentBranch) {
-		fmt.Printf("Branch '%s' exists in %s, using it\n", currentBranch, repo)
+		log.Info(fmt.Sprintf("Branch '%s' exists in %s, using it", currentBranch, repo))
 		return &DependencyInfo{
 			Name:       name,
 			ModulePath: modulePath,
@@ -174,7 +209,7 @@ func detectDependency(name, modulePath string, replaces map[string]Replace, curr
 		}
 	}
 
-	fmt.Printf("No matching branch for %s, will use default (master)\n", name)
+	log.Info(fmt.Sprintf("No matching branch for %s, will use default (%s)", name, masterBranch))
 	return nil
 }
 
@@ -195,22 +230,22 @@ func extractCommitFromPseudoVersion(version string) string {
 // resolveFullSHA resolves a short commit hash to a full 40-char SHA using the GitHub API.
 // Returns empty string if resolution fails
 func resolveFullSHA(repo, shortHash string) string {
-	if len(shortHash) < 7 || len(shortHash) >= 40 {
+	if len(shortHash) < githubSHAShortMinLength || len(shortHash) >= githubSHAFullLength {
 		return ""
 	}
 	if !validGitRefPattern.MatchString(repo) || !validGitRefPattern.MatchString(shortHash) {
 		return ""
 	}
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, shortHash)
+	apiURL := fmt.Sprintf("%s/repos/%s/commits/%s", githubAPIBaseURL, repo, shortHash)
 	cmd := exec.Command("curl", "-sf", "-H", "Accept: application/vnd.github.v3.sha", apiURL) // #nosec G204 -- inputs validated
 	out, err := cmd.Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not resolve full SHA for %s in %s: %v\n", shortHash, repo, err)
+		log.Warn(fmt.Sprintf("could not resolve full SHA for %s in %s: %v", shortHash, repo, err))
 		return ""
 	}
 	sha := strings.TrimSpace(string(out))
-	if len(sha) == 40 {
-		fmt.Printf("Resolved short hash %s to full SHA %s\n", shortHash, sha)
+	if len(sha) == githubSHAFullLength {
+		log.Info(fmt.Sprintf("Resolved short hash %s to full SHA %s", shortHash, sha))
 		return sha
 	}
 	return ""
@@ -231,54 +266,68 @@ var validGitRefPattern = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
 // branchExists checks if a branch exists in a GitHub repository
 func branchExists(repo, branch string) bool {
-	if branch == "" || branch == "main" || branch == "master" {
+	if branch == "" || branch == defaultBranch || branch == masterBranch {
 		return false
 	}
 
 	// Validate repo format to prevent command injection (should be org/repo format)
 	if !validGitRefPattern.MatchString(repo) {
-		fmt.Fprintf(os.Stderr, "Warning: invalid repo format '%s'\n", repo)
+		log.Warn(fmt.Sprintf("invalid repo format '%s'", repo))
 		return false
 	}
 
 	// Validate branch name to prevent command injection
 	if !validGitRefPattern.MatchString(branch) {
-		fmt.Fprintf(os.Stderr, "Warning: invalid branch format '%s'\n", branch)
+		log.Warn(fmt.Sprintf("invalid branch format '%s'", branch))
 		return false
 	}
 
-	url := fmt.Sprintf("https://github.com/%s.git", repo)
+	url := fmt.Sprintf("%s/%s.git", githubBaseURL, repo)
 	cmd := exec.Command("git", "ls-remote", "--heads", url, branch) // #nosec G702 -- inputs validated above
 	out, err := cmd.Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to check branch '%s' in %s: %v\n", branch, repo, err)
+		log.Warn(fmt.Sprintf("failed to check branch '%s' in %s: %v", branch, repo, err))
 		return false
 	}
 
 	return strings.Contains(string(out), fmt.Sprintf("refs/heads/%s", branch))
 }
 
-// writeOutput writes the dependency info to GITHUB_OUTPUT
-func writeOutput(output *os.File, name string, info *DependencyInfo) {
-	// Convert name to output key format (e.g., "build-info-go" -> "build_info_go")
+// collectDependency records the resolved repo/ref for a dependency into the deps map,
+// using the snake_case key format expected by the workflow (e.g. "jfrog-cli" -> "jfrog_cli_repo").
+func collectDependency(deps map[string]string, name string, info *DependencyInfo) {
 	keyName := strings.ReplaceAll(name, "-", "_")
 
 	var repo, ref string
 	if info != nil {
 		repo = info.Repo
 		ref = info.Ref
-	}
-
-	// Write to GITHUB_OUTPUT if available
-	if output != nil {
-		fmt.Fprintf(output, "%s_repo=%s\n", keyName, repo)
-		fmt.Fprintf(output, "%s_ref=%s\n", keyName, ref)
-	}
-
-	if info != nil {
-		fmt.Printf("  %s_repo=%s\n", keyName, repo)
-		fmt.Printf("  %s_ref=%s\n", keyName, ref)
+		log.Info(fmt.Sprintf("  %s_repo=%s", keyName, repo))
+		log.Info(fmt.Sprintf("  %s_ref=%s", keyName, ref))
 	} else {
-		fmt.Printf("  %s: using default\n", keyName)
+		log.Info(fmt.Sprintf("  %s: using default", keyName))
 	}
+
+	deps[keyName+"_repo"] = repo
+	deps[keyName+"_ref"] = ref
+}
+
+// writeDeps marshals all dependency repo/ref pairs into a single JSON object and
+// writes it to GITHUB_OUTPUT as the "deps" output. This lets the workflow pass one
+// value to the composite actions instead of repeating each key in every job.
+func writeDeps(output *os.File, deps map[string]string) error {
+	data, err := json.Marshal(deps)
+	if err != nil {
+		return fmt.Errorf("failed to marshal dependencies: %w", err)
+	}
+
+	// Write the machine-readable output consumed by GitHub Actions.
+	if output != nil {
+		if _, err := fmt.Fprintf(output, "deps=%s\n", data); err != nil {
+			return fmt.Errorf("failed to write deps to %s: %w", githubOutputEnvVar, err)
+		}
+	}
+
+	log.Info(fmt.Sprintf("deps=%s", data))
+	return nil
 }

--- a/.github/tools/detect-deps/main.go
+++ b/.github/tools/detect-deps/main.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// GoMod represents the JSON structure from `go mod edit -json`
+type GoMod struct {
+	Module  Module    `json:"Module"`
+	Go      string    `json:"Go"`
+	Require []Require `json:"Require"`
+	Replace []Replace `json:"Replace"`
+}
+
+// Module represents the module path
+type Module struct {
+	Path string `json:"Path"`
+}
+
+// Require represents a required module
+type Require struct {
+	Path     string `json:"Path"`
+	Version  string `json:"Version"`
+	Indirect bool   `json:"Indirect"`
+}
+
+// Replace represents a replace directive
+type Replace struct {
+	Old ModuleVersion `json:"Old"`
+	New ModuleVersion `json:"New"`
+}
+
+// ModuleVersion represents a module with optional version
+type ModuleVersion struct {
+	Path    string `json:"Path"`
+	Version string `json:"Version,omitempty"`
+}
+
+// DependencyInfo holds information about a detected dependency
+type DependencyInfo struct {
+	Name       string
+	ModulePath string
+	Repo       string
+	Ref        string
+}
+
+// jfrogDependencies maps short names to their module paths.
+// build-info-go is intentionally excluded: it is the repository under test and
+// is always checked out at the workspace root, so it is never a detected sibling.
+var jfrogDependencies = map[string]string{
+	"jfrog-cli":             "github.com/jfrog/jfrog-cli",
+	"jfrog-cli-artifactory": "github.com/jfrog/jfrog-cli-artifactory",
+	"jfrog-cli-core":        "github.com/jfrog/jfrog-cli-core/v2",
+	"jfrog-client-go":       "github.com/jfrog/jfrog-client-go",
+}
+
+func main() {
+	// Get current branch from environment
+	currentBranch := os.Getenv("CURRENT_BRANCH")
+	if currentBranch == "" {
+		currentBranch = "main"
+	}
+
+	// Parse go.mod
+	goMod, err := parseGoMod()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing go.mod: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build a map of replace directives
+	replaces := make(map[string]Replace)
+	for _, r := range goMod.Replace {
+		replaces[r.Old.Path] = r
+	}
+
+	// Open GITHUB_OUTPUT file for writing outputs
+	outputFile := os.Getenv("GITHUB_OUTPUT")
+	var output *os.File
+	if outputFile != "" {
+		var err error
+		cleanOutputFile := filepath.Clean(outputFile)
+		output, err = os.OpenFile(cleanOutputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644) // #nosec G703 -- GitHub Actions env var
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening GITHUB_OUTPUT: %v\n", err)
+			os.Exit(1)
+		}
+		defer output.Close()
+	}
+
+	// Process each dependency
+	for name, modulePath := range jfrogDependencies {
+		info := detectDependency(name, modulePath, replaces, currentBranch)
+		writeOutput(output, name, info)
+	}
+}
+
+// parseGoMod runs `go mod edit -json` and parses the output
+func parseGoMod() (*GoMod, error) {
+	cmd := exec.Command("go", "mod", "edit", "-json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run go mod edit -json: %w", err)
+	}
+
+	var goMod GoMod
+	if err := json.Unmarshal(out, &goMod); err != nil {
+		return nil, fmt.Errorf("failed to parse go.mod JSON: %w", err)
+	}
+
+	return &goMod, nil
+}
+
+// detectDependency determines the repository and ref for a dependency
+func detectDependency(name, modulePath string, replaces map[string]Replace, currentBranch string) *DependencyInfo {
+	// Check if there's a replace directive for this module
+	if replace, ok := replaces[modulePath]; ok {
+		// Parse the replace target
+		newPath := replace.New.Path
+		if strings.HasPrefix(newPath, "github.com/") {
+			// Extract repo and version/ref, stripping Go module major version suffixes (e.g. /v2)
+			parts := strings.TrimPrefix(newPath, "github.com/")
+			repo := stripMajorVersionSuffix(parts)
+			ref := replace.New.Version
+
+			if ref != "" {
+				// Prefer the current branch if it exists on the forked repo,
+				if branchExists(repo, currentBranch) {
+					fmt.Printf("Found replace directive: %s => %s, branch '%s' exists, using it\n", name, repo, currentBranch)
+					return &DependencyInfo{
+						Name:       name,
+						ModulePath: modulePath,
+						Repo:       repo,
+						Ref:        currentBranch,
+					}
+				}
+				// Extract the short commit hash from pseudo-version, then
+				// resolve it to a full 40-char SHA so actions/checkout can fetch it
+				ref = extractCommitFromPseudoVersion(ref)
+				fullSHA := resolveFullSHA(repo, ref)
+				if fullSHA == "" {
+					fmt.Fprintf(os.Stderr, "Error: could not resolve commit %s to full SHA in %s\n", ref, repo)
+					os.Exit(1)
+				}
+				ref = fullSHA
+				fmt.Printf("Found replace directive: %s => %s @ %s\n", name, repo, ref)
+				return &DependencyInfo{
+					Name:       name,
+					ModulePath: modulePath,
+					Repo:       repo,
+					Ref:        ref,
+				}
+			}
+		}
+	}
+
+	// No replace directive found, check if current branch exists in the dependency repo
+	repo := fmt.Sprintf("jfrog/%s", name)
+
+	// Check if the current branch exists in the repo
+	if branchExists(repo, currentBranch) {
+		fmt.Printf("Branch '%s' exists in %s, using it\n", currentBranch, repo)
+		return &DependencyInfo{
+			Name:       name,
+			ModulePath: modulePath,
+			Repo:       repo,
+			Ref:        currentBranch,
+		}
+	}
+
+	fmt.Printf("No matching branch for %s, will use default (master)\n", name)
+	return nil
+}
+
+// pseudoVersionPattern matches Go module pseudo-versions and captures the commit hash.
+// Format: vX.Y.Z-0.YYYYMMDDHHMMSS-COMMITHASH or vX.Y.Z-pre.0.YYYYMMDDHHMMSS-COMMITHASH
+var pseudoVersionPattern = regexp.MustCompile(`-(?:\d+\.)?(\d{14})-([a-f0-9]{12})$`)
+
+// extractCommitFromPseudoVersion returns the 12-char commit hash from a Go pseudo-version,
+// or the original string if it is not a pseudo-version.
+func extractCommitFromPseudoVersion(version string) string {
+	matches := pseudoVersionPattern.FindStringSubmatch(version)
+	if len(matches) == 3 {
+		return matches[2]
+	}
+	return version
+}
+
+// resolveFullSHA resolves a short commit hash to a full 40-char SHA using the GitHub API.
+// Returns empty string if resolution fails
+func resolveFullSHA(repo, shortHash string) string {
+	if len(shortHash) < 7 || len(shortHash) >= 40 {
+		return ""
+	}
+	if !validGitRefPattern.MatchString(repo) || !validGitRefPattern.MatchString(shortHash) {
+		return ""
+	}
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, shortHash)
+	cmd := exec.Command("curl", "-sf", "-H", "Accept: application/vnd.github.v3.sha", apiURL) // #nosec G204 -- inputs validated
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not resolve full SHA for %s in %s: %v\n", shortHash, repo, err)
+		return ""
+	}
+	sha := strings.TrimSpace(string(out))
+	if len(sha) == 40 {
+		fmt.Printf("Resolved short hash %s to full SHA %s\n", shortHash, sha)
+		return sha
+	}
+	return ""
+}
+
+// majorVersionSuffix matches Go module major version suffixes like /v2, /v3, etc.
+var majorVersionSuffix = regexp.MustCompile(`/v\d+$`)
+
+// stripMajorVersionSuffix removes the Go module major version suffix (e.g. /v2)
+// from a repo path, since it's not part of the actual GitHub repository name.
+func stripMajorVersionSuffix(repoPath string) string {
+	return majorVersionSuffix.ReplaceAllString(repoPath, "")
+}
+
+// isValidGitRef validates that a string is a valid git reference name
+// This prevents command injection by ensuring only safe characters are used
+var validGitRefPattern = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
+// branchExists checks if a branch exists in a GitHub repository
+func branchExists(repo, branch string) bool {
+	if branch == "" || branch == "main" || branch == "master" {
+		return false
+	}
+
+	// Validate repo format to prevent command injection (should be org/repo format)
+	if !validGitRefPattern.MatchString(repo) {
+		fmt.Fprintf(os.Stderr, "Warning: invalid repo format '%s'\n", repo)
+		return false
+	}
+
+	// Validate branch name to prevent command injection
+	if !validGitRefPattern.MatchString(branch) {
+		fmt.Fprintf(os.Stderr, "Warning: invalid branch format '%s'\n", branch)
+		return false
+	}
+
+	url := fmt.Sprintf("https://github.com/%s.git", repo)
+	cmd := exec.Command("git", "ls-remote", "--heads", url, branch) // #nosec G702 -- inputs validated above
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to check branch '%s' in %s: %v\n", branch, repo, err)
+		return false
+	}
+
+	return strings.Contains(string(out), fmt.Sprintf("refs/heads/%s", branch))
+}
+
+// writeOutput writes the dependency info to GITHUB_OUTPUT
+func writeOutput(output *os.File, name string, info *DependencyInfo) {
+	// Convert name to output key format (e.g., "build-info-go" -> "build_info_go")
+	keyName := strings.ReplaceAll(name, "-", "_")
+
+	var repo, ref string
+	if info != nil {
+		repo = info.Repo
+		ref = info.Ref
+	}
+
+	// Write to GITHUB_OUTPUT if available
+	if output != nil {
+		fmt.Fprintf(output, "%s_repo=%s\n", keyName, repo)
+		fmt.Fprintf(output, "%s_ref=%s\n", keyName, ref)
+	}
+
+	if info != nil {
+		fmt.Printf("  %s_repo=%s\n", keyName, repo)
+		fmt.Printf("  %s_ref=%s\n", keyName, ref)
+	} else {
+		fmt.Printf("  %s: using default\n", keyName)
+	}
+}

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -1,0 +1,896 @@
+name: CLI Integration Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Remove-Label:
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    name: Remove label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove 'safe to test'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "safe to test"
+
+  Detect-Deps:
+    name: Detect Dependencies
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    runs-on: ubuntu-latest
+    outputs:
+      jfrog_cli_repo: ${{ steps.detect.outputs.jfrog_cli_repo }}
+      jfrog_cli_ref: ${{ steps.detect.outputs.jfrog_cli_ref }}
+      jfrog_cli_artifactory_repo: ${{ steps.detect.outputs.jfrog_cli_artifactory_repo }}
+      jfrog_cli_artifactory_ref: ${{ steps.detect.outputs.jfrog_cli_artifactory_ref }}
+      jfrog_client_go_repo: ${{ steps.detect.outputs.jfrog_client_go_repo }}
+      jfrog_client_go_ref: ${{ steps.detect.outputs.jfrog_client_go_ref }}
+      jfrog_cli_core_repo: ${{ steps.detect.outputs.jfrog_cli_core_repo }}
+      jfrog_cli_core_ref: ${{ steps.detect.outputs.jfrog_cli_core_ref }}
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: false
+
+      - name: Detect dependencies
+        id: detect
+        run: go run .github/tools/detect-deps/main.go
+        env:
+          CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
+
+  Artifactory-Tests:
+    name: ${{ matrix.suite }} ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [artifactory, artifactoryProject]
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Artifactory tests
+        if: matrix.suite == 'artifactory'
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactory --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+
+      - name: Run Artifactory Project tests
+        if: matrix.suite == 'artifactoryProject'
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactoryProject --ci.runId=${{ runner.os }}-${{ matrix.suite }}
+
+  Go-Tests:
+    name: Go ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Run Go tests
+        working-directory: jfrog-cli
+        env:
+          GOWORK: off
+        run: go test -v -timeout 0 --test.go --jfrog.url=${{ secrets.EPLUS_PLATFORM_URL }} --jfrog.adminToken=${{ secrets.EPLUS_ADMIN_TOKEN }} --ci.runId=${{ runner.os }}-go
+
+  NuGet-Tests:
+    name: NuGet ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Prepare ubuntu
+        if: matrix.os.name == 'ubuntu'
+        run: |
+          # Install Mono
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https dirmngr gnupg ca-certificates
+          sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+          # Fixes dotnet installation issues
+          echo "DOTNET_INSTALL_DIR=/usr/share/dotnet" >> $GITHUB_ENV
+          sudo mkdir -p /usr/share/dotnet
+          sudo chmod 777 /usr/share/dotnet
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.x"
+
+      - name: Install NuGet
+        uses: nuget/setup-nuget@v2
+        with:
+          nuget-version: "6.x"
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run NuGet tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.nuget
+
+  npm-Tests:
+    name: npm ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Install npm
+        uses: actions/setup-node@v5
+        with:
+          node-version: "16"
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run npm tests
+        working-directory: jfrog-cli
+        env:
+          YARN_IGNORE_NODE: 1
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.npm
+
+  pnpm-Tests:
+    name: pnpm ${{ matrix.pnpm-version }} ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+        pnpm-version: [10]
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ matrix.pnpm-version }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run pnpm tests
+        working-directory: jfrog-cli
+        env:
+          YARN_IGNORE_NODE: 1
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.pnpm
+
+  Maven-Tests:
+    name: Maven ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Maven v3.8.8
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.8.8
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Maven tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.maven
+
+  Gradle-Tests:
+    name: Gradle ${{ matrix.gradle-version }} ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+        gradle-version: [5.6.4, 8.3]
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "11"
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: ${{ matrix.gradle-version }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Gradle tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.gradle
+
+  Conan-Tests:
+    name: Conan ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Install Conan
+        uses: turtlebrowser/get-conan@main
+        with:
+          version: '2.10.2'
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Conan tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan
+
+  Helm-Tests:
+    name: Helm ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Helm tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.helm
+
+  Docker-Tests:
+    name: Docker ubuntu
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+        disable-containerd-snapshotter: [ true, false ]
+    runs-on: ubuntu-24.04
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Configure Docker with legacy snapshotter
+        if: matrix.disable-containerd-snapshotter == true
+        run: |
+          sudo bash -c 'cat <<EOF > /etc/docker/daemon.json
+          {
+          "insecure-registries": ["localhost:8082"],
+          "features": {
+           "containerd-snapshotter": false
+          }
+          }
+          EOF'
+          sudo systemctl restart docker
+
+      - name: Configure Docker with containerd snapshotter
+        if: matrix.disable-containerd-snapshotter == false
+        run: |
+          sudo bash -c 'cat <<EOF > /etc/docker/daemon.json
+          {
+            "insecure-registries": ["localhost:8082"]
+          }
+          EOF'
+          sudo systemctl restart docker
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ubuntu
+
+      - name: Containerize Artifactory
+        run: |
+          cd jfrog-cli/testdata/docker/artifactory/
+          ./start.sh
+        env:
+          RTLIC: ${{ secrets.RTLIC }}
+
+      - name: Wait for Artifactory (Native)
+        run: |
+          timeout 600s bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8082)" != "200" ]]; do sleep 5; done'
+
+      - name: Run Docker tests
+        working-directory: jfrog-cli
+        run: go test -v -timeout 0 --test.docker --jfrog.url=http://localhost:8082/
+
+  Podman-Tests:
+    name: Podman ubuntu
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    runs-on: ubuntu-24.04
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Configure Docker 29 for Legacy Support
+        run: |
+          sudo bash -c 'cat <<EOF > /etc/docker/daemon.json
+          {
+            "insecure-registries": ["localhost:8082"],
+            "features": {
+              "containerd-snapshotter": false
+            }
+          }
+          EOF'
+          sudo systemctl restart docker
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ubuntu
+
+      - name: Run Podman tests
+        working-directory: jfrog-cli
+        run: go test -v -timeout 0 --test.podman --jfrog.url=${{ secrets.EPLUS_PLATFORM_URL }} --jfrog.adminToken=${{ secrets.EPLUS_ADMIN_TOKEN }} --test.containerRegistry=${{ secrets.CONTAINER_REGISTRY }}
+
+  Python-Tests:
+    name: ${{ matrix.suite }} ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [pip, pipenv]
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Python3
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11.5"
+
+      - name: Setup Pipenv
+        if: matrix.suite == 'pipenv'
+        run: python -m pip install pipenv==2026.2.2
+
+      - name: Setup Twine
+        if: matrix.suite == 'pip'
+        run: python -m pip install twine
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Python tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}
+
+  Lifecycle-Tests:
+    name: Lifecycle ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run Lifecycle tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.lifecycle --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }} --ci.runId=${{ runner.os }}-lifecycle
+
+  Distribution-Tests:
+    name: Distribution ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout build-info-go
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
+          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
+          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
+          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Run Distribution tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.distribution --jfrog.url=${{ secrets.EPLUS_PLATFORM_URL }} --jfrog.adminToken=${{ secrets.EPLUS_ADMIN_TOKEN }} --jfrog.user=${{ secrets.PLATFORM_USER }} --ci.runId=${{ runner.os }}-distribution

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-  pull_request_target:
+  pull_request:
     types: [labeled]
     branches:
       - main

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-  pull_request:
+  pull_request_target:
     types: [labeled]
     branches:
       - main

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -31,14 +31,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     runs-on: ubuntu-latest
     outputs:
-      jfrog_cli_repo: ${{ steps.detect.outputs.jfrog_cli_repo }}
-      jfrog_cli_ref: ${{ steps.detect.outputs.jfrog_cli_ref }}
-      jfrog_cli_artifactory_repo: ${{ steps.detect.outputs.jfrog_cli_artifactory_repo }}
-      jfrog_cli_artifactory_ref: ${{ steps.detect.outputs.jfrog_cli_artifactory_ref }}
-      jfrog_client_go_repo: ${{ steps.detect.outputs.jfrog_client_go_repo }}
-      jfrog_client_go_ref: ${{ steps.detect.outputs.jfrog_client_go_ref }}
-      jfrog_cli_core_repo: ${{ steps.detect.outputs.jfrog_cli_core_repo }}
-      jfrog_cli_core_ref: ${{ steps.detect.outputs.jfrog_cli_core_ref }}
+      deps: ${{ steps.detect.outputs.deps }}
     steps:
       - name: Checkout build-info-go
         uses: actions/checkout@v4
@@ -81,24 +74,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
@@ -139,24 +118,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ${{ matrix.os.name }}
 
       - name: Run Go tests
@@ -187,17 +152,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Prepare ubuntu
         if: matrix.os.name == 'ubuntu'
@@ -223,14 +182,6 @@ jobs:
         uses: nuget/setup-nuget@v2
         with:
           nuget-version: "6.x"
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -264,30 +215,16 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Install npm
         uses: actions/setup-node@v5
         with:
           node-version: "16"
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -324,17 +261,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Install Node.js
         uses: actions/setup-node@v5
@@ -345,14 +276,6 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: ${{ matrix.pnpm-version }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -388,30 +311,16 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Setup Maven v3.8.8
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.8
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -447,17 +356,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -469,14 +372,6 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           gradle-version: ${{ matrix.gradle-version }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -510,30 +405,16 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Install Conan
         uses: turtlebrowser/get-conan@main
         with:
           version: '2.10.2'
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -567,30 +448,16 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
           version: 'latest'
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -646,24 +513,10 @@ jobs:
           EOF'
           sudo systemctl restart docker
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ubuntu
 
       - name: Containerize Artifactory
@@ -707,24 +560,10 @@ jobs:
           EOF'
           sudo systemctl restart docker
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ubuntu
 
       - name: Run Podman tests
@@ -754,17 +593,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
+          os_name: ${{ matrix.os.name }}
 
       - name: Setup Python3
         uses: actions/setup-python@v6
@@ -778,14 +611,6 @@ jobs:
       - name: Setup Twine
         if: matrix.suite == 'pip'
         run: python -m pip install twine
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
-          os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main
@@ -819,24 +644,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ${{ matrix.os.name }}
 
       - name: Install local Artifactory
@@ -871,24 +682,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Checkout all JFrog repositories
-        uses: ./.github/actions/checkout-jfrog-repos
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
         with:
-          jfrog_cli_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_repo }}
-          jfrog_cli_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_ref }}
-          jfrog_cli_artifactory_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_repo }}
-          jfrog_cli_artifactory_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_artifactory_ref }}
-          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
-          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
-          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
-          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
-
-      - name: Setup Go with cache
-        uses: jfrog/.github/actions/install-go-with-cache@main
-
-      - name: Setup Go workspace
-        uses: ./.github/actions/setup-go-workspace
-        with:
+          deps: ${{ needs.Detect-Deps.outputs.deps }}
           os_name: ${{ matrix.os.name }}
 
       - name: Run Distribution tests


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
Add workflow to trigger cli integration tests