### PR TITLE
RTECO-1187 - Updated logic to skip cache check for empty depedency project

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -33,8 +33,11 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 		return nil, err
 	}
 	var cacache *cacache
-	if calculateChecksums {
-		// Get local npm cache.
+	// Skip the _cacache lookup when there are no dependencies to checksum.
+	// A project with no dependencies never causes npm to create the _cacache
+	// directory, so requiring it would fail `jf npm ci` on a fresh CI workspace
+	// (e.g. a Jenkins agent) for projects whose package.json has no dependencies.
+	if calculateChecksums && len(dependenciesMap) > 0 {
 		cacheLocation, err := GetNpmConfigCache(srcPath, executablePath, npmParams.Args, log)
 		if err != nil {
 			return nil, err

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -461,18 +461,27 @@ func TestCalculateNpmDependenciesListWithoutDependencies(t *testing.T) {
 	cachePath := filepath.Join(tempDir, "tmpcache")
 	npmArgs := []string{"--cache=" + cachePath}
 
-	// Generate package-lock.json (required by 'npm ci') without populating _cacache.
+	// Generate package-lock.json (required by 'npm ci' in real-world usage) without
+	// installing any tarballs. With modern npm this leaves _cacache absent; older npm
+	// (e.g. npm v6 bundled with Node 14) creates _cacache eagerly even on a no-op
+	// install. We force the "missing _cacache" state below to make the test
+	// deterministic across npm versions and to faithfully reproduce a fresh CI
+	// workspace (e.g. a Jenkins agent that wipes node_modules + the npm cache).
 	installArgs := append([]string{"--package-lock-only"}, npmArgs...)
 	_, _, err := RunNpmCmd("npm", tempDir, AppendNpmCommand(installArgs, "install"), logger)
 	require.NoError(t, err)
 
-	// Precondition: the npm cache must NOT contain _cacache. If this ever changes
-	// (e.g. a future npm version starts creating it eagerly), the test would silently
-	// stop exercising the regression path; fail loudly instead.
 	cacachePath := filepath.Join(cachePath, "_cacache")
+	if exists, err := utils.IsDirExists(cacachePath, false); err == nil && exists {
+		require.NoError(t, os.RemoveAll(cacachePath))
+	}
+
+	// Post-condition: _cacache must be absent. This is the precondition for the
+	// regression scenario; if it ever fails, the test would silently stop
+	// exercising the new guard, so fail loudly instead.
 	cacacheExists, err := utils.IsDirExists(cacachePath, false)
 	require.NoError(t, err)
-	require.Falsef(t, cacacheExists, "test precondition violated: '_cacache' must not exist at %q for this regression test to be meaningful", cacachePath)
+	require.Falsef(t, cacacheExists, "could not remove _cacache at %q; regression test would not exercise the fixed code path", cacachePath)
 
 	// The actual regression check.
 	dependencies, err := CalculateNpmDependenciesList("npm", tempDir, "no-deps-project",

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -427,6 +427,60 @@ func TestGetConfigCacheNpmIntegration(t *testing.T) {
 	assert.Equal(t, filepath.Join(cachePath, "_cacache"), configCache)
 }
 
+// TestCalculateNpmDependenciesListWithoutDependencies is a regression test for the bug
+// where 'jf npm ci' fails on a project with no dependencies because npm never creates
+// the '_cacache' directory under the npm cache path.
+//
+// Scenario reproduced:
+//   - package.json declares zero dependencies/devDependencies.
+//   - npm cache is pointed at a fresh empty directory (simulates a clean CI workspace,
+//     e.g. a Jenkins agent that wipes the workspace between builds).
+//   - 'npm install --package-lock-only' generates package-lock.json (a real-world
+//     precondition for 'npm ci') but does NOT create '_cacache' because no tarballs
+//     are fetched.
+//
+// Before the fix, CalculateNpmDependenciesList returned the error:
+//
+//	"_cacache folder is not found in '<cache>/_cacache'. Hint: Delete node_modules
+//	 directory and run npm install or npm ci."
+//
+// After the fix it returns no error and an empty dependency list.
+func TestCalculateNpmDependenciesListWithoutDependencies(t *testing.T) {
+	tempDir, cleanup := tests.CreateTempDirWithCallbackAndAssert(t)
+	defer cleanup()
+
+	packageJSON := []byte(`{
+  "name": "no-deps-project",
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}`)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "package.json"), packageJSON, 0600))
+
+	// Point npm at an empty cache dir inside the project to simulate a fresh CI workspace.
+	cachePath := filepath.Join(tempDir, "tmpcache")
+	npmArgs := []string{"--cache=" + cachePath}
+
+	// Generate package-lock.json (required by 'npm ci') without populating _cacache.
+	installArgs := append([]string{"--package-lock-only"}, npmArgs...)
+	_, _, err := RunNpmCmd("npm", tempDir, AppendNpmCommand(installArgs, "install"), logger)
+	require.NoError(t, err)
+
+	// Precondition: the npm cache must NOT contain _cacache. If this ever changes
+	// (e.g. a future npm version starts creating it eagerly), the test would silently
+	// stop exercising the regression path; fail loudly instead.
+	cacachePath := filepath.Join(cachePath, "_cacache")
+	cacacheExists, err := utils.IsDirExists(cacachePath, false)
+	require.NoError(t, err)
+	require.Falsef(t, cacacheExists, "test precondition violated: '_cacache' must not exist at %q for this regression test to be meaningful", cacachePath)
+
+	// The actual regression check.
+	dependencies, err := CalculateNpmDependenciesList("npm", tempDir, "no-deps-project",
+		NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	assert.NoError(t, err)
+	assert.Empty(t, dependencies)
+}
+
 // This function executes Ci, then validate generating dependencies in two possible scenarios:
 // 1. node_module exists in the project.
 // 2. node_module doesn't exist in the project and generating dependencies needs package-lock.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Appropriate label is added to the PR for auto generate release notes.
-----
What: Fix jf npm ci (and any caller of build.CollectDependenciesAndPublishBuildInfo) failing with _cacache folder is not found in '<npm-cache>/_cacache' on projects whose package.json declares no dependencies.

Why: npm only creates <npm-cache>/_cacache after it fetches its first tarball, so a zero-dependency project on a fresh CI workspace (e.g. a Jenkins agent that wipes between builds) never has it — but CalculateNpmDependenciesList was unconditionally requiring it for checksum calculation, hard-failing builds that have nothing to checksum in the first place.

How: Guard the GetNpmConfigCache call in build/utils/npm.go on len(dependenciesMap) > 0 so the _cacache lookup is skipped when there are no dependencies; added TestCalculateNpmDependenciesListWithoutDependencies as a regression test (verified failing on main, passing with the fix).