### PR TITLE
add ci env check for buid info duration capture

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -14,6 +14,7 @@ import (
 	ioutils "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/gofrog/log"
 
+	"github.com/jfrog/build-info-go/utils/cienv"
 	"github.com/jfrog/build-info-go/utils/pythonutils"
 
 	"github.com/jfrog/build-info-go/entities"
@@ -296,7 +297,7 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 	// Record build duration only when running in a CI environment. Duration is measured from the
 	// build's start (recorded by the first build command) until now - the moment the build-info is
 	// assembled for publishing.
-	if isRunningInCI() && !startTime.IsZero() {
+	if cienv.IsCIRunning() && !startTime.IsZero() {
 		if duration := time.Since(startTime).Milliseconds(); duration > 0 {
 			buildInfo.DurationMillis = duration
 		}
@@ -324,29 +325,6 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 	return buildInfo, nil
 }
 
-// ciEnvIndicators are environment variables set by common CI providers. Presence of any of them
-// (in addition to the standard CI=true) indicates the build is running inside a CI pipeline.
-var ciEnvIndicators = []string{
-	"JENKINS_URL",    // Jenkins
-	"GITHUB_ACTIONS", // GitHub Actions
-	"GITLAB_CI",      // GitLab CI
-	"TF_BUILD",       // Azure Pipelines
-	"CIRCLECI",       // CircleCI
-}
-
-// isRunningInCI reports whether the process is running inside a CI environment. It treats the
-// standard CI=true variable (set by most CI systems) or any known provider-specific variable as CI.
-func isRunningInCI() bool {
-	if os.Getenv("CI") == "true" {
-		return true
-	}
-	for _, envVar := range ciEnvIndicators {
-		if os.Getenv(envVar) != "" {
-			return true
-		}
-	}
-	return false
-}
 
 func (b *Build) readPartialBuildInfoFiles() (entities.Partials, error) {
 	var partials entities.Partials

--- a/build/build.go
+++ b/build/build.go
@@ -293,8 +293,10 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 	}
 	startTime := buildGeneralDetails.Timestamp
 	buildInfo.Started = startTime.Format(entities.TimeFormat)
-	// Record how long the build took from its start until now (build-info generation / publish time).
-	if !startTime.IsZero() {
+	// Record build duration only when running in a CI environment. Duration is measured from the
+	// build's start (recorded by the first build command) until now - the moment the build-info is
+	// assembled for publishing.
+	if isRunningInCI() && !startTime.IsZero() {
 		if duration := time.Since(startTime).Milliseconds(); duration > 0 {
 			buildInfo.DurationMillis = duration
 		}
@@ -320,6 +322,30 @@ func (b *Build) createBuildInfoFromPartials() (*entities.BuildInfo, error) {
 		buildInfo.Modules = append(buildInfo.Modules, module)
 	}
 	return buildInfo, nil
+}
+
+// ciEnvIndicators are environment variables set by common CI providers. Presence of any of them
+// (in addition to the standard CI=true) indicates the build is running inside a CI pipeline.
+var ciEnvIndicators = []string{
+	"JENKINS_URL",    // Jenkins
+	"GITHUB_ACTIONS", // GitHub Actions
+	"GITLAB_CI",      // GitLab CI
+	"TF_BUILD",       // Azure Pipelines
+	"CIRCLECI",       // CircleCI
+}
+
+// isRunningInCI reports whether the process is running inside a CI environment. It treats the
+// standard CI=true variable (set by most CI systems) or any known provider-specific variable as CI.
+func isRunningInCI() bool {
+	if os.Getenv("CI") == "true" {
+		return true
+	}
+	for _, envVar := range ciEnvIndicators {
+		if os.Getenv(envVar) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *Build) readPartialBuildInfoFiles() (entities.Partials, error) {

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/build-info-go/utils/cienv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,7 +136,8 @@ func TestBuildInfoDurationMillisSkippedOutsideCI(t *testing.T) {
 	defer func() { assert.NoError(t, build.Clean()) }()
 
 	// Ensure no CI markers are present.
-	for _, envVar := range append([]string{"CI"}, ciEnvIndicators...) {
+	t.Setenv("CI", "")
+	for _, envVar := range cienv.CIEnvIndicators {
 		t.Setenv(envVar, "")
 	}
 

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -100,6 +100,9 @@ func TestBuildInfoDurationMillis(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, build.Clean()) }()
 
+	// Duration is only recorded in CI environments.
+	t.Setenv("CI", "true")
+
 	// Simulate a build that started one hour ago by rewriting the persisted start time.
 	startedAt := time.Now().Add(-time.Hour)
 	writeBuildGeneralDetails(t, tmpDir, buildName, buildNumber, startedAt)
@@ -115,6 +118,35 @@ func TestBuildInfoDurationMillis(t *testing.T) {
 	// Duration must be ~1 hour, and crucially not 0.
 	assert.Greater(t, buildInfo.DurationMillis, int64(0))
 	assert.InDelta(t, time.Hour.Milliseconds(), buildInfo.DurationMillis, float64((30 * time.Second).Milliseconds()))
+}
+
+// TestBuildInfoDurationMillisSkippedOutsideCI verifies the duration is not recorded when not in CI.
+func TestBuildInfoDurationMillisSkippedOutsideCI(t *testing.T) {
+	tmpDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, utils.RemoveTempDir(tmpDir)) }()
+
+	const buildName, buildNumber = "duration-test-noci", "1"
+	service := NewBuildInfoService()
+	service.SetTempDirPath(tmpDir)
+
+	build, err := service.GetOrCreateBuild(buildName, buildNumber)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, build.Clean()) }()
+
+	// Ensure no CI markers are present.
+	for _, envVar := range append([]string{"CI"}, ciEnvIndicators...) {
+		t.Setenv(envVar, "")
+	}
+
+	writeBuildGeneralDetails(t, tmpDir, buildName, buildNumber, time.Now().Add(-time.Hour))
+
+	buildInfo, err := build.ToBuildInfo()
+	assert.NoError(t, err)
+
+	// Started is still recorded, but duration must remain 0 outside CI.
+	assert.NotEmpty(t, buildInfo.Started)
+	assert.Equal(t, int64(0), buildInfo.DurationMillis)
 }
 
 // writeBuildGeneralDetails overwrites the persisted build "details" file with the given start time.

--- a/utils/cienv/utils.go
+++ b/utils/cienv/utils.go
@@ -1,0 +1,28 @@
+package cienv
+
+import "os"
+
+// CIEnvIndicators are environment variables set by common CI providers.
+// Presence of any of them indicates the build is running inside a CI pipeline.
+var CIEnvIndicators = []string{
+	"JENKINS_URL",    // Jenkins (does not set CI=true by default)
+	"GITHUB_ACTIONS", // GitHub Actions
+	"GITLAB_CI",      // GitLab CI
+	"TF_BUILD",       // Azure Pipelines
+	"CIRCLECI",       // CircleCI
+}
+
+// IsCIRunning reports whether the process is running inside a CI environment.
+// CI is checked for the exact value "true" (the universal standard); provider-specific
+// variables are checked for mere presence because their values vary (e.g. JENKINS_URL is a URL).
+func IsCIRunning() bool {
+	if os.Getenv(CIEnvVar) == "true" {
+		return true
+	}
+	for _, envVar := range CIEnvIndicators {
+		if os.Getenv(envVar) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/cienv/utils_test.go
+++ b/utils/cienv/utils_test.go
@@ -1,0 +1,52 @@
+package cienv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCIRunning_CIEnvVar(t *testing.T) {
+	// Clear all CI markers before each sub-test.
+	clearAllCIMarkers(t)
+
+	t.Run("CI=true returns true", func(t *testing.T) {
+		setEnvForTest(t, CIEnvVar, "true")
+		assert.True(t, IsCIRunning())
+	})
+
+	t.Run("CI=false returns false", func(t *testing.T) {
+		setEnvForTest(t, CIEnvVar, "false")
+		assert.False(t, IsCIRunning())
+	})
+
+	t.Run("CI unset returns false", func(t *testing.T) {
+		unsetEnvForTest(t, CIEnvVar)
+		assert.False(t, IsCIRunning())
+	})
+}
+
+func TestIsCIRunning_ProviderIndicators(t *testing.T) {
+	for _, envVar := range CIEnvIndicators {
+		envVar := envVar
+		t.Run(envVar, func(t *testing.T) {
+			clearAllCIMarkers(t)
+			setEnvForTest(t, envVar, "somevalue")
+			assert.True(t, IsCIRunning(), "expected IsCIRunning()=true when %s is set", envVar)
+		})
+	}
+}
+
+func TestIsCIRunning_NoCIMarkersReturnsFalse(t *testing.T) {
+	clearAllCIMarkers(t)
+	assert.False(t, IsCIRunning())
+}
+
+// clearAllCIMarkers unsets CI and every provider-specific indicator for the duration of the test.
+func clearAllCIMarkers(t *testing.T) {
+	t.Helper()
+	unsetEnvForTest(t, CIEnvVar)
+	for _, envVar := range CIEnvIndicators {
+		unsetEnvForTest(t, envVar)
+	}
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
