### PR TITLE
XRAY-157662 - fix npm peer dependency

### DIFF
--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/jfrog/gofrog/crypto"
@@ -119,13 +120,23 @@ func CalculateDependenciesMap(executablePath, srcPath, moduleId string, npmListP
 		}
 	}
 	parseFunc := parseNpmLsDependencyFunc(npmVersion)
+	// Dependencies that npm never resolved (e.g. an unmet peer dependency) and that therefore
+	// carry no locator we can hash into a version. They're excluded from dependenciesMap below;
+	// collect their names here so they're still visible to the caller instead of vanishing silently.
+	var unresolvedDeps []string
 	// Parse the dependencies json object.
-	return dependenciesMap, jsonparser.ObjectEach(data, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) (err error) {
+	if err := jsonparser.ObjectEach(data, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) (err error) {
 		if string(key) == "dependencies" {
-			err = parseDependencies(value, []string{moduleId}, dependenciesMap, parseFunc, log)
+			err = parseDependencies(value, []string{moduleId}, dependenciesMap, parseFunc, &unresolvedDeps, log)
 		}
 		return err
-	})
+	}); err != nil {
+		return nil, err
+	}
+	if len(unresolvedDeps) > 0 {
+		printMissingDependenciesWarning("unresolved dependency", unresolvedDeps, log)
+	}
+	return dependenciesMap, nil
 }
 
 func runNpmLsWithNodeModules(executablePath, srcPath string, npmArgs []string, log utils.Log) (data []byte) {
@@ -266,11 +277,11 @@ type npmLsDependency struct {
 	InBundle  bool
 	Dev       bool
 	Optional  bool
-	// Missing peer dependency in npm version 7/8
+	// Missing dependency in npm version 7/8 (not peer-specific)
 	Missing bool
-	// Problems with missing peer dependency in npm version 7/8
+	// Problems with missing dependency in npm version 7/8 (not peer-specific)
 	Problems []string
-	// Missing  peer dependency in npm version 6
+	// Missing peer dependency in npm version 6
 	// Bound to 'legacyNpmLsDependency' struct
 	PeerMissing interface{}
 }
@@ -349,10 +360,38 @@ func extractUrlFromProblems(problems []string, packageName string) string {
 			if idx := strings.Index(url, ","); idx > 0 {
 				url = url[:idx]
 			}
-			return strings.TrimSpace(url)
+			url = strings.TrimSpace(url)
+			// npm reports any missing dependency via this same "missing: name@X" shape.
+			if !isNonRegistryLocator(url) {
+				return ""
+			}
+			return url
 		}
 	}
 	return ""
+}
+
+// bareGitHubShorthandWithRef matches npm's un-prefixed "owner/repo#ref" shorthand
+// (e.g. "expressjs/express#v4.18.0"). The ref is required: without one, "owner/repo"
+// has nothing to pin a version to and would only fabricate a hash — same as "github:owner/repo#ref".
+var bareGitHubShorthandWithRef = regexp.MustCompile(`^[\w.-]+/[\w.-]+#.+$`)
+
+// isNonRegistryLocator reports whether s is a fetchable locator (URL, git, file)
+// rather than a semver range or npm alias spec.
+func isNonRegistryLocator(s string) bool {
+	if strings.Contains(s, "://") {
+		return true
+	}
+	lower := strings.ToLower(s)
+	// git+ and git: are listed for readability but never reach this loop in practice —
+	// real npm git specs using either always include "://" right after (git+ssh://,
+	// git+https://, git://), so the check above already catches them first.
+	for _, prefix := range []string{"git+", "git:", "file:", "github:", "gitlab:", "bitbucket:", "gist:"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return bareGitHubShorthandWithRef.MatchString(s)
 }
 
 func (nld *npmLsDependency) getScopes() (scopes []string) {
@@ -371,7 +410,9 @@ func (nld *npmLsDependency) getScopes() (scopes []string) {
 }
 
 // Parses npm dependencies recursively and adds the collected dependencies to the given dependencies map.
-func parseDependencies(data []byte, pathToRoot []string, dependencies map[string]*dependencyInfo, parseFunc func(data []byte) (*npmLsDependency, error), log utils.Log) error {
+// Dependencies that npm never resolved (missing, with no locator to hash into a version) are excluded
+// from dependencies and their names appended to unresolvedDeps instead, so the caller can still report them.
+func parseDependencies(data []byte, pathToRoot []string, dependencies map[string]*dependencyInfo, parseFunc func(data []byte) (*npmLsDependency, error), unresolvedDeps *[]string, log utils.Log) error {
 	return jsonparser.ObjectEach(data, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
 		if string(value) == "{}" {
 			// Skip missing optional dependency.
@@ -426,7 +467,13 @@ func parseDependencies(data []byte, pathToRoot []string, dependencies map[string
 				}
 			case npmLsDependency.Missing || npmLsDependency.Problems != nil:
 				// Skip missing peer dependency.
-				log.Debug(fmt.Sprintf("%s is missing, this may be the result of an peer dependency.", key))
+				log.Debug(fmt.Sprintf("%s is missing and has no resolvable locator (e.g. an unmet peer dependency).", key))
+				// The same name can turn up once per sibling package that's missing it
+				// (e.g. a peer several packages all require but none of them installed) —
+				// dedupe here so one real problem doesn't get reported as several.
+				if !slices.Contains(*unresolvedDeps, npmLsDependency.Name) {
+					*unresolvedDeps = append(*unresolvedDeps, npmLsDependency.Name)
+				}
 				return nil
 			default:
 				return errors.New("failed to parse '" + string(value) + "' from npm ls output.")
@@ -438,7 +485,7 @@ func parseDependencies(data []byte, pathToRoot []string, dependencies map[string
 			return err
 		}
 		if len(transitive) > 0 {
-			if err := parseDependencies(transitive, append([]string{npmLsDependency.id()}, pathToRoot...), dependencies, parseFunc, log); err != nil {
+			if err := parseDependencies(transitive, append([]string{npmLsDependency.id()}, pathToRoot...), dependencies, parseFunc, unresolvedDeps, log); err != nil {
 				return err
 			}
 		}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -138,7 +138,8 @@ func TestParseDependencies(t *testing.T) {
 		{"shopify-liquid:1.d7.9", [][]string{{"xpm:0.1.1", "@jfrog/npm_scoped:1.0.0", "root"}}},
 	}
 	dependencies := make(map[string]*dependencyInfo)
-	err = parseDependencies(dependenciesJsonList, []string{"root"}, dependencies, npmLsDependencyParser, utils.NewDefaultLogger(utils.INFO))
+	var unresolvedDeps []string
+	err = parseDependencies(dependenciesJsonList, []string{"root"}, dependencies, npmLsDependencyParser, &unresolvedDeps, utils.NewDefaultLogger(utils.INFO))
 	assert.NoError(t, err)
 	assert.Equal(t, len(expectedDependenciesList), len(dependencies))
 	for _, eDependency := range expectedDependenciesList {
@@ -151,6 +152,23 @@ func TestParseDependencies(t *testing.T) {
 		}
 		assert.True(t, found, "The expected dependency:", eDependency, "is missing from the actual dependencies list:\n", dependencies)
 	}
+}
+
+func TestParseDependencies_UnresolvedDepsDeduplicated(t *testing.T) {
+	inputJson := `{
+		"pkg-a": {"version": "1.0.0", "dependencies": {
+			"react": {"problems": ["missing: react@^18.0.0, required by pkg-a@1.0.0"]}
+		}},
+		"pkg-b": {"version": "1.0.0", "dependencies": {
+			"react": {"problems": ["missing: react@^18.0.0, required by pkg-b@1.0.0"]}
+		}}
+	}`
+	depsMap := make(map[string]*dependencyInfo)
+	var unresolvedDeps []string
+	err := parseDependencies([]byte(inputJson), []string{"root"}, depsMap, npmLsDependencyParser, &unresolvedDeps, &utils.NullLog{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"react"}, unresolvedDeps,
+		"expected 'react' to be reported once even though it is missing under two different parents")
 }
 
 func TestAppendScopes(t *testing.T) {
@@ -549,12 +567,13 @@ func TestFilterUniqueArgs(t *testing.T) {
 
 func TestParseDependenciesEdgeCases(t *testing.T) {
 	testcases := []struct {
-		name                string
-		inputJson           string
-		expectedId          string
-		shouldBeSkipped     bool
-		expectParseError    bool
-		expectedRequestedBy [][]string
+		name                   string
+		inputJson              string
+		expectedId             string
+		shouldBeSkipped        bool
+		expectParseError       bool
+		expectedRequestedBy    [][]string
+		expectedUnresolvedName string
 	}{
 		{
 			name:             "Git URL with hash in resolved",
@@ -594,10 +613,11 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 			expectParseError: false,
 		},
 		{
-			name:             "No version and no resolved, but missing",
-			inputJson:        `{"bad-pkg":{"missing": true}}`,
-			shouldBeSkipped:  true,
-			expectParseError: false,
+			name:                   "No version and no resolved, but missing",
+			inputJson:              `{"bad-pkg":{"missing": true}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "bad-pkg",
 		},
 		{
 			name:             "No version and no resolved, not missing",
@@ -606,10 +626,61 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 			expectParseError: true,
 		},
 		{
-			name:             "Missing peer dependency",
-			inputJson:        `{"peer-pkg":{"missing": true}}`,
-			shouldBeSkipped:  true,
+			name:                   "Missing dependency with no problems array",
+			inputJson:              `{"peer-pkg":{"missing": true}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "peer-pkg",
+		},
+		{
+			// npm reports this identical shape for a missing peer, prod, or dev dependency;
+			// react/react-dom here just mirrors the ticket's actual repro (an unmet peer).
+			name:                   "Missing dependency with semver range in problems",
+			inputJson:              `{"react":{"problems": ["missing: react@^18.2.0, required by react-dom@18.2.0"]}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "react",
+		},
+		{
+			name:      "Missing dependency with git locator in problems",
+			inputJson: `{"my-private-package":{"problems": ["missing: my-private-package@git+ssh://git@github.com/my-org/my-private-package.git#v1.0.0, required by root"]}}`,
+			expectedId: func() string {
+				return "my-private-package:v1.0.0"
+			}(),
+			shouldBeSkipped:  false,
 			expectParseError: false,
+		},
+		{
+			name:                   "Missing dependency with bare GitHub shorthand, no ref, in problems",
+			inputJson:              `{"express":{"problems": ["missing: express@expressjs/express, required by react-dom@18.2.0"]}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "express",
+		},
+		{
+			name:             "Missing dependency with bare GitHub shorthand and ref in problems",
+			inputJson:        `{"express":{"problems": ["missing: express@expressjs/express#v4.18.0, required by react-dom@18.2.0"]}}`,
+			expectedId:       "express:v4.18.0",
+			shouldBeSkipped:  false,
+			expectParseError: false,
+		},
+		{
+			// The literal "peer dependency" scenario: a peer pinned to an exact version that
+			// was never installed. X here is a bare version, not a range and not a locator.
+			name:                   "Missing peer dependency with exact pinned version in problems",
+			inputJson:              `{"left-pad":{"problems": ["missing: left-pad@2.5.3, required by pkg-a@1.0.0"]}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "left-pad",
+		},
+		{
+			// Same mechanism, but the requirer relationship is an ordinary (non-peer) dependency,
+			// not a peer — proves the skip isn't peer-specific (see Finding #1/#2 discussion).
+			name:                   "Missing non-peer dependency with semver range in problems",
+			inputJson:              `{"lodash":{"problems": ["missing: lodash@^4.17.0, required by pkg-a@1.0.0"]}}`,
+			shouldBeSkipped:        true,
+			expectParseError:       false,
+			expectedUnresolvedName: "lodash",
 		},
 		{
 			name:             "Regular dependency is not affected",
@@ -641,7 +712,8 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			depsMap := make(map[string]*dependencyInfo)
 			parseFunc := npmLsDependencyParser
-			err := parseDependencies([]byte(tc.inputJson), []string{"root"}, depsMap, parseFunc, &utils.NullLog{})
+			var unresolvedDeps []string
+			err := parseDependencies([]byte(tc.inputJson), []string{"root"}, depsMap, parseFunc, &unresolvedDeps, &utils.NullLog{})
 
 			if tc.expectParseError {
 				assert.Error(t, err)
@@ -651,6 +723,9 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 
 			if tc.shouldBeSkipped {
 				assert.Empty(t, depsMap, "Expected dependency to be skipped, but it was added")
+				if tc.expectedUnresolvedName != "" {
+					assert.Contains(t, unresolvedDeps, tc.expectedUnresolvedName, "Expected skipped dependency to be reported as unresolved")
+				}
 			} else {
 				assert.Len(t, depsMap, 1, "Expected exactly one dependency")
 				// Check if the key exists
@@ -660,6 +735,34 @@ func TestParseDependenciesEdgeCases(t *testing.T) {
 					assert.Equal(t, tc.expectedId, depInfo.Id, "Dependency ID mismatch")
 				}
 			}
+		})
+	}
+}
+
+func TestNpmIsNonRegistryLocator(t *testing.T) {
+	testcases := []struct {
+		name     string
+		spec     string
+		expected bool
+	}{
+		{"semver range is not a locator", "^18.2.0", false},
+		{"npm alias spec is not a locator", "npm:strip-ansi@^6.0.1", false},
+		{"exact pinned version is not a locator", "2.5.3", false},
+		{"github: prefix is a locator", "github:expressjs/express", true},
+		{"gitlab: prefix is a locator", "gitlab:owner/repo", true},
+		{"bitbucket: prefix is a locator", "bitbucket:owner/repo", true},
+		{"gist: prefix is a locator", "gist:abc123", true},
+		{"file: path is a locator", "file:../shared/my-local-pkg", true},
+		{"git+ssh URL is a locator", "git+ssh://git@github.com/org/repo.git#v1.0.0", true},
+		{"git+https URL is a locator", "git+https://github.com/org/repo.git", true},
+		{"bare git:// URL is a locator", "git://github.com/org/repo.git", true},
+		{"tarball URL is a locator", "https://example.com/pkg-1.0.0.tgz", true},
+		{"bare GitHub shorthand without a ref is not a locator", "expressjs/express", false},
+		{"bare GitHub shorthand with a ref is a locator", "expressjs/express#v4.18.0", true},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isNonRegistryLocator(tc.spec))
 		})
 	}
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----

For unresolved peer dependencies, they should be skipped and reported as missing dependencies. Previously, they were being converted to a SHA1 hash and sent to curation, which returned a 404 for a package version that never existed. Now they are correctly skipped instead of being treated as a resolvable package.

Before:
<img width="1728" height="597" alt="Screenshot 2026-08-13 at 11 58 47 AM" src="https://github.com/user-attachments/assets/e0c0e7ee-9c85-45ef-9f5e-a89794628921" />

After:
<img width="1176" height="687" alt="Screenshot 2026-08-13 at 12 06 07 PM" src="https://github.com/user-attachments/assets/fb9df158-8a99-4d0d-b18a-5fe669eb98d2" />
