### PR TITLE
Resolve dynamic project version from uv.lock for UV build info

### DIFF
--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -1,6 +1,9 @@
 package unit
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +44,55 @@ func writeTempFiles(t *testing.T, dir string, files map[string]string) {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
 			t.Fatalf("Failed to write %s: %v", name, err)
 		}
+	}
+}
+
+// writeTestWheel creates a minimal but real wheel (zip) at path containing just a
+// "{name}.dist-info/METADATA" entry, mirroring what a real build backend writes.
+func writeTestWheel(t *testing.T, path, name, version string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Failed to create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	w, err := zw.Create(name + ".dist-info/METADATA")
+	if err != nil {
+		t.Fatalf("Failed to add METADATA entry: %v", err)
+	}
+	if _, err := w.Write([]byte("Metadata-Version: 2.4\nName: " + name + "\nVersion: " + version + "\n\n")); err != nil {
+		t.Fatalf("Failed to write METADATA: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close wheel zip: %v", err)
+	}
+}
+
+// writeTestSdist creates a minimal but real sdist (tar.gz) at path containing just a
+// top-level "PKG-INFO" file, mirroring what a real build backend writes.
+func writeTestSdist(t *testing.T, path, name, version string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Failed to create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	content := []byte("Metadata-Version: 2.4\nName: " + name + "\nVersion: " + version + "\n\n")
+	hdr := &tar.Header{Name: name + "-" + version + "/PKG-INFO", Mode: 0644, Size: int64(len(content))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("Failed to write PKG-INFO: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Failed to close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer: %v", err)
 	}
 }
 
@@ -828,9 +880,10 @@ func TestUvDynamicVersionResolvedFromLockFallback(t *testing.T) {
 
 // TestUvDynamicVersionResolvedFromDist covers `jf uv build`/`jf uv publish`: by the time
 // build-info collection runs for those commands, `uv build`/`uv publish` has already
-// succeeded, so dist/ is guaranteed to contain the built wheel/sdist whose filename encodes
-// the real backend-resolved version. This is the exact scenario from the reported bug
-// (jfrog/jfrog-cli#3624): a hatch-vcs project with no uv.lock root version at all.
+// succeeded, so dist/ is guaranteed to contain a wheel/sdist whose embedded package metadata
+// (METADATA/PKG-INFO) records the real backend-resolved version. This is the exact scenario
+// from the reported bug (jfrog/jfrog-cli#3624): a hatch-vcs project with no uv.lock root
+// version at all.
 func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
@@ -841,10 +894,9 @@ func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
 		t.Fatalf("Failed to create dist dir: %v", err)
 	}
 	// Real hatch-vcs-resolved version, e.g. a dev build a few commits past the last tag.
-	writeTempFiles(t, distDir, map[string]string{
-		"my_app-1.2.4.dev0+g6df800799.d20260730-py3-none-any.whl": "",
-		"my_app-1.2.4.dev0+g6df800799.d20260730.tar.gz":           "",
-	})
+	const version = "1.2.4.dev0+g6df800799.d20260730"
+	writeTestWheel(t, filepath.Join(distDir, "my_app-"+version+"-py3-none-any.whl"), "my-app", version)
+	writeTestSdist(t, filepath.Join(distDir, "my_app-"+version+".tar.gz"), "my-app", version)
 
 	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 	if err != nil {
@@ -854,7 +906,7 @@ func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CollectBuildInfo failed: %v", err)
 	}
-	want := "my-app:1.2.4.dev0+g6df800799.d20260730"
+	want := "my-app:" + version
 	if buildInfo.Modules[0].Id != want {
 		t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
 	}
@@ -949,9 +1001,9 @@ source = { registry = "https://pypi.org/simple" }
 		if err := os.MkdirAll(distDir, 0755); err != nil {
 			t.Fatalf("Failed to create dist dir: %v", err)
 		}
-		writeTempFiles(t, distDir, map[string]string{
-			"other_package-2.0.0-py3-none-any.whl": "",
-		})
+		// A real, valid wheel — just for a different package. Its Name field in METADATA
+		// must be checked against, not just its filename, or this would false-match.
+		writeTestWheel(t, filepath.Join(distDir, "other_package-2.0.0-py3-none-any.whl"), "other-package", "2.0.0")
 
 		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 		if err != nil {
@@ -981,10 +1033,8 @@ func TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch(t *testing.T) {
 	if err := os.MkdirAll(distDir, 0755); err != nil {
 		t.Fatalf("Failed to create dist dir: %v", err)
 	}
-	writeTempFiles(t, distDir, map[string]string{
-		"my_app-1.2.3-py3-none-any.whl": "", // stale, from an earlier build
-		"my_app-1.2.4.dev0+abc.tar.gz":  "", // fresh, from the current build
-	})
+	writeTestWheel(t, filepath.Join(distDir, "my_app-1.2.3-py3-none-any.whl"), "my-app", "1.2.3")         // stale, from an earlier build
+	writeTestSdist(t, filepath.Join(distDir, "my_app-1.2.4.dev0+abc.tar.gz"), "my-app", "1.2.4.dev0+abc") // fresh, from the current build
 	staleTime := time.Now().Add(-time.Hour)
 	if err := os.Chtimes(filepath.Join(distDir, "my_app-1.2.3-py3-none-any.whl"), staleTime, staleTime); err != nil {
 		t.Fatalf("Failed to set stale mtime: %v", err)
@@ -1001,6 +1051,37 @@ func TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch(t *testing.T) {
 	want := "my-app:1.2.4.dev0+abc"
 	if buildInfo.Modules[0].Id != want {
 		t.Errorf("Expected module ID %q (from the freshly built artifact), got %q", want, buildInfo.Modules[0].Id)
+	}
+}
+
+// TestUvDynamicVersionSkipsUnreadableDistArchive covers a corrupt or partially-written
+// archive in dist/ (e.g. an interrupted build) sitting next to a good one — reading package
+// metadata must skip files it can't open rather than erroring the whole resolution.
+func TestUvDynamicVersionSkipsUnreadableDistArchive(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject("my-app"),
+	})
+	distDir := filepath.Join(tempDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("Failed to create dist dir: %v", err)
+	}
+	writeTempFiles(t, distDir, map[string]string{
+		"my_app-1.2.3-py3-none-any.whl": "not a real zip file",
+	})
+	writeTestSdist(t, filepath.Join(distDir, "my_app-1.2.3.tar.gz"), "my-app", "1.2.3")
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my-app:1.2.3"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected the valid sdist's version %q despite the corrupt wheel, got %q", want, buildInfo.Modules[0].Id)
 	}
 }
 

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -787,3 +787,95 @@ func TestUvErrorHandling(t *testing.T) {
 		}
 	})
 }
+
+// dynamicPyproject returns a pyproject.toml declaring `dynamic = ["version"]`,
+// e.g. as produced by hatch-vcs, with no static [project.version].
+func dynamicPyproject(name string) string {
+	return "[project]\nname = \"" + name + "\"\ndynamic = [\"version\"]\n" +
+		"[tool.hatch.version]\nsource = \"vcs\"\n"
+}
+
+func TestUvDynamicVersionResolvedFromLock(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject("my-app"),
+		"uv.lock":        minimalUvLock("my-app"),
+	})
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed for dynamic version: %v", err)
+	}
+
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	if len(buildInfo.Modules) == 0 {
+		t.Fatal("Expected at least one module")
+	}
+	// minimalUvLock's root package entry is version "1.0.0" — that's what uv resolved
+	// the dynamic version to at lock time, so it must be reflected in the module ID.
+	if buildInfo.Modules[0].Id != "my-app:1.0.0" {
+		t.Errorf("Expected module ID 'my-app:1.0.0', got '%s'", buildInfo.Modules[0].Id)
+	}
+}
+
+func TestUvDynamicVersionErrors(t *testing.T) {
+	t.Run("dynamic version but no uv.lock", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": dynamicPyproject("my-app"),
+		})
+
+		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err == nil {
+			t.Fatal("Expected error when dynamic version can't be resolved without uv.lock")
+		}
+	})
+
+	t.Run("dynamic version but uv.lock has no root package entry", func(t *testing.T) {
+		tempDir := t.TempDir()
+		// A lock file with only a third-party dependency and no root ("virtual"/"editable"/
+		// "directory" == ".") entry — e.g. malformed or stale relative to pyproject.toml.
+		uvLockContent := `version = 1
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+`
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": dynamicPyproject("my-app"),
+			"uv.lock":        uvLockContent,
+		})
+
+		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err == nil {
+			t.Fatal("Expected error when uv.lock has no root package entry to resolve the dynamic version from")
+		}
+	})
+}
+
+func TestUvStaticVersionUnaffectedByDynamicField(t *testing.T) {
+	// A project that declares dynamic = ["version"] alongside dependency collection
+	// still using a plain static pyproject.toml (no dynamic field at all) must behave
+	// exactly as before: unchanged error and success paths.
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": minimalPyproject("my-app"),
+		"uv.lock":        minimalUvLock("my-app"),
+	})
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed for static version: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	if buildInfo.Modules[0].Id != "my-app:1.0.0" {
+		t.Errorf("Expected module ID 'my-app:1.0.0', got '%s'", buildInfo.Modules[0].Id)
+	}
+}

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -841,10 +841,10 @@ func TestUvErrorHandling(t *testing.T) {
 	})
 }
 
-// dynamicPyproject returns a pyproject.toml declaring `dynamic = ["version"]`,
-// e.g. as produced by hatch-vcs, with no static [project.version].
-func dynamicPyproject(name string) string {
-	return "[project]\nname = \"" + name + "\"\ndynamic = [\"version\"]\n" +
+// dynamicPyproject returns a pyproject.toml for project "my-app" declaring
+// `dynamic = ["version"]`, e.g. as produced by hatch-vcs, with no static [project.version].
+func dynamicPyproject() string {
+	return "[project]\nname = \"my-app\"\ndynamic = [\"version\"]\n" +
 		"[tool.hatch.version]\nsource = \"vcs\"\n"
 }
 
@@ -857,7 +857,7 @@ func dynamicPyproject(name string) string {
 func TestUvDynamicVersionResolvedFromLockFallback(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": dynamicPyproject("my-app"),
+		"pyproject.toml": dynamicPyproject(),
 		"uv.lock":        minimalUvLock("my-app"),
 	})
 
@@ -887,7 +887,7 @@ func TestUvDynamicVersionResolvedFromLockFallback(t *testing.T) {
 func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": dynamicPyproject("my-app"),
+		"pyproject.toml": dynamicPyproject(),
 	})
 	distDir := filepath.Join(tempDir, "dist")
 	if err := os.MkdirAll(distDir, 0755); err != nil {
@@ -918,7 +918,7 @@ func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
 func TestUvDynamicVersionResolvedFromInstalledPackages(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": dynamicPyproject("my-app"),
+		"pyproject.toml": dynamicPyproject(),
 	})
 
 	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
@@ -947,7 +947,7 @@ func TestUvDynamicVersionFallsBackToEmptyVersion(t *testing.T) {
 	t.Run("no uv.lock, dist/, or installed packages", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": dynamicPyproject("my-app"),
+			"pyproject.toml": dynamicPyproject(),
 		})
 
 		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
@@ -975,7 +975,7 @@ version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 `
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": dynamicPyproject("my-app"),
+			"pyproject.toml": dynamicPyproject(),
 			"uv.lock":        uvLockContent,
 		})
 
@@ -995,7 +995,7 @@ source = { registry = "https://pypi.org/simple" }
 	t.Run("dist/ has only unrelated packages", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
-			"pyproject.toml": dynamicPyproject("my-app"),
+			"pyproject.toml": dynamicPyproject(),
 		})
 		distDir := filepath.Join(tempDir, "dist")
 		if err := os.MkdirAll(distDir, 0755); err != nil {
@@ -1027,7 +1027,7 @@ source = { registry = "https://pypi.org/simple" }
 func TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": dynamicPyproject("my-app"),
+		"pyproject.toml": dynamicPyproject(),
 	})
 	distDir := filepath.Join(tempDir, "dist")
 	if err := os.MkdirAll(distDir, 0755); err != nil {
@@ -1060,7 +1060,7 @@ func TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch(t *testing.T) {
 func TestUvDynamicVersionSkipsUnreadableDistArchive(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
-		"pyproject.toml": dynamicPyproject("my-app"),
+		"pyproject.toml": dynamicPyproject(),
 	})
 	distDir := filepath.Join(tempDir, "dist")
 	if err := os.MkdirAll(distDir, 0755); err != nil {
@@ -1082,6 +1082,103 @@ func TestUvDynamicVersionSkipsUnreadableDistArchive(t *testing.T) {
 	want := "my-app:1.2.3"
 	if buildInfo.Modules[0].Id != want {
 		t.Errorf("Expected the valid sdist's version %q despite the corrupt wheel, got %q", want, buildInfo.Modules[0].Id)
+	}
+}
+
+// writeTestSdistWithEntries creates a tar.gz at path with the given entries written in
+// order, each as a plain file. Used to control tar entry ordering precisely, unlike
+// writeTestSdist which always writes a single well-formed top-level PKG-INFO.
+func writeTestSdistWithEntries(t *testing.T, path string, entries map[string]string, order []string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Failed to create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for _, name := range order {
+		content := []byte(entries[name])
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}); err != nil {
+			t.Fatalf("Failed to write tar header for %s: %v", name, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("Failed to write %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Failed to close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer: %v", err)
+	}
+}
+
+// TestUvDynamicVersionIgnoresNestedEggInfoPkgInfo covers an sdist that accidentally bundles
+// a nested *.egg-info/PKG-INFO (a known historical setuptools quirk) alongside the real
+// top-level PKG-INFO, with the nested (stale) one appearing FIRST in tar order. The nested
+// entry must be ignored — only the top-level "{name}-{version}/PKG-INFO" is authoritative.
+func TestUvDynamicVersionIgnoresNestedEggInfoPkgInfo(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject(),
+	})
+	distDir := filepath.Join(tempDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("Failed to create dist dir: %v", err)
+	}
+	staleMetadata := "Metadata-Version: 2.4\nName: my-app\nVersion: 0.0.1-stale\n\n"
+	realMetadata := "Metadata-Version: 2.4\nName: my-app\nVersion: 1.2.3\n\n"
+	writeTestSdistWithEntries(t, filepath.Join(distDir, "my_app-1.2.3.tar.gz"),
+		map[string]string{
+			"my_app-1.2.3/my_app.egg-info/PKG-INFO": staleMetadata, // nested, listed first
+			"my_app-1.2.3/PKG-INFO":                 realMetadata,  // top-level, authoritative
+		},
+		[]string{"my_app-1.2.3/my_app.egg-info/PKG-INFO", "my_app-1.2.3/PKG-INFO"},
+	)
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my-app:1.2.3"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected the top-level PKG-INFO's version %q, got %q (picked up the nested egg-info instead?)", want, buildInfo.Modules[0].Id)
+	}
+}
+
+// TestUvDynamicVersionResolvedFromInstalledPackagesWithDottedName covers a project name
+// containing "." (common for Python namespace packages, e.g. zope.interface). Callers like
+// jfrog-cli-artifactory's uvInstalledPackages build UVConfig.InstalledPackages with only
+// ToLower + "_"->"-" (dots untouched), not full PEP 503 normalization — the lookup must still
+// match despite that mismatch, comparing both sides through the same normalization.
+func TestUvDynamicVersionResolvedFromInstalledPackagesWithDottedName(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": "[project]\nname = \"my.app\"\ndynamic = [\"version\"]\n" +
+			"[tool.hatch.version]\nsource = \"vcs\"\n",
+	})
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
+		WorkingDirectory: tempDir,
+		// Mirrors jfrog-cli-artifactory's uvInstalledPackages key format: lowercase + "_"->"-"
+		// only — "my.app" stays "my.app", it is NOT collapsed to "my-app".
+		InstalledPackages: map[string]string{"my.app": "1.2.4.dev0+g6df800799.d20260730"},
+	})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed for dotted project name: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my.app:1.2.4.dev0+g6df800799.d20260730"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
 	}
 }
 

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jfrog/build-info-go/flexpack"
 )
@@ -885,20 +886,32 @@ func TestUvDynamicVersionResolvedFromInstalledPackages(t *testing.T) {
 	}
 }
 
-func TestUvDynamicVersionErrors(t *testing.T) {
-	t.Run("dynamic version but no uv.lock, dist/, or installed packages", func(t *testing.T) {
+// TestUvDynamicVersionFallsBackToEmptyVersion covers the case where a dynamic version can't
+// be resolved from any source at all. This must NOT fail collector construction — that would
+// throw away dependency and artifact collection too, just because one field is unknown. It
+// mirrors the existing PEP 723 inline-script tolerance (see loadPyProjectToml): an empty
+// version still produces a usable "name:" module ID.
+func TestUvDynamicVersionFallsBackToEmptyVersion(t *testing.T) {
+	t.Run("no uv.lock, dist/, or installed packages", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
 			"pyproject.toml": dynamicPyproject("my-app"),
 		})
 
-		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
-		if err == nil {
-			t.Fatal("Expected error when dynamic version can't be resolved from any source")
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err != nil {
+			t.Fatalf("Expected constructor to succeed with an empty fallback version, got: %v", err)
+		}
+		buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+		if err != nil {
+			t.Fatalf("CollectBuildInfo failed: %v", err)
+		}
+		if want := "my-app:"; buildInfo.Modules[0].Id != want {
+			t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
 		}
 	})
 
-	t.Run("dynamic version but uv.lock has no root package entry", func(t *testing.T) {
+	t.Run("uv.lock has no root package entry", func(t *testing.T) {
 		tempDir := t.TempDir()
 		// A lock file with only a third-party dependency and no root ("virtual"/"editable"/
 		// "directory" == ".") entry — e.g. malformed or stale relative to pyproject.toml.
@@ -914,13 +927,20 @@ source = { registry = "https://pypi.org/simple" }
 			"uv.lock":        uvLockContent,
 		})
 
-		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
-		if err == nil {
-			t.Fatal("Expected error when uv.lock has no root package entry to resolve the dynamic version from")
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err != nil {
+			t.Fatalf("Expected constructor to succeed with an empty fallback version, got: %v", err)
+		}
+		buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+		if err != nil {
+			t.Fatalf("CollectBuildInfo failed: %v", err)
+		}
+		if want := "my-app:"; buildInfo.Modules[0].Id != want {
+			t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
 		}
 	})
 
-	t.Run("dynamic version but dist/ has only unrelated packages", func(t *testing.T) {
+	t.Run("dist/ has only unrelated packages", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
 			"pyproject.toml": dynamicPyproject("my-app"),
@@ -933,11 +953,55 @@ source = { registry = "https://pypi.org/simple" }
 			"other_package-2.0.0-py3-none-any.whl": "",
 		})
 
-		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
-		if err == nil {
-			t.Fatal("Expected error when dist/ contains no artifact matching this project's name")
+		uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err != nil {
+			t.Fatalf("Expected constructor to succeed with an empty fallback version, got: %v", err)
+		}
+		buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+		if err != nil {
+			t.Fatalf("CollectBuildInfo failed: %v", err)
+		}
+		if want := "my-app:"; buildInfo.Modules[0].Id != want {
+			t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
 		}
 	})
+}
+
+// TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch covers dist/ accumulating
+// artifacts across multiple builds (uv does not clean dist/ between `uv build` runs): a
+// stale wheel from an older version alongside a freshly built sdist for the current version.
+// The most recently modified matching file must win, not whichever os.ReadDir happens to
+// return first.
+func TestUvDynamicVersionResolvedFromDistPrefersNewestOnMismatch(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject("my-app"),
+	})
+	distDir := filepath.Join(tempDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("Failed to create dist dir: %v", err)
+	}
+	writeTempFiles(t, distDir, map[string]string{
+		"my_app-1.2.3-py3-none-any.whl": "", // stale, from an earlier build
+		"my_app-1.2.4.dev0+abc.tar.gz":  "", // fresh, from the current build
+	})
+	staleTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(filepath.Join(distDir, "my_app-1.2.3-py3-none-any.whl"), staleTime, staleTime); err != nil {
+		t.Fatalf("Failed to set stale mtime: %v", err)
+	}
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my-app:1.2.4.dev0+abc"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected module ID %q (from the freshly built artifact), got %q", want, buildInfo.Modules[0].Id)
+	}
 }
 
 func TestUvStaticVersionUnaffectedByDynamicField(t *testing.T) {

--- a/flexpack/tests/unit/uv_flexpack_test.go
+++ b/flexpack/tests/unit/uv_flexpack_test.go
@@ -795,7 +795,13 @@ func dynamicPyproject(name string) string {
 		"[tool.hatch.version]\nsource = \"vcs\"\n"
 }
 
-func TestUvDynamicVersionResolvedFromLock(t *testing.T) {
+// TestUvDynamicVersionResolvedFromLockFallback covers the (currently unobserved in real uv
+// output, but cheap and harmless to support) case where uv.lock's root package entry does
+// carry an explicit version. The realistic sources — dist/ artifacts and installed packages —
+// are covered by TestUvDynamicVersionResolvedFromDist and
+// TestUvDynamicVersionResolvedFromInstalledPackages below; real `uv lock` output was verified
+// to never populate a version on the root/editable [[package]] entry, static or dynamic.
+func TestUvDynamicVersionResolvedFromLockFallback(t *testing.T) {
 	tempDir := t.TempDir()
 	writeTempFiles(t, tempDir, map[string]string{
 		"pyproject.toml": dynamicPyproject("my-app"),
@@ -814,15 +820,73 @@ func TestUvDynamicVersionResolvedFromLock(t *testing.T) {
 	if len(buildInfo.Modules) == 0 {
 		t.Fatal("Expected at least one module")
 	}
-	// minimalUvLock's root package entry is version "1.0.0" — that's what uv resolved
-	// the dynamic version to at lock time, so it must be reflected in the module ID.
 	if buildInfo.Modules[0].Id != "my-app:1.0.0" {
 		t.Errorf("Expected module ID 'my-app:1.0.0', got '%s'", buildInfo.Modules[0].Id)
 	}
 }
 
+// TestUvDynamicVersionResolvedFromDist covers `jf uv build`/`jf uv publish`: by the time
+// build-info collection runs for those commands, `uv build`/`uv publish` has already
+// succeeded, so dist/ is guaranteed to contain the built wheel/sdist whose filename encodes
+// the real backend-resolved version. This is the exact scenario from the reported bug
+// (jfrog/jfrog-cli#3624): a hatch-vcs project with no uv.lock root version at all.
+func TestUvDynamicVersionResolvedFromDist(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject("my-app"),
+	})
+	distDir := filepath.Join(tempDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("Failed to create dist dir: %v", err)
+	}
+	// Real hatch-vcs-resolved version, e.g. a dev build a few commits past the last tag.
+	writeTempFiles(t, distDir, map[string]string{
+		"my_app-1.2.4.dev0+g6df800799.d20260730-py3-none-any.whl": "",
+		"my_app-1.2.4.dev0+g6df800799.d20260730.tar.gz":           "",
+	})
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed for dynamic version resolved from dist/: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my-app:1.2.4.dev0+g6df800799.d20260730"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
+	}
+}
+
+// TestUvDynamicVersionResolvedFromInstalledPackages covers `jf uv sync`/`add`/`install`/
+// `remove`: those commands install the project itself into the venv, and `uv pip list`
+// (already collected into UVConfig.InstalledPackages) reports its resolved version.
+func TestUvDynamicVersionResolvedFromInstalledPackages(t *testing.T) {
+	tempDir := t.TempDir()
+	writeTempFiles(t, tempDir, map[string]string{
+		"pyproject.toml": dynamicPyproject("my-app"),
+	})
+
+	uf, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
+		WorkingDirectory:  tempDir,
+		InstalledPackages: map[string]string{"my-app": "1.2.4.dev0+g6df800799.d20260730"},
+	})
+	if err != nil {
+		t.Fatalf("NewUvFlexPack failed for dynamic version resolved from installed packages: %v", err)
+	}
+	buildInfo, err := uf.CollectBuildInfo("my-build", "1")
+	if err != nil {
+		t.Fatalf("CollectBuildInfo failed: %v", err)
+	}
+	want := "my-app:1.2.4.dev0+g6df800799.d20260730"
+	if buildInfo.Modules[0].Id != want {
+		t.Errorf("Expected module ID %q, got %q", want, buildInfo.Modules[0].Id)
+	}
+}
+
 func TestUvDynamicVersionErrors(t *testing.T) {
-	t.Run("dynamic version but no uv.lock", func(t *testing.T) {
+	t.Run("dynamic version but no uv.lock, dist/, or installed packages", func(t *testing.T) {
 		tempDir := t.TempDir()
 		writeTempFiles(t, tempDir, map[string]string{
 			"pyproject.toml": dynamicPyproject("my-app"),
@@ -830,7 +894,7 @@ func TestUvDynamicVersionErrors(t *testing.T) {
 
 		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 		if err == nil {
-			t.Fatal("Expected error when dynamic version can't be resolved without uv.lock")
+			t.Fatal("Expected error when dynamic version can't be resolved from any source")
 		}
 	})
 
@@ -853,6 +917,25 @@ source = { registry = "https://pypi.org/simple" }
 		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
 		if err == nil {
 			t.Fatal("Expected error when uv.lock has no root package entry to resolve the dynamic version from")
+		}
+	})
+
+	t.Run("dynamic version but dist/ has only unrelated packages", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writeTempFiles(t, tempDir, map[string]string{
+			"pyproject.toml": dynamicPyproject("my-app"),
+		})
+		distDir := filepath.Join(tempDir, "dist")
+		if err := os.MkdirAll(distDir, 0755); err != nil {
+			t.Fatalf("Failed to create dist dir: %v", err)
+		}
+		writeTempFiles(t, distDir, map[string]string{
+			"other_package-2.0.0-py3-none-any.whl": "",
+		})
+
+		_, err := flexpack.NewUVFlexPack(flexpack.UVConfig{WorkingDirectory: tempDir})
+		if err == nil {
+			t.Fatal("Expected error when dist/ contains no artifact matching this project's name")
 		}
 	})
 }

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -147,9 +147,9 @@ func (uf *UVFlexPack) loadPyProjectToml() error {
 		return fmt.Errorf("project name not found in pyproject.toml (checked [project.name])")
 	}
 	// A dynamic version (PEP 621 `dynamic = ["version"]`, e.g. via hatch-vcs) is resolved
-	// later from uv.lock once it's loaded — see resolveDynamicVersion.
+	// later, once uv.lock/dist/installed-packages state is available — see resolveDynamicVersion.
 	if uf.projectVersion == "" && !uf.versionIsDynamic {
-		return fmt.Errorf("project version not found in pyproject.toml (checked [project.version])")
+		return fmt.Errorf("project version not found in pyproject.toml (checked [project.version] and [project.dynamic] for \"version\")")
 	}
 	return nil
 }

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -21,20 +21,20 @@ import (
 
 // UVLockFile represents the top-level structure of uv.lock
 type UVLockFile struct {
-	Version  int          `toml:"version"`
-	Revision int          `toml:"revision"`
-	Packages []UVPackage  `toml:"package"`
+	Version  int         `toml:"version"`
+	Revision int         `toml:"revision"`
+	Packages []UVPackage `toml:"package"`
 }
 
 // UVPackage represents a [[package]] entry in uv.lock
 type UVPackage struct {
-	Name            string                         `toml:"name"`
-	Version         string                         `toml:"version"`
-	Source          UVSource                       `toml:"source"`
-	Dependencies    []UVDependencyEdge             `toml:"dependencies"`
-	DevDependencies map[string][]UVDependencyEdge  `toml:"dev-dependencies"`
-	Sdist           *UVArtifact                    `toml:"sdist"`
-	Wheels          []UVArtifact                   `toml:"wheels"`
+	Name            string                        `toml:"name"`
+	Version         string                        `toml:"version"`
+	Source          UVSource                      `toml:"source"`
+	Dependencies    []UVDependencyEdge            `toml:"dependencies"`
+	DevDependencies map[string][]UVDependencyEdge `toml:"dev-dependencies"`
+	Sdist           *UVArtifact                   `toml:"sdist"`
+	Wheels          []UVArtifact                  `toml:"wheels"`
 }
 
 // UVSource is an inline table with exactly one key identifying the source type.
@@ -56,7 +56,7 @@ func (s UVSource) IsWorkspacePackage() bool {
 type UVArtifact struct {
 	URL        string `toml:"url"`
 	Path       string `toml:"path"`
-	Hash       string `toml:"hash"`        // "sha256:<hex>"; absent for git
+	Hash       string `toml:"hash"` // "sha256:<hex>"; absent for git
 	Size       int64  `toml:"size"`
 	UploadTime string `toml:"upload-time"` // ISO 8601; may be absent (revision < 3)
 }
@@ -175,9 +175,10 @@ func isVersionDynamic(dynamic []string) bool {
 //     populate it — cheap to check, correct if present.
 //  2. UVConfig.InstalledPackages (populated from `uv pip list` for sync/install/add/remove),
 //     which includes the project's own resolved version once it's installed into the venv.
-//  3. dist/*.whl or dist/*.tar.gz filenames, which encode the resolved version and are
-//     guaranteed to exist by the time build-info collection runs for build/publish (both
-//     only reach this point after `uv build`/`uv publish` already succeeded).
+//  3. dist/*.whl or dist/*.tar.gz archives — build/publish only reach this point after
+//     `uv build`/`uv publish` already succeeded, and each archive's own embedded package
+//     metadata (wheel: *.dist-info/METADATA; sdist: top-level PKG-INFO) records the version
+//     the backend resolved for it — see resolveVersionFromDist.
 //
 // Returns "" if none of these have anything to offer.
 func (uf *UVFlexPack) resolveDynamicVersion() string {
@@ -187,8 +188,16 @@ func (uf *UVFlexPack) resolveDynamicVersion() string {
 		}
 	}
 	if uf.config.InstalledPackages != nil {
-		if version, ok := uf.config.InstalledPackages[normalizeName(uf.projectName)]; ok && version != "" {
-			return version
+		// Compare via normalizeName on both sides rather than indexing by a normalized key
+		// directly: callers (e.g. jfrog-cli-artifactory's uvInstalledPackages) build this map
+		// with their own lowercase/underscore-only normalization, which doesn't collapse dots
+		// or repeated separators the way full PEP 503 normalization does — a project name
+		// containing "." would silently never match a plain map lookup.
+		want := normalizeName(uf.projectName)
+		for pkgName, pkgVersion := range uf.config.InstalledPackages {
+			if pkgVersion != "" && normalizeName(pkgName) == want {
+				return pkgVersion
+			}
 		}
 	}
 	return uf.resolveVersionFromDist()
@@ -290,8 +299,12 @@ func readSdistMetadata(path string) (name, version string) {
 		if err != nil {
 			return "", ""
 		}
-		// PKG-INFO sits directly under the single top-level "{name}-{version}/" directory.
-		if strings.HasSuffix(hdr.Name, "/PKG-INFO") || hdr.Name == "PKG-INFO" {
+		// The authoritative PKG-INFO sits directly under the single top-level
+		// "{name}-{version}/" directory — i.e. exactly one path separator. A deeper match
+		// (e.g. "{name}-{version}/{name}.egg-info/PKG-INFO", which some sdists accidentally
+		// bundle) belongs to a nested, possibly stale build artifact and must be skipped, even
+		// if tar ordering happens to list it before the real top-level one.
+		if hdr.Name == "PKG-INFO" || (strings.Count(hdr.Name, "/") == 1 && strings.HasSuffix(hdr.Name, "/PKG-INFO")) {
 			return parsePackageMetadata(tr)
 		}
 	}

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -1,7 +1,12 @@
 package flexpack
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -189,55 +194,44 @@ func (uf *UVFlexPack) resolveDynamicVersion() string {
 	return uf.resolveVersionFromDist()
 }
 
-// distNameRe matches runs of the characters PEP 427/625 filename escaping collapses to "_".
-var distNameRe = regexp.MustCompile(`[-_.]+`)
-
-// escapeDistName mirrors the distribution-name escaping wheel/sdist filenames use
-// (packaging.utils.disk_filename-style): lowercase, with runs of -_. collapsed to a single "_".
-func escapeDistName(name string) string {
-	return distNameRe.ReplaceAllString(strings.ToLower(name), "_")
-}
-
-// resolveVersionFromDist scans WorkingDirectory/dist for wheel/sdist filenames belonging to
-// this project and extracts the resolved version. Since the project name is already known,
-// the escaped-name prefix unambiguously bounds where the version substring starts, avoiding
-// the general "which hyphen is the name/version boundary" ambiguity of parsing wheel/sdist
-// filenames blind.
+// resolveVersionFromDist scans WorkingDirectory/dist for wheel/sdist archives belonging to
+// this project and returns the resolved version. `uv version` refuses outright to report a
+// dynamic version under any circumstance (verified empirically: it errors even right after a
+// successful build or sync), so there's no CLI command to ask — but the build backend already
+// wrote the real, resolved version into the archive's own package metadata (wheel: a
+// `*.dist-info/METADATA` entry; sdist: a top-level `PKG-INFO` file), the same metadata that
+// would be published to the index. Reading that directly is strictly more reliable than
+// parsing it out of the filename: no PEP 427/625 name-escaping to get right, and the archive's
+// declared Name is checked against the project name instead of assumed from a prefix match.
 //
-// A single `uv build` produces both a wheel and an sdist for the same version, but uv does
-// not clean dist/ between builds — it can accumulate artifacts from earlier versions too.
-// When matching filenames disagree on version, the most recently modified one wins, since
-// that's the artifact the build/publish invocation currently in progress just produced.
+// A single `uv build` produces both a wheel and an sdist for the same version, but uv does not
+// clean dist/ between builds — it can accumulate archives from earlier versions too. When
+// matching archives disagree on version, the most recently modified one wins, since that's the
+// artifact the build/publish invocation currently in progress just produced.
 func (uf *UVFlexPack) resolveVersionFromDist() string {
 	entries, err := os.ReadDir(filepath.Join(uf.config.WorkingDirectory, "dist"))
 	if err != nil {
 		return ""
 	}
-	prefix := escapeDistName(uf.projectName) + "-"
+	wantName := normalizeName(uf.projectName)
 	var bestVersion string
 	var bestModTime time.Time
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
+		path := filepath.Join(uf.config.WorkingDirectory, "dist", entry.Name())
 		lower := strings.ToLower(entry.Name())
-		var stripped string
+		var name, version string
 		switch {
 		case strings.HasSuffix(lower, ".whl"):
-			stripped = strings.TrimSuffix(lower, ".whl")
+			name, version = readWheelMetadata(path)
 		case strings.HasSuffix(lower, ".tar.gz"):
-			stripped = strings.TrimSuffix(lower, ".tar.gz")
+			name, version = readSdistMetadata(path)
 		default:
 			continue
 		}
-		if !strings.HasPrefix(stripped, prefix) {
-			continue
-		}
-		// Wheel filenames continue with -{build tag}?-{python tag}-{abi tag}-{platform tag};
-		// sdist filenames end right after the version. Either way the version is the first
-		// "-"-delimited segment after the name prefix (PEP 440 versions never contain "-").
-		version := strings.SplitN(stripped[len(prefix):], "-", 2)[0]
-		if version == "" {
+		if version == "" || normalizeName(name) != wantName {
 			continue
 		}
 		info, err := entry.Info()
@@ -250,6 +244,78 @@ func (uf *UVFlexPack) resolveVersionFromDist() string {
 		}
 	}
 	return bestVersion
+}
+
+// readWheelMetadata extracts Name/Version from a wheel's `*.dist-info/METADATA` entry.
+// Returns ("", "") if the file can't be read as a wheel or has no readable metadata.
+func readWheelMetadata(path string) (name, version string) {
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = r.Close() }()
+	for _, f := range r.File {
+		if !strings.HasSuffix(f.Name, ".dist-info/METADATA") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", ""
+		}
+		defer func() { _ = rc.Close() }()
+		return parsePackageMetadata(rc)
+	}
+	return "", ""
+}
+
+// readSdistMetadata extracts Name/Version from an sdist's top-level `PKG-INFO` file.
+// Returns ("", "") if the file can't be read as a gzipped tarball or has no PKG-INFO.
+func readSdistMetadata(path string) (name, version string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return "", ""
+		}
+		if err != nil {
+			return "", ""
+		}
+		// PKG-INFO sits directly under the single top-level "{name}-{version}/" directory.
+		if strings.HasSuffix(hdr.Name, "/PKG-INFO") || hdr.Name == "PKG-INFO" {
+			return parsePackageMetadata(tr)
+		}
+	}
+}
+
+// parsePackageMetadata reads Name/Version from a PEP 566 core-metadata document (email-header
+// style: "Key: value" lines followed by a blank line, then an optional free-text description).
+// Header parsing stops at the first blank line so header-like text inside the description
+// (e.g. a changelog entry starting with "Version:") is never mistaken for a real field.
+func parsePackageMetadata(r io.Reader) (name, version string) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		switch {
+		case name == "" && strings.HasPrefix(line, "Name:"):
+			name = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+		case version == "" && strings.HasPrefix(line, "Version:"):
+			version = strings.TrimSpace(strings.TrimPrefix(line, "Version:"))
+		}
+	}
+	return name, version
 }
 
 // loadUvLock reads and parses the lock file. Uses LockFilePath if set (for PEP 723

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -66,8 +66,9 @@ type UVDependencyEdge struct {
 // UVPyProjectToml reads only [project] (PEP 621) — UV format, not Poetry
 type UVPyProjectToml struct {
 	Project struct {
-		Name    string `toml:"name"`
-		Version string `toml:"version"`
+		Name    string   `toml:"name"`
+		Version string   `toml:"version"`
+		Dynamic []string `toml:"dynamic"`
 	} `toml:"project"`
 }
 
@@ -78,6 +79,7 @@ type UVFlexPack struct {
 	pyprojectData     *UVPyProjectToml
 	projectName       string
 	projectVersion    string
+	versionIsDynamic  bool // true when pyproject.toml declares `dynamic = ["version"]`
 	parsed            bool
 	dependencies      []DependencyInfo
 	depGraph          map[string][]string   // dep ID ("name:version") -> []dep IDs
@@ -97,6 +99,13 @@ func NewUVFlexPack(config UVConfig) (*UVFlexPack, error) {
 	}
 	if err := uf.loadUvLock(); err != nil {
 		log.Debug("Failed to load uv.lock, dependency collection will be empty: " + err.Error())
+	}
+	if uf.projectVersion == "" && uf.versionIsDynamic {
+		if resolved := uf.resolveDynamicVersion(); resolved != "" {
+			uf.projectVersion = resolved
+		} else {
+			return nil, fmt.Errorf("failed to load pyproject.toml: project declares dynamic = [\"version\"] but the resolved version could not be found in uv.lock (checked the workspace root package); make sure the project is locked via `uv lock`")
+		}
 	}
 	return uf, nil
 }
@@ -122,13 +131,42 @@ func (uf *UVFlexPack) loadPyProjectToml() error {
 	}
 	uf.projectName = uf.pyprojectData.Project.Name
 	uf.projectVersion = uf.pyprojectData.Project.Version
+	uf.versionIsDynamic = isVersionDynamic(uf.pyprojectData.Project.Dynamic)
 	if uf.projectName == "" {
 		return fmt.Errorf("project name not found in pyproject.toml (checked [project.name])")
 	}
-	if uf.projectVersion == "" {
+	// A dynamic version (PEP 621 `dynamic = ["version"]`, e.g. via hatch-vcs) is resolved
+	// later from uv.lock once it's loaded — see resolveDynamicVersion.
+	if uf.projectVersion == "" && !uf.versionIsDynamic {
 		return fmt.Errorf("project version not found in pyproject.toml (checked [project.version])")
 	}
 	return nil
+}
+
+// isVersionDynamic reports whether "version" appears in a PEP 621 [project.dynamic] list.
+func isVersionDynamic(dynamic []string) bool {
+	for _, field := range dynamic {
+		if field == "version" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveDynamicVersion looks up the version uv resolved for the workspace root package
+// (source.virtual/editable/directory == ".") in the already-parsed uv.lock. uv resolves
+// dynamic versions (e.g. via hatch-vcs) at lock time, so the lock file's root entry carries
+// the real version even though pyproject.toml itself only declares `dynamic = ["version"]`.
+// Returns "" if uv.lock wasn't loaded or has no root package entry.
+func (uf *UVFlexPack) resolveDynamicVersion() string {
+	if uf.lockFileData == nil {
+		return ""
+	}
+	rootPkg := findRootPackage(uf.lockFileData.Packages)
+	if rootPkg == nil {
+		return ""
+	}
+	return rootPkg.Version
 }
 
 // loadUvLock reads and parses the lock file. Uses LockFilePath if set (for PEP 723

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jfrog/build-info-go/entities"
@@ -104,7 +105,12 @@ func NewUVFlexPack(config UVConfig) (*UVFlexPack, error) {
 		if resolved := uf.resolveDynamicVersion(); resolved != "" {
 			uf.projectVersion = resolved
 		} else {
-			return nil, fmt.Errorf("failed to load pyproject.toml: project declares dynamic = [\"version\"] but the resolved version could not be found (checked uv.lock's workspace root package, installed packages, and dist/ artifacts); build or install the project first so the backend (e.g. hatch-vcs) can resolve it")
+			// Same tolerance as the PEP 723 inline-script case above: an empty version
+			// still yields a usable "name:" module ID, and failing outright here would
+			// throw away dependency/artifact collection too, not just the version.
+			log.Warn("UV: project declares dynamic = [\"version\"] but the resolved version could not be found " +
+				"(checked uv.lock's workspace root package, installed packages, and dist/ artifacts); " +
+				"build info will use an empty version in the module ID")
 		}
 	}
 	return uf, nil
@@ -192,17 +198,24 @@ func escapeDistName(name string) string {
 	return distNameRe.ReplaceAllString(strings.ToLower(name), "_")
 }
 
-// resolveVersionFromDist scans WorkingDirectory/dist for a wheel or sdist filename
-// belonging to this project and extracts its version. Since the project name is already
-// known, the escaped-name prefix unambiguously bounds where the version substring starts,
-// avoiding the general "which hyphen is the name/version boundary" ambiguity of parsing
-// wheel/sdist filenames blind.
+// resolveVersionFromDist scans WorkingDirectory/dist for wheel/sdist filenames belonging to
+// this project and extracts the resolved version. Since the project name is already known,
+// the escaped-name prefix unambiguously bounds where the version substring starts, avoiding
+// the general "which hyphen is the name/version boundary" ambiguity of parsing wheel/sdist
+// filenames blind.
+//
+// A single `uv build` produces both a wheel and an sdist for the same version, but uv does
+// not clean dist/ between builds — it can accumulate artifacts from earlier versions too.
+// When matching filenames disagree on version, the most recently modified one wins, since
+// that's the artifact the build/publish invocation currently in progress just produced.
 func (uf *UVFlexPack) resolveVersionFromDist() string {
 	entries, err := os.ReadDir(filepath.Join(uf.config.WorkingDirectory, "dist"))
 	if err != nil {
 		return ""
 	}
 	prefix := escapeDistName(uf.projectName) + "-"
+	var bestVersion string
+	var bestModTime time.Time
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -223,11 +236,20 @@ func (uf *UVFlexPack) resolveVersionFromDist() string {
 		// Wheel filenames continue with -{build tag}?-{python tag}-{abi tag}-{platform tag};
 		// sdist filenames end right after the version. Either way the version is the first
 		// "-"-delimited segment after the name prefix (PEP 440 versions never contain "-").
-		if version := strings.SplitN(stripped[len(prefix):], "-", 2)[0]; version != "" {
-			return version
+		version := strings.SplitN(stripped[len(prefix):], "-", 2)[0]
+		if version == "" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if bestVersion == "" || info.ModTime().After(bestModTime) {
+			bestVersion = version
+			bestModTime = info.ModTime()
 		}
 	}
-	return ""
+	return bestVersion
 }
 
 // loadUvLock reads and parses the lock file. Uses LockFilePath if set (for PEP 723

--- a/flexpack/uv_flexpack.go
+++ b/flexpack/uv_flexpack.go
@@ -104,7 +104,7 @@ func NewUVFlexPack(config UVConfig) (*UVFlexPack, error) {
 		if resolved := uf.resolveDynamicVersion(); resolved != "" {
 			uf.projectVersion = resolved
 		} else {
-			return nil, fmt.Errorf("failed to load pyproject.toml: project declares dynamic = [\"version\"] but the resolved version could not be found in uv.lock (checked the workspace root package); make sure the project is locked via `uv lock`")
+			return nil, fmt.Errorf("failed to load pyproject.toml: project declares dynamic = [\"version\"] but the resolved version could not be found (checked uv.lock's workspace root package, installed packages, and dist/ artifacts); build or install the project first so the backend (e.g. hatch-vcs) can resolve it")
 		}
 	}
 	return uf, nil
@@ -153,20 +153,81 @@ func isVersionDynamic(dynamic []string) bool {
 	return false
 }
 
-// resolveDynamicVersion looks up the version uv resolved for the workspace root package
-// (source.virtual/editable/directory == ".") in the already-parsed uv.lock. uv resolves
-// dynamic versions (e.g. via hatch-vcs) at lock time, so the lock file's root entry carries
-// the real version even though pyproject.toml itself only declares `dynamic = ["version"]`.
-// Returns "" if uv.lock wasn't loaded or has no root package entry.
+// resolveDynamicVersion finds the backend-resolved version for a project whose
+// pyproject.toml only declares `dynamic = ["version"]` (e.g. via hatch-vcs). uv.lock's
+// workspace root package entry ([[package]] with source.virtual/editable/directory == ".")
+// does NOT carry a version field in practice — verified empirically against real `uv lock`
+// output, which omits it entirely for the root/editable entry regardless of a static or
+// dynamic pyproject.toml version. The real resolved version instead shows up in whichever
+// of these the current uv invocation already produced, checked in order:
+//  1. uv.lock's root package version, in case a future uv release (or another tool) does
+//     populate it — cheap to check, correct if present.
+//  2. UVConfig.InstalledPackages (populated from `uv pip list` for sync/install/add/remove),
+//     which includes the project's own resolved version once it's installed into the venv.
+//  3. dist/*.whl or dist/*.tar.gz filenames, which encode the resolved version and are
+//     guaranteed to exist by the time build-info collection runs for build/publish (both
+//     only reach this point after `uv build`/`uv publish` already succeeded).
+//
+// Returns "" if none of these have anything to offer.
 func (uf *UVFlexPack) resolveDynamicVersion() string {
-	if uf.lockFileData == nil {
+	if uf.lockFileData != nil {
+		if rootPkg := findRootPackage(uf.lockFileData.Packages); rootPkg != nil && rootPkg.Version != "" {
+			return rootPkg.Version
+		}
+	}
+	if uf.config.InstalledPackages != nil {
+		if version, ok := uf.config.InstalledPackages[normalizeName(uf.projectName)]; ok && version != "" {
+			return version
+		}
+	}
+	return uf.resolveVersionFromDist()
+}
+
+// distNameRe matches runs of the characters PEP 427/625 filename escaping collapses to "_".
+var distNameRe = regexp.MustCompile(`[-_.]+`)
+
+// escapeDistName mirrors the distribution-name escaping wheel/sdist filenames use
+// (packaging.utils.disk_filename-style): lowercase, with runs of -_. collapsed to a single "_".
+func escapeDistName(name string) string {
+	return distNameRe.ReplaceAllString(strings.ToLower(name), "_")
+}
+
+// resolveVersionFromDist scans WorkingDirectory/dist for a wheel or sdist filename
+// belonging to this project and extracts its version. Since the project name is already
+// known, the escaped-name prefix unambiguously bounds where the version substring starts,
+// avoiding the general "which hyphen is the name/version boundary" ambiguity of parsing
+// wheel/sdist filenames blind.
+func (uf *UVFlexPack) resolveVersionFromDist() string {
+	entries, err := os.ReadDir(filepath.Join(uf.config.WorkingDirectory, "dist"))
+	if err != nil {
 		return ""
 	}
-	rootPkg := findRootPackage(uf.lockFileData.Packages)
-	if rootPkg == nil {
-		return ""
+	prefix := escapeDistName(uf.projectName) + "-"
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(entry.Name())
+		var stripped string
+		switch {
+		case strings.HasSuffix(lower, ".whl"):
+			stripped = strings.TrimSuffix(lower, ".whl")
+		case strings.HasSuffix(lower, ".tar.gz"):
+			stripped = strings.TrimSuffix(lower, ".tar.gz")
+		default:
+			continue
+		}
+		if !strings.HasPrefix(stripped, prefix) {
+			continue
+		}
+		// Wheel filenames continue with -{build tag}?-{python tag}-{abi tag}-{platform tag};
+		// sdist filenames end right after the version. Either way the version is the first
+		// "-"-delimited segment after the name prefix (PEP 440 versions never contain "-").
+		if version := strings.SplitN(stripped[len(prefix):], "-", 2)[0]; version != "" {
+			return version
+		}
 	}
-	return rootPkg.Version
+	return ""
 }
 
 // loadUvLock reads and parses the lock file. Uses LockFilePath if set (for PEP 723


### PR DESCRIPTION
## Summary

`jf uv publish`/build-info collection failed for projects that use PEP 621's `dynamic = ["version"]` (e.g. via hatch-vcs), since pyproject.toml has no static [project.version] in that case. The UV FlexPack collector required that field unconditionally and errored out immediately, never getting a chance to look anywhere else for the real version.

Fixes jfrog/jfrog-cli#3624.

## Change

- UVPyProjectToml now also parses project.dynamic.
- loadPyProjectToml no longer errors on a missing version when it's declared dynamic — resolution is deferred.
- NewUVFlexPack resolves the version, checked in order:
  1. uv.lock's workspace root package entry, if present (kept as a cheap first check; real uv.lock output never populates this in practice, verified empirically, but harmless to check).
  2. UVConfig.InstalledPackages (already populated from `uv pip list` for sync/install/add/remove) — includes the project's own resolved version once it's installed into the venv.
  3. dist/*.whl and dist/*.tar.gz archives in the working directory (build/publish) — both only reach build-info collection after the build itself already succeeded. `uv version` refuses outright to report a dynamic version under any circumstance (verified: it errors even right after a successful build or install), so there's no CLI command to ask directly — but the build backend already writes the resolved version into the archive's own package metadata (wheel: `*.dist-info/METADATA`; sdist: top-level `PKG-INFO`), the same record that would be published to the index. Reading that directly avoids guessing from the filename: no PEP 427/625 name-escaping to get right, and the archive's declared Name is checked against the project name rather than assumed from a prefix match. Since uv doesn't clean dist/ between builds, multiple versions' archives can coexist; the most recently modified matching one wins.
- If none of the above resolve anything, this no longer fails collector construction (which would throw away dependency/artifact collection too). It logs a warning and falls back to an empty version, producing a "name:" module ID — the same tolerance already in place for PEP 723 inline scripts (see the existing comment in loadPyProjectToml).
- Static-version projects are unaffected — this only changes behavior when `dynamic` includes `"version"`.

## Test plan

- Unit tests in flexpack/tests/unit/uv_flexpack_test.go build real (minimal but valid) wheel/sdist archives via archive/zip and archive/tar+compress/gzip to cover: all three resolution sources, the dist/ freshness tie-break (stale + fresh archives present, newest wins), a corrupt/unreadable archive being skipped rather than breaking resolution, a valid archive for an unrelated package correctly not matching by name, and the empty-version fallback path (no source available at all, lock file with no root entry, dist/ with only an unrelated package).
- `go build ./...` and `go vet ./...` clean.
- `go test ./flexpack/...` and `go test -race ./flexpack/...`: all UV tests pass, including every pre-existing one (no regression).
- End-to-end verification against a real hatch-vcs project (git repo, tagged, pyproject.toml with `dynamic = ["version"]` + `[tool.hatch.version] source = "vcs"`), built with a real jf binary wired to this branch via a local go.mod replace, each time in a freshly created isolated worktree so as not to disturb other in-progress work in the shared checkout:
  - `jf uv build` / `jf uv sync`: no warning, build info correctly records the resolved version as the module ID.
  - Reverted to the original unfixed build-info-go and reran the identical `jf uv build`: reproduced the exact reported warning verbatim, confirming the fix addresses the real bug.
  - Built twice without cleaning dist/ (a stale wheel/sdist pair left next to a freshly built one — 4 files spanning 2 versions): confirmed the module ID picks up the fresh version, not the stale one, by reading the actual embedded METADATA/PKG-INFO of each candidate.
  - Ran `jf uv lock` on a project with no dist/, no venv, and no resolvable lock-file version: confirmed the warning fires and build info is still collected (module ID `name:`) instead of being dropped entirely.
  - Confirmed via `uv version`/`uv version --short --output-format json` (before build, after build, after sync) that uv itself has no command that reports a dynamic version under any circumstance, ruling out a simpler native-CLI approach.
- Ran the full repo test suite (`go test ./...`) on both this branch and unmodified main — the only failures on either are pre-existing, environment-dependent ones in build/utils (npm), build/utils/dotnet/solution (nuget), and flexpack/gradle (local Maven/Ivy), unrelated to this change and identical on both branches.
