### PR TITLE
Added uv, pipenv package support to recognise 403 Forbidden output

### DIFF
--- a/utils/error.go
+++ b/utils/error.go
@@ -15,6 +15,8 @@ const (
 	Poetry PackageManager = "poetry"
 	Yarn   PackageManager = "yarn"
 	Pnpm   PackageManager = "pnpm"
+	Uv     PackageManager = "uv"
+	Pipenv PackageManager = "pipenv"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -65,6 +67,10 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 	case "poetry":
 		return strings.Contains(strings.ToLower(cmdOutput), "http error 403") ||
 			strings.Contains(strings.ToLower(cmdOutput), "403 client error")
+	case "uv":
+		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
+	case "pipenv":
+		return strings.Contains(strings.ToLower(cmdOutput), "http error 403")
 	}
 	return false
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

Extends IsForbiddenOutput (utils/error.go) to recognize 403 Forbidden output for uv and pipenv, so we can see clearer auth errors instead of silently passing them through.