### PR TITLE
XRAY-135041 slnx support added for dotnet

### DIFF
--- a/build/utils/dotnet/solution/solution.go
+++ b/build/utils/dotnet/solution/solution.go
@@ -2,6 +2,7 @@ package solution
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"os"
@@ -311,7 +312,7 @@ func (solution *solution) loadSingleProject(project project.Project, log utils.L
 	return nil
 }
 
-// Finds all the projects by reading the content of the sln files.
+// Finds all the projects by reading the content of the sln/slnx files.
 // Returns a slice with all the projects in the solution.
 func (solution *solution) getProjectsFromSlns() ([]string, error) {
 	var allProjects []string
@@ -320,7 +321,11 @@ func (solution *solution) getProjectsFromSlns() ([]string, error) {
 		return nil, err
 	}
 	for _, slnFile := range slnFiles {
-		projects, err := parseSlnFile(slnFile)
+		parseFile := parseSlnFile
+		if strings.EqualFold(filepath.Ext(slnFile), ".slnx") {
+			parseFile = parseSlnxFile
+		}
+		projects, err := parseFile(slnFile)
 		if err != nil {
 			return nil, err
 		}
@@ -329,15 +334,24 @@ func (solution *solution) getProjectsFromSlns() ([]string, error) {
 	return allProjects, nil
 }
 
-// If sln file is not provided, finds all sln files in the directory.
+// If sln file is not provided, finds all sln/slnx files in the directory.
+// '.slnx' files take precedence over '.sln' files: after 'dotnet sln migrate', a directory can
+// contain both a legacy '.sln' and its migrated '.slnx' counterpart, and auto-discovering both
+// would parse the same projects twice.
 func (solution *solution) getSlnFiles() (slnFiles []string, err error) {
 	if solution.slnFile != "" {
 		slnFiles = append(slnFiles, filepath.Join(solution.path, solution.slnFile))
-	} else {
-		slnFiles, err = utils.ListFilesByFilterFunc(solution.path, func(filePath string) (bool, error) {
-			return filepath.Ext(filePath) == ".sln", nil
-		})
+		return
 	}
+	slnFiles, err = utils.ListFilesByFilterFunc(solution.path, func(filePath string) (bool, error) {
+		return strings.EqualFold(filepath.Ext(filePath), ".slnx"), nil
+	})
+	if err != nil || len(slnFiles) > 0 {
+		return
+	}
+	slnFiles, err = utils.ListFilesByFilterFunc(solution.path, func(filePath string) (bool, error) {
+		return strings.EqualFold(filepath.Ext(filePath), ".sln"), nil
+	})
 	return
 }
 
@@ -381,6 +395,82 @@ func parseSlnFile(slnFile string) ([]string, error) {
 	}
 	projects := projectRegExp.FindAllString(string(content), -1)
 	return projects, nil
+}
+
+// slnxDocument is the XML schema of a '.slnx' solution file.
+// Projects can sit directly under <Solution> or inside a <Folder>, which is purely organizational
+// and carries no dependency info. Per Slnx.xsd, <Folder> cannot nest further <Folder> elements;
+// all folders are flat siblings directly under <Solution>, and hierarchy is expressed via a
+// path-style Name attribute (e.g. "/src/nested/") rather than actual XML nesting.
+//
+//	<Solution>
+//	  <Project Path="src/MyProject/MyProject.csproj" />
+//	  <Folder Name="/tests/">
+//	    <Project Path="tests/MyProject.Tests/MyProject.Tests.csproj" />
+//	  </Folder>
+//	</Solution>
+type slnxDocument struct {
+	XMLName  xml.Name      `xml:"Solution"`
+	Projects []slnxProject `xml:"Project"`
+	Folders  []slnxFolder  `xml:"Folder"`
+}
+
+type slnxFolder struct {
+	Projects []slnxProject `xml:"Project"`
+}
+
+type slnxProject struct {
+	// Path is relative to the .slnx file's directory, using '/' as separator.
+	Path string `xml:"Path,attr"`
+	// DisplayName overrides the default display name. If empty, it defaults to the project file's base name.
+	DisplayName string `xml:"DisplayName,attr"`
+}
+
+// collectSlnxProjects collects every <Project>, whether directly under <Solution> or inside one
+// of its flat <Folder> siblings.
+func collectSlnxProjects(projects []slnxProject, folders []slnxFolder) []slnxProject {
+	all := append([]slnxProject{}, projects...)
+	for _, folder := range folders {
+		all = append(all, folder.Projects...)
+	}
+	return all
+}
+
+// parseSlnxFile parses a '.slnx' file and returns synthetic project lines shaped like the
+// legacy '.sln' format ('Project("{guid}") = "Name", "path"'), so parseProjectLine can
+// handle both formats unchanged. The GUID is a placeholder; parseProjectLine ignores it.
+func parseSlnxFile(slnxFile string) ([]string, error) {
+	content, err := os.ReadFile(slnxFile)
+	if err != nil {
+		return nil, err
+	}
+	var doc slnxDocument
+	if err = xml.Unmarshal(content, &doc); err != nil {
+		return nil, err
+	}
+	var lines []string
+	for _, proj := range collectSlnxProjects(doc.Projects, doc.Folders) {
+		if proj.Path == "" {
+			continue
+		}
+		name := proj.DisplayName
+		if name == "" {
+			name = slnxProjectNameFromPath(proj.Path)
+		}
+		lines = append(lines, fmt.Sprintf(`Project("{00000000-0000-0000-0000-000000000000}") = "%s", "%s"`, name, proj.Path))
+	}
+	return lines, nil
+}
+
+// slnxProjectNameFromPath derives a default project name from a Path attribute,
+// e.g. "src/MyProject/MyProject.csproj" -> "MyProject".
+func slnxProjectNameFromPath(projectPath string) string {
+	normalized := strings.ReplaceAll(projectPath, "\\", "/")
+	base := normalized
+	if idx := strings.LastIndex(normalized, "/"); idx != -1 {
+		base = normalized[idx+1:]
+	}
+	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
 func removeQuotes(value string) string {

--- a/build/utils/dotnet/solution/solution_test.go
+++ b/build/utils/dotnet/solution/solution_test.go
@@ -277,6 +277,147 @@ func TestParseSln(t *testing.T) {
 	}
 }
 
+func TestParseSlnx(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
+
+	testdataDir := filepath.Join(pwd, "testdata", "slnx")
+
+	tests := []struct {
+		name     string
+		slnxPath string
+		expected []string
+	}{
+		{"single", filepath.Join(testdataDir, "single.slnx"), []string{
+			`Project("{00000000-0000-0000-0000-000000000000}") = "packagesconfig", "packagesconfig.csproj"`,
+		}},
+		{"multiWithFolder", filepath.Join(testdataDir, "multi.slnx"), []string{
+			`Project("{00000000-0000-0000-0000-000000000000}") = "MyConsoleApp", "MyConsoleApp/MyConsoleApp.csproj"`,
+			`Project("{00000000-0000-0000-0000-000000000000}") = "ClassLibrary1", "ClassLibrary1/ClassLibrary1.csproj"`,
+		}},
+		{"explicitDisplayNameInFolder", filepath.Join(testdataDir, "namedproject.slnx"), []string{
+			`Project("{00000000-0000-0000-0000-000000000000}") = "CustomName", "deep/DeepProj.csproj"`,
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results, err := parseSlnxFile(test.slnxPath)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, results)
+		})
+	}
+}
+
+func TestSlnxProjectNameFromPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"forwardSlash", "src/MyProject/MyProject.csproj", "MyProject"},
+		{"backslash", `src\MyProject\MyProject.csproj`, "MyProject"},
+		{"noDir", "MyProject.csproj", "MyProject"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, slnxProjectNameFromPath(test.path))
+		})
+	}
+}
+
+// TestGetSlnFilesMatchesSlnx verifies getSlnFiles() picks up '.slnx' files, both when
+// auto-discovering in a directory and when an explicit slnFile is provided.
+func TestGetSlnFilesMatchesSlnx(t *testing.T) {
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	testdataDir := filepath.Join(pwd, "testdata", "slnx")
+
+	t.Run("autoDiscover", func(t *testing.T) {
+		sol := solution{path: testdataDir}
+		slnFiles, err := sol.getSlnFiles()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			filepath.Join(testdataDir, "single.slnx"),
+			filepath.Join(testdataDir, "multi.slnx"),
+			filepath.Join(testdataDir, "namedproject.slnx"),
+		}, slnFiles)
+	})
+
+	t.Run("explicitSlnFile", func(t *testing.T) {
+		sol := solution{path: testdataDir, slnFile: "single.slnx"}
+		slnFiles, err := sol.getSlnFiles()
+		require.NoError(t, err)
+		assert.Equal(t, []string{filepath.Join(testdataDir, "single.slnx")}, slnFiles)
+	})
+}
+
+// TestGetSlnFilesPrefersSlnxOverSln verifies that when a directory contains both a legacy
+// '.sln' and its migrated '.slnx' counterpart (e.g. after 'dotnet sln migrate' leaves the old
+// '.sln' behind), auto-discovery only picks up the '.slnx', so the same projects aren't parsed
+// twice.
+func TestGetSlnFilesPrefersSlnxOverSln(t *testing.T) {
+	dir := t.TempDir()
+	slnxPath := filepath.Join(dir, "MySolution.slnx")
+	require.NoError(t, os.WriteFile(slnxPath, []byte(`<Solution>
+  <Project Path="proj/proj.csproj" />
+</Solution>`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "MySolution.sln"), []byte(`Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "proj", "proj\proj.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+`), 0644))
+
+	sol := solution{path: dir}
+	slnFiles, err := sol.getSlnFiles()
+	require.NoError(t, err)
+	assert.Equal(t, []string{slnxPath}, slnFiles)
+
+	results, err := sol.getProjectsFromSlns()
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		`Project("{00000000-0000-0000-0000-000000000000}") = "proj", "proj/proj.csproj"`,
+	}, results, "expected the project to be parsed once, from the '.slnx', not duplicated from the '.sln'")
+}
+
+// TestGetProjectsFromSlnsRoutesSlnxByExtension verifies getProjectsFromSlns() routes
+// '.slnx' files to parseSlnxFile and leaves legacy '.sln' parsing untouched.
+func TestGetProjectsFromSlnsRoutesSlnxByExtension(t *testing.T) {
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	testdataDir := filepath.Join(pwd, "testdata", "slnx")
+
+	sol := solution{path: testdataDir, slnFile: "multi.slnx"}
+	results, err := sol.getProjectsFromSlns()
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		`Project("{00000000-0000-0000-0000-000000000000}") = "MyConsoleApp", "MyConsoleApp/MyConsoleApp.csproj"`,
+		`Project("{00000000-0000-0000-0000-000000000000}") = "ClassLibrary1", "ClassLibrary1/ClassLibrary1.csproj"`,
+	}, results)
+}
+
+// TestGetSlnFilesCaseInsensitiveExtension verifies '.sln'/'.slnx' matching (both in
+// auto-discovery and in extension-based parser routing) is case-insensitive, since macOS and
+// Windows filesystems are case-insensitive/case-preserving.
+func TestGetSlnFilesCaseInsensitiveExtension(t *testing.T) {
+	dir := t.TempDir()
+	slnxPath := filepath.Join(dir, "Upper.SLNX")
+	require.NoError(t, os.WriteFile(slnxPath, []byte(`<Solution>
+  <Project Path="proj/proj.csproj" />
+</Solution>`), 0644))
+
+	sol := solution{path: dir}
+	slnFiles, err := sol.getSlnFiles()
+	require.NoError(t, err)
+	require.Equal(t, []string{slnxPath}, slnFiles)
+
+	results, err := sol.getProjectsFromSlns()
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		`Project("{00000000-0000-0000-0000-000000000000}") = "proj", "proj/proj.csproj"`,
+	}, results)
+}
+
 func TestParseProjectLine(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -425,6 +566,51 @@ func TestLoadMixed(t *testing.T) {
 			assert.ElementsMatch(t, []string{"newtonsoft.json:9.0.1"}, direct)
 		case "core":
 			assert.Equal(t, filepath.Join(wd, "tmp", "multi", "core"), project.RootPath())
+			direct, err := project.Extractor().DirectDependencies()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"newtonsoft.json:9.0.1"}, direct)
+		default:
+			t.Errorf("Unexpected project name: %s", project.Name())
+		}
+	}
+}
+
+// TestLoadSlnx is the end-to-end counterpart to TestLoadMixed for the '.slnx' format: it exercises
+// the full Load(...) path (auto-discovering dependency sources, running project extractors) with
+// an explicit '.slnx' file, not just parseSlnxFile() in isolation.
+func TestLoadSlnx(t *testing.T) {
+	// Prepare
+	log := utils.NewDefaultLogger(utils.INFO)
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	testdataDir := filepath.Join(wd, "testdata")
+
+	// Run 'nuget restore' (multi) / 'dotnet restore' (core) command before testing 'Load()' functionality.
+	assert.NoError(t, utils.CopyDir(filepath.Join(testdataDir, "multi"), filepath.Join(wd, "tmp", "multi-slnx"), true, nil))
+	defer func() {
+		assert.NoError(t, utils.RemoveTempDir(filepath.Join(wd, "tmp")))
+	}()
+	nugetCmd := exec.Command("nuget", "restore", filepath.Join(wd, "tmp", "multi-slnx", "multi.sln"))
+	assert.NoError(t, nugetCmd.Run())
+
+	solution := solution{path: filepath.Join(wd, "tmp", "multi-slnx"), slnFile: "multi.slnx"}
+	solutions, err := Load(solution.path, solution.slnFile, "", log)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(solutions.GetProjects()))
+	assert.ElementsMatch(t, solutions.GetDependenciesSources(), []string{
+		filepath.Join(wd, "tmp", "multi-slnx", "multi", "packages.config"),
+		filepath.Join(wd, "tmp", "multi-slnx", "core", "obj", "project.assets.json"),
+	})
+
+	for _, project := range solutions.GetProjects() {
+		switch project.Name() {
+		case "multi":
+			assert.Equal(t, filepath.Join(wd, "tmp", "multi-slnx", "multi"), project.RootPath())
+			direct, err := project.Extractor().DirectDependencies()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"newtonsoft.json"}, direct)
+		case "core":
+			assert.Equal(t, filepath.Join(wd, "tmp", "multi-slnx", "core"), project.RootPath())
 			direct, err := project.Extractor().DirectDependencies()
 			require.NoError(t, err)
 			assert.ElementsMatch(t, []string{"newtonsoft.json:9.0.1"}, direct)

--- a/build/utils/dotnet/solution/testdata/multi/multi.slnx
+++ b/build/utils/dotnet/solution/testdata/multi/multi.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="core/core.csproj" />
+  <Project Path="multi/multi.csproj" />
+</Solution>

--- a/build/utils/dotnet/solution/testdata/slnx/multi.slnx
+++ b/build/utils/dotnet/solution/testdata/slnx/multi.slnx
@@ -1,0 +1,6 @@
+<Solution>
+  <Project Path="MyConsoleApp/MyConsoleApp.csproj" />
+  <Folder Name="/lib/">
+    <Project Path="ClassLibrary1/ClassLibrary1.csproj" />
+  </Folder>
+</Solution>

--- a/build/utils/dotnet/solution/testdata/slnx/namedproject.slnx
+++ b/build/utils/dotnet/solution/testdata/slnx/namedproject.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Folder Name="/src/nested/">
+    <Project Path="deep/DeepProj.csproj" DisplayName="CustomName" />
+  </Folder>
+</Solution>

--- a/build/utils/dotnet/solution/testdata/slnx/single.slnx
+++ b/build/utils/dotnet/solution/testdata/slnx/single.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="packagesconfig.csproj" />
+</Solution>


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
Add parsing support for '.slnx', the new XML-based .NET solution format.

- getSlnFiles now also matches *.slnx.
- New parseSlnxFile unmarshals the XML, recurses through <Folder> nesting, and emits the same synthetic project-line format parseSlnFile produces for .sln, so existing downstream parsing is unchanged.

No breaking changes — purely additive, .sln parsing untouched.