### PR TITLE
Added uv, pipenv package support to recognise 403 Forbidden output

### DIFF
--- a/utils/error.go
+++ b/utils/error.go
@@ -16,6 +16,7 @@ const (
 	Yarn   PackageManager = "yarn"
 	Pnpm   PackageManager = "pnpm"
 	Uv     PackageManager = "uv"
+	Pipenv PackageManager = "pipenv"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -61,6 +62,8 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
 	case "uv":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
+	case "pipenv":
+		return strings.Contains(strings.ToLower(cmdOutput), "http error 403")
 	}
 	return false
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -8,10 +8,14 @@ import (
 type PackageManager string
 
 const (
-	Npm   PackageManager = "npm"
-	Maven PackageManager = "maven"
-	Pip   PackageManager = "pip"
-	Go    PackageManager = "go"
+	Npm    PackageManager = "npm"
+	Maven  PackageManager = "maven"
+	Pip    PackageManager = "pip"
+	Go     PackageManager = "go"
+	Poetry PackageManager = "poetry"
+	Yarn   PackageManager = "yarn"
+	Pnpm   PackageManager = "pnpm"
+	Uv     PackageManager = "uv"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -52,6 +56,11 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	case "go":
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden") ||
 			strings.Contains(strings.ToLower(cmdOutput), " 403")
+	case "poetry":
+		return strings.Contains(strings.ToLower(cmdOutput), "http error 403") ||
+			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
+	case "uv":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
 	}
 	return false
 }


### PR DESCRIPTION
…rror detection

Extends IsForbiddenOutput to recognize 403 errors for poetry and uv, in support of the uv package manager integration.

- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
Extends IsForbiddenOutput (utils/error.go) to recognize 403 Forbidden output for uv and pipenv, so we can see clearer auth errors instead of silently passing them through.