### PR TITLE
XRAY-157605 Use the real package name for aliased npm dependencies

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -383,7 +383,12 @@ func parseDependencies(data []byte, pathToRoot []string, dependencies map[string
 			return err
 		}
 		// The dependency name is a key in the object, which is not always available inside the value.
-		npmLsDependency.Name = string(key)
+		// When the value does hold a name, it takes precedence over the key: aliased dependencies
+		// (e.g. "strip-ansi-cjs": "npm:strip-ansi@^6.0.1") are keyed by their alias, while the real
+		// registry package name is the one reported inside the value.
+		if npmLsDependency.Name == "" {
+			npmLsDependency.Name = string(key)
+		}
 
 		// Some old npm versions store the git hash in the version field. We'll extract it to be used as the version.
 		if isGitDependency(npmLsDependency.Version) {

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -618,6 +618,23 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 			shouldBeSkipped:  false,
 			expectParseError: false,
 		},
+		{
+			// Aliased dependency, e.g. "strip-ansi-cjs": "npm:strip-ansi@^6.0.1".
+			// The key is the alias, while "name" holds the real registry package.
+			name:             "Aliased dependency is identified by its real name",
+			inputJson:        `{"strip-ansi-cjs":{"name": "strip-ansi", "version": "6.0.1", "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"}}`,
+			expectedId:       "strip-ansi:6.0.1",
+			shouldBeSkipped:  false,
+			expectParseError: false,
+		},
+		{
+			// Scoped alias, e.g. "cliui-cjs": "npm:@isaacs/cliui@^8.0.2".
+			name:             "Aliased scoped dependency is identified by its real name",
+			inputJson:        `{"cliui-cjs":{"name": "@isaacs/cliui", "version": "8.0.2", "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"}}`,
+			expectedId:       "@isaacs/cliui:8.0.2",
+			shouldBeSkipped:  false,
+			expectParseError: false,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

npm aliases let a project install a package under a different local name:

"strip-ansi-cjs": "npm:strip-ansi@^6.0.1"
Here strip-ansi-cjs is just the folder name — the real package is strip-ansi.

npm ls gives us both: the alias as the object key, the real name in the value. We were overwriting the real name with the key, so the dependency ID became strip-ansi-cjs:6.0.1 — a package that exists in no registry.

The fix makes the key a fallback, used only when the value has no name.