### PR TITLE
RTECO-1401 Fix/Publish Build Info with Build Duration 

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -291,7 +291,14 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	buildInfo.Started = buildGeneralDetails.Timestamp.Format(entities.TimeFormat)
+	startTime := buildGeneralDetails.Timestamp
+	buildInfo.Started = startTime.Format(entities.TimeFormat)
+	// Record how long the build took from its start until now (build-info generation / publish time).
+	if !startTime.IsZero() {
+		if duration := time.Since(startTime).Milliseconds(); duration > 0 {
+			buildInfo.DurationMillis = duration
+		}
+	}
 	modules, env, vcsList, issues, err := extractBuildInfoData(partials)
 	if err != nil {
 		return nil, err

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -1,10 +1,14 @@
 package build
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/build-info-go/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,6 +83,47 @@ func TestCollectEnv(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+// TestBuildInfoDurationMillis verifies that the generated build-info carries the elapsed
+// time between the build's start and the moment the build-info is generated (publish time).
+func TestBuildInfoDurationMillis(t *testing.T) {
+	tmpDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, utils.RemoveTempDir(tmpDir)) }()
+
+	const buildName, buildNumber = "duration-test", "1"
+	service := NewBuildInfoService()
+	service.SetTempDirPath(tmpDir)
+
+	build, err := service.GetOrCreateBuild(buildName, buildNumber)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, build.Clean()) }()
+
+	// Simulate a build that started one hour ago by rewriting the persisted start time.
+	startedAt := time.Now().Add(-time.Hour)
+	writeBuildGeneralDetails(t, tmpDir, buildName, buildNumber, startedAt)
+
+	buildInfo, err := build.ToBuildInfo()
+	assert.NoError(t, err)
+
+	// Started must reflect the recorded start time.
+	parsedStart, err := time.Parse(entities.TimeFormat, buildInfo.Started)
+	assert.NoError(t, err)
+	assert.WithinDuration(t, startedAt, parsedStart, time.Second)
+
+	// Duration must be ~1 hour, and crucially not 0.
+	assert.Greater(t, buildInfo.DurationMillis, int64(0))
+	assert.InDelta(t, time.Hour.Milliseconds(), buildInfo.DurationMillis, float64((30 * time.Second).Milliseconds()))
+}
+
+// writeBuildGeneralDetails overwrites the persisted build "details" file with the given start time.
+func writeBuildGeneralDetails(t *testing.T, tmpDir, buildName, buildNumber string, startedAt time.Time) {
+	partialsBuildDir, err := utils.GetPartialsBuildDir(buildName, buildNumber, "", tmpDir)
+	assert.NoError(t, err)
+	content, err := json.Marshal(&entities.General{Timestamp: startedAt})
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(filepath.Join(partialsBuildDir, BuildInfoDetails), content, 0600))
 }
 
 func TestSortBuildInfosByTimestamp(t *testing.T) {

--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -51,18 +51,19 @@ const (
 )
 
 type BuildInfo struct {
-	Name          string   `json:"name,omitempty"`
-	Number        string   `json:"number,omitempty"`
-	Agent         *Agent   `json:"agent,omitempty"`
-	BuildAgent    *Agent   `json:"buildAgent,omitempty"`
-	Modules       []Module `json:"modules,omitempty"`
-	Started       string   `json:"started,omitempty"`
-	Properties    Env      `json:"properties,omitempty"`
-	Principal     string   `json:"artifactoryPrincipal,omitempty"`
-	BuildUrl      string   `json:"url,omitempty"`
-	Issues        *Issues  `json:"issues,omitempty"`
-	PluginVersion string   `json:"artifactoryPluginVersion,omitempty"`
-	VcsList       []Vcs    `json:"vcs,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	Number         string   `json:"number,omitempty"`
+	Agent          *Agent   `json:"agent,omitempty"`
+	BuildAgent     *Agent   `json:"buildAgent,omitempty"`
+	Modules        []Module `json:"modules,omitempty"`
+	Started        string   `json:"started,omitempty"`
+	DurationMillis int64    `json:"durationMillis,omitempty"`
+	Properties     Env      `json:"properties,omitempty"`
+	Principal      string   `json:"artifactoryPrincipal,omitempty"`
+	BuildUrl       string   `json:"url,omitempty"`
+	Issues         *Issues  `json:"issues,omitempty"`
+	PluginVersion  string   `json:"artifactoryPluginVersion,omitempty"`
+	VcsList        []Vcs    `json:"vcs,omitempty"`
 }
 
 func New() *BuildInfo {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
Problem : the build duration was always coming `0` in the build info.
Solution: added the logic to calculate the build duration and capture it in build info.