### PR TITLE
RTECO-1646 - Add tests for BuildInfo properties and enhance MavenFlexPack functionality

### DIFF
--- a/entities/buildinfo.go
+++ b/entities/buildinfo.go
@@ -31,6 +31,13 @@ const (
 	BuildInfoEnvPrefix   = "buildInfo.env."
 	RequestedByMaxLength = 15
 
+	// MavenBuildModeProperty records which Maven integration produced the build info; it is stamped
+	// with MavenBuildModeNative by the native (FlexPack) collector and MavenBuildModeLegacy by the
+	// legacy build-info-extractor path, giving both a single comparable marker in the published JSON.
+	MavenBuildModeProperty = BuildInfoEnvPrefix + "JFROG_MAVEN_MODE"
+	MavenBuildModeNative   = "native"
+	MavenBuildModeLegacy   = "legacy"
+
 	// Build type
 	Build ModuleType = "build"
 
@@ -106,6 +113,20 @@ func (targetBuildInfo *BuildInfo) Append(buildInfo *BuildInfo) {
 		}
 		if !exists {
 			targetBuildInfo.Modules = append(targetBuildInfo.Modules, newModule)
+		}
+	}
+	// Carry over properties set by the appended build info (e.g. a build-mode marker recorded by the
+	// collector). Existing values on the target win, so this only fills gaps and never clobbers env
+	// already assembled from partials.
+	if len(buildInfo.Properties) == 0 {
+		return
+	}
+	if targetBuildInfo.Properties == nil {
+		targetBuildInfo.Properties = make(Env)
+	}
+	for key, value := range buildInfo.Properties {
+		if _, exists := targetBuildInfo.Properties[key]; !exists {
+			targetBuildInfo.Properties[key] = value
 		}
 	}
 }

--- a/entities/buildinfo_test.go
+++ b/entities/buildinfo_test.go
@@ -255,6 +255,29 @@ func TestAppendProperties(t *testing.T) {
 		target.Append(&source)
 		assert.Equal(t, MavenBuildModeNative, target.Properties[MavenBuildModeProperty])
 	})
+
+	t.Run("empty string in target is treated as existing", func(t *testing.T) {
+		target := BuildInfo{Properties: Env{"x": ""}}
+		source := BuildInfo{Properties: Env{"x": "v"}}
+		target.Append(&source)
+		assert.Equal(t, "", target.Properties["x"])
+	})
+
+	t.Run("chained appends first writer wins", func(t *testing.T) {
+		target := BuildInfo{}
+		b := BuildInfo{Properties: Env{"key": "b"}}
+		c := BuildInfo{Properties: Env{"key": "c"}}
+		target.Append(&b)
+		target.Append(&c)
+		assert.Equal(t, "b", target.Properties["key"])
+	})
+
+	t.Run("non-nil empty source properties is no-op", func(t *testing.T) {
+		target := BuildInfo{Properties: Env{"keep": "v"}}
+		source := BuildInfo{Properties: Env{}}
+		target.Append(&source)
+		assert.Equal(t, Env{"keep": "v"}, target.Properties)
+	})
 }
 
 func TestToCycloneDxBOM(t *testing.T) {

--- a/entities/buildinfo_test.go
+++ b/entities/buildinfo_test.go
@@ -241,6 +241,22 @@ func TestAppend(t *testing.T) {
 	assert.True(t, results)
 }
 
+func TestAppendProperties(t *testing.T) {
+	t.Run("fills gaps without clobbering", func(t *testing.T) {
+		target := BuildInfo{Properties: Env{"keep": "target", "shared": "target-wins"}}
+		source := BuildInfo{Properties: Env{"shared": "source-loses", "added": "source"}}
+		target.Append(&source)
+		assert.Equal(t, Env{"keep": "target", "shared": "target-wins", "added": "source"}, target.Properties)
+	})
+
+	t.Run("initializes nil target properties", func(t *testing.T) {
+		target := BuildInfo{}
+		source := BuildInfo{Properties: Env{MavenBuildModeProperty: MavenBuildModeNative}}
+		target.Append(&source)
+		assert.Equal(t, MavenBuildModeNative, target.Properties[MavenBuildModeProperty])
+	})
+}
+
 func TestToCycloneDxBOM(t *testing.T) {
 	dependencyA := Dependency{Id: "dependency-a", Checksum: Checksum{Sha1: "dependency-a-sha"}, RequestedBy: [][]string{{"dependency-c"}}}
 	dependencyB := Dependency{Id: "dependency-b", Checksum: Checksum{Sha1: "dependency-b-sha"}, RequestedBy: [][]string{{"dependency-b"}, {"dependency-c"}}}

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -1159,11 +1159,12 @@ func (mf *MavenFlexPack) deployURLFromEffectiveSettings(isSnapshot bool) (string
 	}
 	result := ""
 	for _, profile := range settings.Profiles {
-		if isSnapshot && profile.AltSnapshotDeploymentRepository != "" {
+		switch {
+		case isSnapshot && profile.AltSnapshotDeploymentRepository != "":
 			result = repoURLFromAltValue(profile.AltSnapshotDeploymentRepository)
-		} else if !isSnapshot && profile.AltReleaseDeploymentRepository != "" {
+		case !isSnapshot && profile.AltReleaseDeploymentRepository != "":
 			result = repoURLFromAltValue(profile.AltReleaseDeploymentRepository)
-		} else if profile.AltDeploymentRepository != "" {
+		case profile.AltDeploymentRepository != "":
 			result = repoURLFromAltValue(profile.AltDeploymentRepository)
 		}
 	}

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -44,6 +45,17 @@ type MavenFlexPack struct {
 // artifactChecksum holds the checksums of a single file, cached across modules by artifact path.
 type artifactChecksum struct {
 	sha1, sha256, md5 string
+}
+
+// checksumCacheKey returns a normalized path suitable for use as a checksumCache map key.
+// On case-insensitive filesystems (macOS default, Windows) the same file can be reached
+// via different-cased paths, so the key is lowercased on those platforms.
+func checksumCacheKey(path string) string {
+	key := filepath.Clean(path)
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		return strings.ToLower(key)
+	}
+	return key
 }
 
 // ModuleLocation records where a reactor module was built and its packaging, derived from the
@@ -419,11 +431,12 @@ func (mf *MavenFlexPack) calculateChecksumWithFallback(dep DependencyInfo) map[s
 	// Strategy 1: Try to find artifact in Maven local repository. Checksums are cached by path so a
 	// dependency shared across reactor modules is hashed only once.
 	if artifactPath := mf.findMavenArtifact(dep); artifactPath != "" {
-		cached, ok := mf.checksumCache[artifactPath]
+		cacheKey := checksumCacheKey(artifactPath)
+		cached, ok := mf.checksumCache[cacheKey]
 		if !ok {
 			if sha1, sha256, md5, err := mf.calculateFileChecksum(artifactPath); err == nil {
 				cached = artifactChecksum{sha1: sha1, sha256: sha256, md5: md5}
-				mf.checksumCache[artifactPath] = cached
+				mf.checksumCache[cacheKey] = cached
 				ok = true
 			} else {
 				log.Warn(fmt.Sprintf("Failed to calculate checksum for artifact: %s", artifactPath))
@@ -862,9 +875,13 @@ func invertDependencyGraph(graph map[string][]string) map[string][]string {
 // than one parent) yields one path per distinct route. A cycle, which a resolved Maven tree should
 // never contain, is broken defensively by terminating the offending path at the repeated node.
 func buildRequestedByPaths(depID string, parents map[string][]string) [][]string {
+	const maxPaths = 15
 	var paths [][]string
 	var walk func(node string, acc []string, onPath map[string]bool)
 	walk = func(node string, acc []string, onPath map[string]bool) {
+		if len(paths) >= maxPaths {
+			return
+		}
 		directParents := parents[node]
 		if len(directParents) == 0 {
 			// Reached a root: the accumulated ancestors form one complete path.
@@ -874,6 +891,9 @@ func buildRequestedByPaths(depID string, parents map[string][]string) [][]string
 			return
 		}
 		for _, parent := range directParents {
+			if len(paths) >= maxPaths {
+				return
+			}
 			if onPath[parent] {
 				// Cycle guard: close the path at the repeated node instead of recursing forever.
 				paths = append(paths, append(append([]string(nil), acc...), parent))
@@ -885,6 +905,9 @@ func buildRequestedByPaths(depID string, parents map[string][]string) [][]string
 		}
 	}
 	walk(depID, nil, map[string]bool{depID: true})
+	if len(paths) == maxPaths {
+		log.Debug(fmt.Sprintf("dependency %s RequestedBy paths capped at %d", depID, maxPaths))
+	}
 	return paths
 }
 
@@ -1120,7 +1143,7 @@ func distributionURL(project effectivePomProject, fallbackSnapshot bool) string 
 	if dm.Repository.URL != "" {
 		return dm.Repository.URL
 	}
-	return dm.SnapshotRepository.URL
+	return ""
 }
 
 func (mf *MavenFlexPack) deployURLFromEffectiveSettings(isSnapshot bool) (string, error) {
@@ -1134,18 +1157,17 @@ func (mf *MavenFlexPack) deployURLFromEffectiveSettings(isSnapshot bool) (string
 	if err := xml.Unmarshal([]byte(content), &settings); err != nil {
 		return "", fmt.Errorf("failed to parse effective-settings: %w", err)
 	}
+	result := ""
 	for _, profile := range settings.Profiles {
 		if isSnapshot && profile.AltSnapshotDeploymentRepository != "" {
-			return repoURLFromAltValue(profile.AltSnapshotDeploymentRepository), nil
-		}
-		if !isSnapshot && profile.AltReleaseDeploymentRepository != "" {
-			return repoURLFromAltValue(profile.AltReleaseDeploymentRepository), nil
-		}
-		if profile.AltDeploymentRepository != "" {
-			return repoURLFromAltValue(profile.AltDeploymentRepository), nil
+			result = repoURLFromAltValue(profile.AltSnapshotDeploymentRepository)
+		} else if !isSnapshot && profile.AltReleaseDeploymentRepository != "" {
+			result = repoURLFromAltValue(profile.AltReleaseDeploymentRepository)
+		} else if profile.AltDeploymentRepository != "" {
+			result = repoURLFromAltValue(profile.AltDeploymentRepository)
 		}
 	}
-	return "", nil
+	return result, nil
 }
 
 // runMavenHelpGoal runs a maven-help-plugin goal that writes its output to a file (-Doutput), forwarding

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -73,10 +73,10 @@ type MavenConfig struct {
 const mavenDepsFileName = "maven-deps.json"
 
 // mavenDependencyPluginTreeGoal is the fully-qualified plugin coordinate used to invoke the
-// dependency:tree goal. The plugin version is pinned so `-DoutputType=json` is honored — older
-// versions (< 3.0.0) that some Maven installs still bind by default silently ignore the option and
-// write plain-text output, which the JSON parser then rejects.
-const mavenDependencyPluginTreeGoal = "org.apache.maven.plugins:maven-dependency-plugin:3.6.1:tree"
+// dependency:tree goal. The version is pinned because `-DoutputType=json` was only added in
+// maven-dependency-plugin 3.7.0; older versions silently write plain-text output which the JSON
+// parser then rejects. 3.8.1 (current latest) is used to also pick up bug fixes.
+const mavenDependencyPluginTreeGoal = "org.apache.maven.plugins:maven-dependency-plugin:3.8.1:tree"
 
 // MavenPOM represents the structure of pom.xml file
 type MavenPOM struct {

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -72,6 +72,12 @@ type MavenConfig struct {
 // module (root aggregator included).
 const mavenDepsFileName = "maven-deps.json"
 
+// mavenDependencyPluginTreeGoal is the fully-qualified plugin coordinate used to invoke the
+// dependency:tree goal. The plugin version is pinned so `-DoutputType=json` is honored — older
+// versions (< 3.0.0) that some Maven installs still bind by default silently ignore the option and
+// write plain-text output, which the JSON parser then rejects.
+const mavenDependencyPluginTreeGoal = "org.apache.maven.plugins:maven-dependency-plugin:3.6.1:tree"
+
 // MavenPOM represents the structure of pom.xml file
 type MavenPOM struct {
 	XMLName      xml.Name `xml:"project"`
@@ -243,7 +249,7 @@ func (mf *MavenFlexPack) parseWithMavenDependencyTree() error {
 		}
 	}()
 
-	args := []string{"dependency:tree", "-DoutputType=json", "-DoutputFile=maven-deps.json"}
+	args := []string{mavenDependencyPluginTreeGoal, "-DoutputType=json", "-DoutputFile=maven-deps.json"}
 	if mf.config.SkipTests {
 		args = append(args, "-DskipTests")
 	}
@@ -638,9 +644,10 @@ func (mf *MavenFlexPack) collectModules() ([]entities.Module, error) {
 // generateReactorDependencyTrees runs `mvn dependency:tree` at the project root and returns the path
 // of every maven-deps.json produced (one per reactor module). Maven overwrites the file for every
 // module that participates, and collectModules removes them all when done, so no separate stale-file
-// sweep is needed.
+// sweep is needed. The plugin version is pinned so `-DoutputType=json` is honored — older 2.x
+// versions silently write plain-text output which JSON parsing then rejects.
 func (mf *MavenFlexPack) generateReactorDependencyTrees() ([]string, error) {
-	args := []string{"dependency:tree", "-DoutputType=json", "-DoutputFile=" + mavenDepsFileName}
+	args := []string{mavenDependencyPluginTreeGoal, "-DoutputType=json", "-DoutputFile=" + mavenDepsFileName}
 	if mf.config.SkipTests {
 		args = append(args, "-DskipTests")
 	}

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,6 +28,30 @@ type MavenFlexPack struct {
 	artifactId      string
 	pomData         *MavenPOM
 	requestedByMap  map[string][]string
+	// moduleLocations maps each collected module's id ("groupId:artifactId:version") to where Maven
+	// built it, captured from the dependency-tree output. It is the authoritative module list (it
+	// reflects what Maven actually ran, including profile-activated modules) and lets callers attach
+	// deployed artifacts without re-parsing the pom tree.
+	moduleLocations map[string]ModuleLocation
+	// checksumCache memoizes file checksums by artifact path, so a dependency shared across several
+	// reactor modules is read and hashed only once instead of once per module.
+	checksumCache map[string]artifactChecksum
+	// localRepo caches the resolved Maven local-repository path (see localRepositoryPath).
+	localRepo         string
+	localRepoResolved bool
+}
+
+// artifactChecksum holds the checksums of a single file, cached across modules by artifact path.
+type artifactChecksum struct {
+	sha1, sha256, md5 string
+}
+
+// ModuleLocation records where a reactor module was built and its packaging, derived from the
+// module's maven-deps.json (the JSON root node carries the resolved coordinates, type, and its file
+// path is the module's base directory).
+type ModuleLocation struct {
+	Dir       string
+	Packaging string
 }
 
 // MavenConfig represents configuration for Maven FlexPack
@@ -35,7 +60,17 @@ type MavenConfig struct {
 	IncludeTestDependencies bool
 	MavenExecutable         string
 	SkipTests               bool
+	// ExtraArgs are appended to the internal `mvn dependency:tree` invocation so dependency
+	// resolution matches the profiles/settings/properties the user built with (e.g. -Pprod,
+	// -s settings.xml, -Drevision=1.2.3).
+	ExtraArgs []string
 }
+
+// mavenDepsFileName is the file each reactor module writes its JSON dependency tree to when
+// `mvn dependency:tree -DoutputFile=<name>` runs. Maven runs the goal once per module and writes
+// this file into every module's own base directory, so a multi-module build produces one file per
+// module (root aggregator included).
+const mavenDepsFileName = "maven-deps.json"
 
 // MavenPOM represents the structure of pom.xml file
 type MavenPOM struct {
@@ -80,6 +115,8 @@ func NewMavenFlexPack(config MavenConfig) (*MavenFlexPack, error) {
 		dependencies:    []DependencyInfo{},
 		dependencyGraph: make(map[string][]string),
 		requestedByMap:  make(map[string][]string),
+		moduleLocations: make(map[string]ModuleLocation),
+		checksumCache:   make(map[string]artifactChecksum),
 	}
 
 	if mf.config.MavenExecutable == "" {
@@ -373,16 +410,26 @@ func (mf *MavenFlexPack) calculateChecksumWithFallback(dep DependencyInfo) map[s
 		"scopes":  mf.validateAndNormalizeScopes(dep.Scopes),
 	}
 
-	// Strategy 1: Try to find artifact in Maven local repository
+	// Strategy 1: Try to find artifact in Maven local repository. Checksums are cached by path so a
+	// dependency shared across reactor modules is hashed only once.
 	if artifactPath := mf.findMavenArtifact(dep); artifactPath != "" {
-		if sha1, sha256, md5, err := mf.calculateFileChecksum(artifactPath); err == nil {
-			checksumMap["sha1"] = sha1
-			checksumMap["sha256"] = sha256
-			checksumMap["md5"] = md5
+		cached, ok := mf.checksumCache[artifactPath]
+		if !ok {
+			if sha1, sha256, md5, err := mf.calculateFileChecksum(artifactPath); err == nil {
+				cached = artifactChecksum{sha1: sha1, sha256: sha256, md5: md5}
+				mf.checksumCache[artifactPath] = cached
+				ok = true
+			} else {
+				log.Warn(fmt.Sprintf("Failed to calculate checksum for artifact: %s", artifactPath))
+			}
+		}
+		if ok {
+			checksumMap["sha1"] = cached.sha1
+			checksumMap["sha256"] = cached.sha256
+			checksumMap["md5"] = cached.md5
 			checksumMap["path"] = artifactPath
 			return checksumMap
 		}
-		log.Warn(fmt.Sprintf("Failed to calculate checksum for artifact: %s", artifactPath))
 	}
 
 	// Strategy 2: Future enhancement - could call Artifactory API to get real checksums
@@ -407,6 +454,40 @@ func (mf *MavenFlexPack) calculateChecksumWithFallback(dep DependencyInfo) map[s
 	return nil
 }
 
+// localRepositoryPath returns the Maven local repository to search for downloaded artifacts. It
+// honors a `-Dmaven.repo.local=<path>` override forwarded from the user's invocation (so checksum
+// lookup works when the build used a custom local repo), falling back to the default ~/.m2/repository.
+func (mf *MavenFlexPack) localRepositoryPath() string {
+	// Resolved once and reused: it is queried for every dependency of every module, but neither
+	// ExtraArgs nor the home directory changes during a collection.
+	if mf.localRepoResolved {
+		return mf.localRepo
+	}
+	mf.localRepo = mf.resolveLocalRepositoryPath()
+	mf.localRepoResolved = true
+	return mf.localRepo
+}
+
+func (mf *MavenFlexPack) resolveLocalRepositoryPath() string {
+	const flag = "-Dmaven.repo.local="
+	// Later occurrences win, matching Maven's last-value-wins behavior for repeated properties.
+	custom := ""
+	for _, arg := range mf.config.ExtraArgs {
+		if v, ok := strings.CutPrefix(arg, flag); ok && v != "" {
+			custom = v
+		}
+	}
+	if custom != "" {
+		return custom
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debug("Failed to get user home directory: " + err.Error())
+		return ""
+	}
+	return filepath.Join(homeDir, ".m2", "repository")
+}
+
 // findMavenArtifact locates a Maven artifact in the local repository
 func (mf *MavenFlexPack) findMavenArtifact(dep DependencyInfo) string {
 	// Parse dependency name to get groupId and artifactId
@@ -418,13 +499,10 @@ func (mf *MavenFlexPack) findMavenArtifact(dep DependencyInfo) string {
 	groupId := parts[0]
 	artifactId := parts[1]
 
-	// Build path to Maven local repository (Windows and Unix compatible)
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Debug("Failed to get user home directory: " + err.Error())
+	localRepo := mf.localRepositoryPath()
+	if localRepo == "" {
 		return ""
 	}
-	localRepo := filepath.Join(homeDir, ".m2", "repository")
 
 	// Convert groupId to path (e.g., com.example -> com/example)
 	groupPath := strings.ReplaceAll(groupId, ".", string(filepath.Separator))
@@ -484,61 +562,20 @@ func (mf *MavenFlexPack) validateAndNormalizeScopes(scopes []string) []string {
 	return normalized
 }
 
-// buildRequestedByMap builds the requested-by relationship map
+// buildRequestedByMap builds the requested-by relationship map by inverting the dependency graph.
 func (mf *MavenFlexPack) buildRequestedByMap() {
-	// Invert the dependency graph to create requested-by relationships
-	for parent, children := range mf.dependencyGraph {
-		for _, child := range children {
-			if mf.requestedByMap[child] == nil {
-				mf.requestedByMap[child] = []string{}
-			}
-			mf.requestedByMap[child] = append(mf.requestedByMap[child], parent)
-		}
-	}
+	mf.requestedByMap = invertDependencyGraph(mf.dependencyGraph)
 }
 
-// CollectBuildInfo collects complete build information for Maven project
+// CollectBuildInfo collects complete build information for a Maven project.
+// For multi-module (reactor) projects it produces one entities.Module per reactor module, each with
+// its own dependencies, instead of collapsing everything into a single module.
 func (mf *MavenFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities.BuildInfo, error) {
-	if len(mf.dependencies) == 0 {
-		mf.parseDependencies()
-	}
-	requestedByMap := mf.CalculateRequestedBy()
-	var dependencies []entities.Dependency
-	for _, dep := range mf.dependencies {
-		// Try to calculate checksum for this specific dependency
-		checksumMap := mf.calculateChecksumWithFallback(dep)
-
-		// Convert checksum map to entities.Checksum struct
-		checksum := entities.Checksum{}
-		if checksumMap != nil {
-			if sha1, ok := checksumMap["sha1"].(string); ok {
-				checksum.Sha1 = sha1
-			}
-			if sha256, ok := checksumMap["sha256"].(string); ok {
-				checksum.Sha256 = sha256
-			}
-			if md5, ok := checksumMap["md5"].(string); ok {
-				checksum.Md5 = md5
-			}
-		}
-		// If checksumMap is nil, checksum will have empty values, which is fine
-
-		entity := entities.Dependency{
-			Id:       dep.ID,
-			Type:     dep.Type,
-			Scopes:   dep.Scopes,
-			Checksum: checksum,
-		}
-
-		// Add requested-by relationships
-		if requesters, exists := requestedByMap[dep.ID]; exists && len(requesters) > 0 {
-			entity.RequestedBy = [][]string{requesters}
-		}
-
-		dependencies = append(dependencies, entity)
+	modules, err := mf.collectModules()
+	if err != nil {
+		return nil, err
 	}
 
-	// Create build info using existing factory method (following Poetry FlexPack pattern)
 	buildInfo := &entities.BuildInfo{
 		Name:    buildName,
 		Number:  buildNumber,
@@ -551,18 +588,297 @@ func (mf *MavenFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entit
 			Name:    "Maven",
 			Version: mf.getMavenVersion(),
 		},
-		Modules: []entities.Module{},
+		Modules: modules,
+		// Mark how this build info was produced. FlexPack is the native collector, so the value is always
+		// "native"; the legacy build-info-extractor path stamps "legacy". Consumers can branch on it and
+		// it makes the two paths distinguishable in the published JSON.
+		Properties: entities.Env{entities.MavenBuildModeProperty: entities.MavenBuildModeNative},
 	}
-
-	// Add Maven module
-	module := entities.Module{
-		Id:           fmt.Sprintf("%s:%s:%s", mf.groupId, mf.artifactId, mf.projectVersion),
-		Type:         "maven",
-		Dependencies: dependencies,
-	}
-	buildInfo.Modules = append(buildInfo.Modules, module)
 
 	return buildInfo, nil
+}
+
+// collectModules produces one entities.Module per reactor module. It runs `mvn dependency:tree` at
+// the project root (Maven executes it for every module, each writing its own maven-deps.json), then
+// builds a module from each generated file. If the tree cannot be generated it falls back to parsing
+// the root pom.xml directly, yielding a single module (pre-reactor behavior).
+func (mf *MavenFlexPack) collectModules() ([]entities.Module, error) {
+	treeFiles, err := mf.generateReactorDependencyTrees()
+	if err != nil {
+		log.Warn("Maven dependency:tree failed, falling back to single-module POM parsing: " + err.Error())
+		return mf.collectSingleModuleFromPOM(), nil
+	}
+	// Clean up generated files once we are done reading them.
+	defer func() {
+		for _, tf := range treeFiles {
+			if removeErr := os.Remove(tf); removeErr != nil && !os.IsNotExist(removeErr) {
+				log.Debug("Failed to remove temporary dependency tree file " + tf + ": " + removeErr.Error())
+			}
+		}
+	}()
+
+	var modules []entities.Module
+	for _, tf := range treeFiles {
+		module, buildErr := mf.buildModuleFromTreeFile(tf)
+		if buildErr != nil {
+			log.Warn(fmt.Sprintf("Skipping dependency tree %s: %s", tf, buildErr))
+			continue
+		}
+		modules = append(modules, module)
+	}
+
+	if len(modules) == 0 {
+		log.Warn("No modules resolved from Maven dependency trees, falling back to single-module POM parsing")
+		return mf.collectSingleModuleFromPOM(), nil
+	}
+	log.Debug(fmt.Sprintf("Collected %d Maven module(s) for build info", len(modules)))
+	return modules, nil
+}
+
+// generateReactorDependencyTrees runs `mvn dependency:tree` at the project root and returns the path
+// of every maven-deps.json produced (one per reactor module). Maven overwrites the file for every
+// module that participates, and collectModules removes them all when done, so no separate stale-file
+// sweep is needed.
+func (mf *MavenFlexPack) generateReactorDependencyTrees() ([]string, error) {
+	args := []string{"dependency:tree", "-DoutputType=json", "-DoutputFile=" + mavenDepsFileName}
+	if mf.config.SkipTests {
+		args = append(args, "-DskipTests")
+	}
+	// Forward the user's resolution flags (profiles/settings/properties) so the dependency tree is
+	// resolved under the same conditions the project was actually built with.
+	args = append(args, mf.config.ExtraArgs...)
+
+	cmd := exec.Command(mf.config.MavenExecutable, args...)
+	cmd.Dir = mf.config.WorkingDirectory
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("mvn dependency:tree failed: %w\nOutput: %s", err, string(output))
+	}
+
+	return mf.findDependencyTreeFiles()
+}
+
+// findDependencyTreeFiles walks the working directory and returns every maven-deps.json file, one per
+// reactor module. WalkDir yields lexical order, keeping module ordering deterministic across runs.
+func (mf *MavenFlexPack) findDependencyTreeFiles() ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(mf.config.WorkingDirectory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// maven-deps.json only ever lives in a module base directory. Skip Maven's build output
+			// ("target", full of .class files after install/deploy) and dot-directories (.git, ...) so
+			// the walk does not stat thousands of irrelevant files on a large reactor.
+			if path != mf.config.WorkingDirectory && (d.Name() == "target" || strings.HasPrefix(d.Name(), ".")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == mavenDepsFileName {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// buildModuleFromTreeFile parses a single module's maven-deps.json into an entities.Module. The JSON
+// root node carries the module's own resolved coordinates; its children are the module dependencies.
+func (mf *MavenFlexPack) buildModuleFromTreeFile(path string) (entities.Module, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return entities.Module{}, fmt.Errorf("failed to read dependency tree: %w", err)
+	}
+
+	var root MavenDependencyJSON
+	if err := json.Unmarshal(content, &root); err != nil {
+		return entities.Module{}, fmt.Errorf("failed to parse dependency tree JSON: %w", err)
+	}
+	if root.GroupID == "" || root.ArtifactID == "" || root.Version == "" {
+		return entities.Module{}, fmt.Errorf("dependency tree is missing module coordinates")
+	}
+
+	moduleId := fmt.Sprintf("%s:%s:%s", root.GroupID, root.ArtifactID, root.Version)
+	// The maven-deps.json lives in the module's base directory, and the JSON root type is the module's
+	// packaging. Record both so callers can attach artifacts without re-discovering modules.
+	mf.moduleLocations[moduleId] = ModuleLocation{Dir: filepath.Dir(path), Packaging: root.Type}
+	depInfos, graph := mf.collectModuleDependencies(moduleId, root)
+	requestedBy := invertDependencyGraph(graph)
+
+	return entities.Module{
+		Id:           moduleId,
+		Type:         entities.Maven,
+		Dependencies: mf.toDependencyEntities(depInfos, requestedBy),
+	}, nil
+}
+
+// GetModuleLocations returns the id -> location map captured during the last CollectBuildInfo call.
+// The map is authoritative: it contains exactly the modules Maven built (profile-activated modules
+// included) and is empty when collection fell back to single-module POM parsing.
+func (mf *MavenFlexPack) GetModuleLocations() map[string]ModuleLocation {
+	return mf.moduleLocations
+}
+
+// collectModuleDependencies flattens a single module's dependency tree. The tree root is the module
+// itself (identified by moduleId), so collection starts from its direct children. Duplicates within
+// the module are collapsed while still recording requested-by (parent -> child) edges.
+func (mf *MavenFlexPack) collectModuleDependencies(moduleId string, root MavenDependencyJSON) ([]DependencyInfo, map[string][]string) {
+	var deps []DependencyInfo
+	graph := make(map[string][]string)
+	seen := make(map[string]bool)
+	for _, child := range root.Children {
+		mf.collectDependencyNode(child, moduleId, seen, &deps, graph)
+	}
+	return deps, graph
+}
+
+// collectDependencyNode recursively walks a dependency subtree, appending each distinct dependency
+// to deps and recording the parent -> child edge in graph.
+func (mf *MavenFlexPack) collectDependencyNode(dep MavenDependencyJSON, parent string, seen map[string]bool, deps *[]DependencyInfo, graph map[string][]string) {
+	if dep.GroupID == "" || dep.ArtifactID == "" || dep.Version == "" {
+		return
+	}
+
+	dependencyId := fmt.Sprintf("%s:%s:%s", dep.GroupID, dep.ArtifactID, dep.Version)
+
+	// A test-scoped dependency that is excluded contributes neither a node nor an edge. It is filtered
+	// before the seen-guard so a later non-test occurrence of the same coordinate is still collected.
+	isTestDependency := strings.ToLower(dep.Scope) == "test"
+	if !mf.config.IncludeTestDependencies && isTestDependency {
+		return
+	}
+
+	// Record the parent -> child edge for EVERY occurrence, even when the dependency was already seen
+	// via another parent. This preserves all requesters of a diamond dependency (a package pulled in by
+	// more than one parent), so requested-by can report every path back to the module root rather than
+	// only the first one discovered.
+	if parent != "" {
+		graph[parent] = append(graph[parent], dependencyId)
+	}
+
+	// The node itself (and its subtree) is collected only once; subsequent occurrences contribute their
+	// edge above but are not re-added or re-walked.
+	if seen[dependencyId] {
+		return
+	}
+	seen[dependencyId] = true
+
+	*deps = append(*deps, DependencyInfo{
+		ID:      dependencyId,
+		Name:    fmt.Sprintf("%s:%s", dep.GroupID, dep.ArtifactID),
+		Version: dep.Version,
+		Type:    mf.mapPackagingToType(dep.Type),
+		Scopes:  mf.mapMavenScopeToScopes(dep.Scope),
+	})
+
+	for _, child := range dep.Children {
+		mf.collectDependencyNode(child, dependencyId, seen, deps, graph)
+	}
+}
+
+// collectSingleModuleFromPOM is the fallback used when a dependency tree cannot be generated. It
+// parses the root pom.xml directly and returns a single module (pre-reactor behavior).
+func (mf *MavenFlexPack) collectSingleModuleFromPOM() []entities.Module {
+	if len(mf.dependencies) == 0 {
+		mf.parseDependencies()
+	}
+	return []entities.Module{{
+		Id:           fmt.Sprintf("%s:%s:%s", mf.groupId, mf.artifactId, mf.projectVersion),
+		Type:         entities.Maven,
+		Dependencies: mf.toDependencyEntities(mf.dependencies, mf.CalculateRequestedBy()),
+	}}
+}
+
+// toDependencyEntities converts internal DependencyInfo values into entities.Dependency, attaching
+// checksums (best effort) and requested-by relationships. Shared by the reactor and fallback paths.
+func (mf *MavenFlexPack) toDependencyEntities(depInfos []DependencyInfo, requestedBy map[string][]string) []entities.Dependency {
+	var dependencies []entities.Dependency
+	for _, dep := range depInfos {
+		checksumMap := mf.calculateChecksumWithFallback(dep)
+		checksum := entities.Checksum{}
+		if checksumMap != nil {
+			if sha1, ok := checksumMap["sha1"].(string); ok {
+				checksum.Sha1 = sha1
+			}
+			if sha256, ok := checksumMap["sha256"].(string); ok {
+				checksum.Sha256 = sha256
+			}
+			if md5, ok := checksumMap["md5"].(string); ok {
+				checksum.Md5 = md5
+			}
+		}
+
+		entity := entities.Dependency{
+			Id:       dep.ID,
+			Type:     dep.Type,
+			Scopes:   dep.Scopes,
+			Checksum: checksum,
+		}
+		// Full ancestor paths (dep's direct requester -> ... -> module root), one per route, matching the
+		// legacy extractor. requestedBy is the child -> direct-parents map; buildRequestedByPaths expands
+		// each direct parent into the complete chain up to the root.
+		if paths := buildRequestedByPaths(dep.ID, requestedBy); len(paths) > 0 {
+			entity.RequestedBy = paths
+		}
+		dependencies = append(dependencies, entity)
+	}
+	return dependencies
+}
+
+// invertDependencyGraph turns a parent -> children graph into a child -> parents (requested-by) map.
+// A child's parents are de-duplicated so a repeated parent -> child edge contributes a single parent.
+type edgeKey struct{ parent, child string }
+
+func invertDependencyGraph(graph map[string][]string) map[string][]string {
+	requestedBy := make(map[string][]string)
+	seen := make(map[edgeKey]bool)
+	for parent, children := range graph {
+		for _, child := range children {
+			edge := edgeKey{parent, child}
+			if seen[edge] {
+				continue
+			}
+			seen[edge] = true
+			requestedBy[child] = append(requestedBy[child], parent)
+		}
+	}
+	return requestedBy
+}
+
+// buildRequestedByPaths returns every ancestor path for depID, walking the child -> parents map from
+// depID's direct parents up to a root (a node that is itself requested by nothing, i.e. the module).
+// Each path lists ancestors nearest-first and ends at the module root, matching the build-info
+// convention and the legacy Maven build-info extractor. A diamond dependency (reached through more
+// than one parent) yields one path per distinct route. A cycle, which a resolved Maven tree should
+// never contain, is broken defensively by terminating the offending path at the repeated node.
+func buildRequestedByPaths(depID string, parents map[string][]string) [][]string {
+	var paths [][]string
+	var walk func(node string, acc []string, onPath map[string]bool)
+	walk = func(node string, acc []string, onPath map[string]bool) {
+		directParents := parents[node]
+		if len(directParents) == 0 {
+			// Reached a root: the accumulated ancestors form one complete path.
+			if len(acc) > 0 {
+				paths = append(paths, append([]string(nil), acc...))
+			}
+			return
+		}
+		for _, parent := range directParents {
+			if onPath[parent] {
+				// Cycle guard: close the path at the repeated node instead of recursing forever.
+				paths = append(paths, append(append([]string(nil), acc...), parent))
+				continue
+			}
+			onPath[parent] = true
+			walk(parent, append(acc, parent), onPath)
+			delete(onPath, parent)
+		}
+	}
+	walk(depID, nil, map[string]bool{depID: true})
+	return paths
 }
 
 // RunMavenInstallWithBuildInfo runs mvn install and collects build information
@@ -689,4 +1005,200 @@ func saveMavenBuildInfoForJfrogCli(buildInfo *entities.BuildInfo) error {
 
 	log.Debug("Successfully saved Maven build info for jfrog-cli")
 	return nil
+}
+
+// --- Deployment repository resolution ---------------------------------------------------------
+// The deploy repository is needed to scope build-property tagging of deployed artifacts. Rather than
+// parse raw pom.xml/settings.xml (which would miss property interpolation, parent inheritance and
+// profile activation), we ask Maven for its EFFECTIVE model via help:effective-settings /
+// help:effective-pom and parse only the deployment-repository fields out of that resolved output.
+
+type effectivePomProject struct {
+	GroupID                string `xml:"groupId"`
+	ArtifactID             string `xml:"artifactId"`
+	Version                string `xml:"version"`
+	DistributionManagement struct {
+		Repository struct {
+			URL string `xml:"url"`
+		} `xml:"repository"`
+		SnapshotRepository struct {
+			URL string `xml:"url"`
+		} `xml:"snapshotRepository"`
+	} `xml:"distributionManagement"`
+}
+
+type effectiveSettingsProfile struct {
+	AltDeploymentRepository         string `xml:"properties>altDeploymentRepository"`
+	AltReleaseDeploymentRepository  string `xml:"properties>altReleaseDeploymentRepository"`
+	AltSnapshotDeploymentRepository string `xml:"properties>altSnapshotDeploymentRepository"`
+}
+
+// GetDeploymentRepositories resolves where Maven deploys, from its effective model. It returns exactly
+// one of:
+//   - overrideURL: a single URL applied to ALL modules - Maven's -DaltDeploymentRepository or an
+//     active-profile altDeploymentRepository in (effective) settings, which override distributionManagement; or
+//   - moduleURLs: per-module (moduleId "groupId:artifactId:version" -> URL) distributionManagement from
+//     the effective pom, so a reactor whose modules deploy to different repos is handled correctly.
+//
+// Both empty means no deployment repository is configured. Precedence follows Maven (override wins).
+func (mf *MavenFlexPack) GetDeploymentRepositories() (moduleURLs map[string]string, overrideURL string, err error) {
+	isSnapshot := strings.HasSuffix(strings.TrimSpace(mf.projectVersion), "-SNAPSHOT")
+
+	// 1. Command-line -Dalt[Snapshot|Release]DeploymentRepository (highest precedence, no mvn run).
+	if repoURL := altDeploymentRepoURLFromArgs(mf.config.ExtraArgs, isSnapshot); repoURL != "" {
+		return nil, repoURL, nil
+	}
+	// 2. altDeploymentRepository from active-profile settings (effective-settings).
+	if repoURL, sErr := mf.deployURLFromEffectiveSettings(isSnapshot); sErr != nil {
+		log.Debug("Could not resolve deploy repository from effective settings: " + sErr.Error())
+	} else if repoURL != "" {
+		return nil, repoURL, nil
+	}
+	// 3. Per-module distributionManagement from the pom (effective-pom: inheritance + interpolation +
+	//    active profiles resolved by Maven; snapshot/release from each module's effective version).
+	moduleURLs, err = mf.moduleDeployURLsFromEffectivePom(isSnapshot)
+	return moduleURLs, "", err
+}
+
+func (mf *MavenFlexPack) moduleDeployURLsFromEffectivePom(fallbackSnapshot bool) (map[string]string, error) {
+	content, err := mf.runMavenHelpGoal("help:effective-pom")
+	if err != nil {
+		return nil, err
+	}
+	return parseModuleDeployURLs(content, fallbackSnapshot)
+}
+
+// parseModuleDeployURLs maps each effective-pom project's module id ("groupId:artifactId:version") to its
+// distributionManagement URL, choosing snapshotRepository vs repository from each project's EFFECTIVE
+// (interpolated) version - so "${revision}" resolved to -SNAPSHOT is classified correctly - falling back
+// to fallbackSnapshot when a project has no version. Modules without distributionManagement are omitted.
+func parseModuleDeployURLs(content string, fallbackSnapshot bool) (map[string]string, error) {
+	// help:effective-pom emits a single <project> for one module, or a <projects> wrapper for a reactor.
+	var wrapper struct {
+		Projects []effectivePomProject `xml:"project"`
+	}
+	b := []byte(content)
+	var projects []effectivePomProject
+	if err := xml.Unmarshal(b, &wrapper); err == nil && len(wrapper.Projects) > 0 {
+		projects = wrapper.Projects
+	} else {
+		var single effectivePomProject
+		if err := xml.Unmarshal(b, &single); err != nil {
+			return nil, fmt.Errorf("failed to parse effective-pom: %w", err)
+		}
+		projects = []effectivePomProject{single}
+	}
+	urls := make(map[string]string)
+	for _, project := range projects {
+		url := distributionURL(project, fallbackSnapshot)
+		if url == "" || project.GroupID == "" || project.ArtifactID == "" || project.Version == "" {
+			continue
+		}
+		urls[project.GroupID+":"+project.ArtifactID+":"+project.Version] = url
+	}
+	return urls, nil
+}
+
+// distributionURL returns a project's distributionManagement URL, snapshot vs release chosen from its
+// effective version (fallbackSnapshot when the version is absent).
+func distributionURL(project effectivePomProject, fallbackSnapshot bool) string {
+	isSnapshot := fallbackSnapshot
+	if project.Version != "" {
+		isSnapshot = strings.HasSuffix(strings.TrimSpace(project.Version), "-SNAPSHOT")
+	}
+	dm := project.DistributionManagement
+	if isSnapshot && dm.SnapshotRepository.URL != "" {
+		return dm.SnapshotRepository.URL
+	}
+	if dm.Repository.URL != "" {
+		return dm.Repository.URL
+	}
+	return dm.SnapshotRepository.URL
+}
+
+func (mf *MavenFlexPack) deployURLFromEffectiveSettings(isSnapshot bool) (string, error) {
+	content, err := mf.runMavenHelpGoal("help:effective-settings")
+	if err != nil {
+		return "", err
+	}
+	var settings struct {
+		Profiles []effectiveSettingsProfile `xml:"profiles>profile"`
+	}
+	if err := xml.Unmarshal([]byte(content), &settings); err != nil {
+		return "", fmt.Errorf("failed to parse effective-settings: %w", err)
+	}
+	for _, profile := range settings.Profiles {
+		if isSnapshot && profile.AltSnapshotDeploymentRepository != "" {
+			return repoURLFromAltValue(profile.AltSnapshotDeploymentRepository), nil
+		}
+		if !isSnapshot && profile.AltReleaseDeploymentRepository != "" {
+			return repoURLFromAltValue(profile.AltReleaseDeploymentRepository), nil
+		}
+		if profile.AltDeploymentRepository != "" {
+			return repoURLFromAltValue(profile.AltDeploymentRepository), nil
+		}
+	}
+	return "", nil
+}
+
+// runMavenHelpGoal runs a maven-help-plugin goal that writes its output to a file (-Doutput), forwarding
+// the same resolution flags used for the build, and returns the file content.
+func (mf *MavenFlexPack) runMavenHelpGoal(goal string) (string, error) {
+	outFile, err := os.CreateTemp("", "flexpack-effective-*.xml")
+	if err != nil {
+		return "", err
+	}
+	outPath := outFile.Name()
+	_ = outFile.Close()
+	defer func() {
+		if removeErr := os.Remove(outPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Debug("Failed to remove temporary file " + outPath + ": " + removeErr.Error())
+		}
+	}()
+
+	args := []string{goal, "-Doutput=" + outPath, "-q", "-B"}
+	args = append(args, mf.config.ExtraArgs...)
+	cmd := exec.Command(mf.config.MavenExecutable, args...)
+	cmd.Dir = mf.config.WorkingDirectory
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		return "", fmt.Errorf("mvn %s failed: %w\nOutput: %s", goal, runErr, string(out))
+	}
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+// altDeploymentRepoURLFromArgs extracts the deployment URL from a -Dalt[Snapshot|Release]DeploymentRepository
+// argument (value form "id::layout::url" or "id::url"), honoring snapshot/release specificity.
+func altDeploymentRepoURLFromArgs(args []string, isSnapshot bool) string {
+	var general, release, snapshot string
+	for _, arg := range args {
+		if value, ok := strings.CutPrefix(arg, "-DaltSnapshotDeploymentRepository="); ok {
+			snapshot = repoURLFromAltValue(value)
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "-DaltReleaseDeploymentRepository="); ok {
+			release = repoURLFromAltValue(value)
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "-DaltDeploymentRepository="); ok {
+			general = repoURLFromAltValue(value)
+		}
+	}
+	if isSnapshot && snapshot != "" {
+		return snapshot
+	}
+	if !isSnapshot && release != "" {
+		return release
+	}
+	return general
+}
+
+// repoURLFromAltValue returns the URL component of an altDeploymentRepository value ("id::layout::url"
+// or "id::url"); the URL is the final "::"-separated segment.
+func repoURLFromAltValue(value string) string {
+	parts := strings.Split(value, "::")
+	return parts[len(parts)-1]
 }

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -85,10 +85,9 @@ type MavenConfig struct {
 const mavenDepsFileName = "maven-deps.json"
 
 // mavenDependencyPluginTreeGoal is the fully-qualified plugin coordinate used to invoke the
-// dependency:tree goal. The version is pinned because `-DoutputType=json` was only added in
-// maven-dependency-plugin 3.7.0; older versions silently write plain-text output which the JSON
-// parser then rejects. 3.8.1 (current latest) is used to also pick up bug fixes.
-const mavenDependencyPluginTreeGoal = "org.apache.maven.plugins:maven-dependency-plugin:3.8.1:tree"
+// dependency:tree goal. The version is pinned to the minimum that supports -DoutputType=json
+// (added in 3.7.0); older versions silently write plain-text output which the JSON parser rejects.
+const mavenDependencyPluginTreeGoal = "org.apache.maven.plugins:maven-dependency-plugin:3.7.0:tree"
 
 // MavenPOM represents the structure of pom.xml file
 type MavenPOM struct {
@@ -488,11 +487,11 @@ func (mf *MavenFlexPack) localRepositoryPath() string {
 }
 
 func (mf *MavenFlexPack) resolveLocalRepositoryPath() string {
-	const flag = "-Dmaven.repo.local="
+	const mavenLocalRepoFlag = "-Dmaven.repo.local="
 	// Later occurrences win, matching Maven's last-value-wins behavior for repeated properties.
 	custom := ""
 	for _, arg := range mf.config.ExtraArgs {
-		if v, ok := strings.CutPrefix(arg, flag); ok && v != "" {
+		if v, ok := strings.CutPrefix(arg, mavenLocalRepoFlag); ok && v != "" {
 			custom = v
 		}
 	}

--- a/flexpack/maven_flexpack.go
+++ b/flexpack/maven_flexpack.go
@@ -598,6 +598,9 @@ func (mf *MavenFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entit
 		Name:    buildName,
 		Number:  buildNumber,
 		Started: time.Now().Format(entities.TimeFormat),
+		// Agent.Name and Agent.Version are overridden at publish time by jfrog-cli via
+		// SetAgentName("jfrog-cli-go") and SetAgentVersion(<cli version>); these values
+		// are placeholders used when the library is called directly outside of jfrog-cli.
 		Agent: &entities.Agent{
 			Name:    "build-info-go",
 			Version: "1.0.0",

--- a/flexpack/maven_flexpack_test.go
+++ b/flexpack/maven_flexpack_test.go
@@ -1,0 +1,233 @@
+package flexpack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvertDependencyGraph(t *testing.T) {
+	graph := map[string][]string{
+		"root": {"a", "b"},
+		"a":    {"c"},
+	}
+	got := invertDependencyGraph(graph)
+	assert.Equal(t, []string{"root"}, got["a"])
+	assert.Equal(t, []string{"root"}, got["b"])
+	assert.Equal(t, []string{"a"}, got["c"])
+	assert.Empty(t, got["root"])
+}
+
+func TestCollectModuleDependencies(t *testing.T) {
+	mf := &MavenFlexPack{config: MavenConfig{IncludeTestDependencies: true}}
+	root := MavenDependencyJSON{
+		GroupID: "com.example", ArtifactID: "app", Version: "1.0",
+		Children: []MavenDependencyJSON{
+			{GroupID: "com.google.guava", ArtifactID: "guava", Version: "32.1", Scope: "compile", Children: []MavenDependencyJSON{
+				{GroupID: "com.google.guava", ArtifactID: "failureaccess", Version: "1.0", Scope: "compile"},
+			}},
+			// failureaccess is a diamond: pulled in transitively via guava AND declared directly on the
+			// module. The node is collapsed to one entry, but BOTH parent edges must be recorded.
+			{GroupID: "com.google.guava", ArtifactID: "failureaccess", Version: "1.0", Scope: "compile"},
+		},
+	}
+	deps, graph := mf.collectModuleDependencies("com.example:app:1.0", root)
+
+	ids := depIDs(deps)
+	assert.ElementsMatch(t, []string{"com.google.guava:guava:32.1", "com.google.guava:failureaccess:1.0"}, ids,
+		"duplicate within module collapsed to a single node")
+	// requested-by edges: guava requested by the module; failureaccess by BOTH guava (transitive) and
+	// the module (direct) - the diamond's two routes are preserved, not just the first discovered.
+	requestedBy := invertDependencyGraph(graph)
+	assert.Equal(t, []string{"com.example:app:1.0"}, requestedBy["com.google.guava:guava:32.1"])
+	assert.ElementsMatch(t, []string{"com.google.guava:guava:32.1", "com.example:app:1.0"},
+		requestedBy["com.google.guava:failureaccess:1.0"])
+}
+
+func TestBuildRequestedByPaths(t *testing.T) {
+	t.Run("full chain to root", func(t *testing.T) {
+		// module -> guava -> failureaccess. failureaccess's path is [guava, module], guava's is [module].
+		parents := map[string][]string{
+			"guava":         {"module"},
+			"failureaccess": {"guava"},
+		}
+		assert.Equal(t, [][]string{{"module"}}, buildRequestedByPaths("guava", parents))
+		assert.Equal(t, [][]string{{"guava", "module"}}, buildRequestedByPaths("failureaccess", parents))
+	})
+
+	t.Run("diamond yields one path per route", func(t *testing.T) {
+		// failureaccess reached via guava and directly from the module -> two complete paths.
+		parents := map[string][]string{
+			"guava":         {"module"},
+			"failureaccess": {"guava", "module"},
+		}
+		assert.ElementsMatch(t,
+			[][]string{{"guava", "module"}, {"module"}},
+			buildRequestedByPaths("failureaccess", parents))
+	})
+
+	t.Run("no parents yields no path", func(t *testing.T) {
+		assert.Empty(t, buildRequestedByPaths("orphan", map[string][]string{}))
+	})
+
+	t.Run("cycle is broken defensively", func(t *testing.T) {
+		// a -> b -> a. Walking from a must terminate rather than recurse forever.
+		parents := map[string][]string{"a": {"b"}, "b": {"a"}}
+		paths := buildRequestedByPaths("a", parents)
+		assert.NotEmpty(t, paths)
+	})
+}
+
+func TestCollectModuleDependencies_TestScopeFiltered(t *testing.T) {
+	root := MavenDependencyJSON{
+		GroupID: "com.example", ArtifactID: "app", Version: "1.0",
+		Children: []MavenDependencyJSON{
+			{GroupID: "junit", ArtifactID: "junit", Version: "4.13", Scope: "test"},
+			{GroupID: "com.google.guava", ArtifactID: "guava", Version: "32.1", Scope: "compile"},
+		},
+	}
+
+	excluded := &MavenFlexPack{config: MavenConfig{IncludeTestDependencies: false}}
+	deps, _ := excluded.collectModuleDependencies("com.example:app:1.0", root)
+	assert.ElementsMatch(t, []string{"com.google.guava:guava:32.1"}, depIDs(deps), "test dep excluded")
+
+	included := &MavenFlexPack{config: MavenConfig{IncludeTestDependencies: true}}
+	deps, _ = included.collectModuleDependencies("com.example:app:1.0", root)
+	assert.ElementsMatch(t, []string{"junit:junit:4.13", "com.google.guava:guava:32.1"}, depIDs(deps), "test dep included")
+}
+
+func TestBuildModuleFromTreeFile(t *testing.T) {
+	dir := t.TempDir()
+	treePath := filepath.Join(dir, mavenDepsFileName)
+	// root node = the module itself (packaging in "type"); children = its dependencies.
+	treeJSON := `{
+	  "groupId": "com.example", "artifactId": "app", "version": "1.0", "type": "war",
+	  "children": [
+	    {"groupId": "com.google.guava", "artifactId": "guava", "version": "32.1", "scope": "compile"}
+	  ]
+	}`
+	require.NoError(t, os.WriteFile(treePath, []byte(treeJSON), 0600))
+
+	mf := &MavenFlexPack{config: MavenConfig{IncludeTestDependencies: true}, moduleLocations: make(map[string]ModuleLocation)}
+	module, err := mf.buildModuleFromTreeFile(treePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "com.example:app:1.0", module.Id)
+	assert.Equal(t, entities.Maven, module.Type)
+	require.Len(t, module.Dependencies, 1)
+	assert.Equal(t, "com.google.guava:guava:32.1", module.Dependencies[0].Id)
+
+	// Location recorded: dir = the tree file's directory, packaging = root "type".
+	loc, ok := mf.GetModuleLocations()["com.example:app:1.0"]
+	require.True(t, ok)
+	assert.Equal(t, dir, loc.Dir)
+	assert.Equal(t, "war", loc.Packaging)
+}
+
+func TestBuildModuleFromTreeFile_MissingCoordinates(t *testing.T) {
+	dir := t.TempDir()
+	treePath := filepath.Join(dir, mavenDepsFileName)
+	require.NoError(t, os.WriteFile(treePath, []byte(`{"groupId": "", "artifactId": "", "version": ""}`), 0600))
+
+	mf := &MavenFlexPack{config: MavenConfig{}, moduleLocations: make(map[string]ModuleLocation)}
+	_, err := mf.buildModuleFromTreeFile(treePath)
+	assert.Error(t, err)
+}
+
+func TestLocalRepositoryPath(t *testing.T) {
+	t.Run("honors maven.repo.local override", func(t *testing.T) {
+		mf := &MavenFlexPack{config: MavenConfig{ExtraArgs: []string{"-Pprod", "-Dmaven.repo.local=/custom/repo"}}}
+		assert.Equal(t, "/custom/repo", mf.localRepositoryPath())
+	})
+	t.Run("last override wins", func(t *testing.T) {
+		mf := &MavenFlexPack{config: MavenConfig{ExtraArgs: []string{"-Dmaven.repo.local=/a", "-Dmaven.repo.local=/b"}}}
+		assert.Equal(t, "/b", mf.localRepositoryPath())
+	})
+	t.Run("falls back to default .m2 when no override", func(t *testing.T) {
+		mf := &MavenFlexPack{config: MavenConfig{ExtraArgs: []string{"-Pprod"}}}
+		got := mf.localRepositoryPath()
+		assert.True(t, filepath.IsAbs(got))
+		assert.Contains(t, got, filepath.Join(".m2", "repository"))
+	})
+}
+
+func depIDs(deps []DependencyInfo) []string {
+	ids := make([]string, 0, len(deps))
+	for _, d := range deps {
+		ids = append(ids, d.ID)
+	}
+	return ids
+}
+
+func TestRepoURLFromAltValue(t *testing.T) {
+	assert.Equal(t, "https://acme/artifactory/libs-release", repoURLFromAltValue("id::default::https://acme/artifactory/libs-release"))
+	assert.Equal(t, "https://acme/artifactory/libs-release", repoURLFromAltValue("id::https://acme/artifactory/libs-release"))
+	assert.Equal(t, "https://acme/artifactory/libs-release", repoURLFromAltValue("https://acme/artifactory/libs-release"))
+}
+
+func TestAltDeploymentRepoURLFromArgs(t *testing.T) {
+	t.Run("general", func(t *testing.T) {
+		args := []string{"-DskipTests", "-DaltDeploymentRepository=id::default::https://acme/artifactory/general"}
+		assert.Equal(t, "https://acme/artifactory/general", altDeploymentRepoURLFromArgs(args, false))
+		assert.Equal(t, "https://acme/artifactory/general", altDeploymentRepoURLFromArgs(args, true))
+	})
+	t.Run("release-specific wins for release", func(t *testing.T) {
+		args := []string{
+			"-DaltDeploymentRepository=id::default::https://acme/artifactory/general",
+			"-DaltReleaseDeploymentRepository=id::default::https://acme/artifactory/releases",
+		}
+		assert.Equal(t, "https://acme/artifactory/releases", altDeploymentRepoURLFromArgs(args, false))
+	})
+	t.Run("snapshot-specific wins for snapshot", func(t *testing.T) {
+		args := []string{
+			"-DaltDeploymentRepository=id::default::https://acme/artifactory/general",
+			"-DaltSnapshotDeploymentRepository=id::default::https://acme/artifactory/snapshots",
+		}
+		assert.Equal(t, "https://acme/artifactory/snapshots", altDeploymentRepoURLFromArgs(args, true))
+	})
+	t.Run("none", func(t *testing.T) {
+		assert.Equal(t, "", altDeploymentRepoURLFromArgs([]string{"-Pprod", "-DskipTests"}, false))
+	})
+}
+
+func TestParseModuleDeployURLs(t *testing.T) {
+	const dm = `<distributionManagement>
+	  <repository><url>https://acme/artifactory/libs-release</url></repository>
+	  <snapshotRepository><url>https://acme/artifactory/libs-snapshot</url></snapshotRepository>
+	</distributionManagement>`
+
+	t.Run("effective SNAPSHOT version picks snapshotRepository (raw ${revision} would misfire)", func(t *testing.T) {
+		content := `<project><groupId>com.acme</groupId><artifactId>app</artifactId><version>1.0.0-SNAPSHOT</version>` + dm + `</project>`
+		urls, err := parseModuleDeployURLs(content, false /*raw said release*/)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{"com.acme:app:1.0.0-SNAPSHOT": "https://acme/artifactory/libs-snapshot"}, urls)
+	})
+	t.Run("effective release version picks repository", func(t *testing.T) {
+		content := `<project><groupId>com.acme</groupId><artifactId>app</artifactId><version>1.0.0</version>` + dm + `</project>`
+		urls, err := parseModuleDeployURLs(content, true /*raw said snapshot*/)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://acme/artifactory/libs-release", urls["com.acme:app:1.0.0"])
+	})
+	t.Run("reactor: each module maps to its OWN repo", func(t *testing.T) {
+		content := `<projects>
+		  <project><groupId>com.acme</groupId><artifactId>lib</artifactId><version>1.0.0</version>
+		    <distributionManagement><repository><url>https://acme/artifactory/repo-lib</url></repository></distributionManagement></project>
+		  <project><groupId>com.acme</groupId><artifactId>app</artifactId><version>1.0.0</version>
+		    <distributionManagement><repository><url>https://acme/artifactory/repo-app</url></repository></distributionManagement></project>
+		</projects>`
+		urls, err := parseModuleDeployURLs(content, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://acme/artifactory/repo-lib", urls["com.acme:lib:1.0.0"])
+		assert.Equal(t, "https://acme/artifactory/repo-app", urls["com.acme:app:1.0.0"])
+	})
+	t.Run("module without distributionManagement is omitted", func(t *testing.T) {
+		content := `<project><groupId>com.acme</groupId><artifactId>app</artifactId><version>1.0.0</version></project>`
+		urls, err := parseModuleDeployURLs(content, false)
+		assert.NoError(t, err)
+		assert.Empty(t, urls)
+	})
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

- Implement TestAppendProperties to verify the behavior of the Append method in BuildInfo, ensuring it fills gaps without clobbering existing properties and initializes nil target properties.
- Enhance MavenFlexPack with additional fields for module locations and checksum caching to optimize artifact handling.
- Introduce methods for resolving the local Maven repository path and collecting build information from multi-module projects.
- Add comprehensive tests for MavenFlexPack, including dependency graph inversion, module dependency collection, and effective POM parsing.
- Ensure that deployment repository resolution is robust, handling various scenarios for snapshot and release versions.