### PR TITLE
RTECO-1885 - Fix Gradle -D/-P property values getting wrapped in literal quotes

### DIFF
--- a/build/gradle.go
+++ b/build/gradle.go
@@ -296,14 +296,7 @@ func unquoteProperty(task string) string {
 	if len(parts) < 2 {
 		return task
 	}
-	value := parts[1]
-	if len(value) >= 2 {
-		first, last := value[0], value[len(value)-1]
-		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
-			value = value[1 : len(value)-1]
-		}
-	}
-	return parts[0] + "=" + value
+	return parts[0] + "=" + utils.StripSurroundingQuotes(parts[1])
 }
 
 // quoteArgsForLog returns a copy of args with system/project property values wrapped in quotes when they contain

--- a/build/gradle.go
+++ b/build/gradle.go
@@ -260,26 +260,27 @@ func (config *gradleRunConfig) GetCmd() *exec.Cmd {
 	}
 	// Add BUILDINFO_PROPFILE system property if extractor properties file exists
 	if config.extractorPropsFile != "" {
-		jvmProp := fmt.Sprintf("-D%s=%s", extractorPropsDir, config.extractorPropsFile)
-		if strings.Contains(config.extractorPropsFile, " ") {
-			jvmProp = fmt.Sprintf("-D%s='%s'", extractorPropsDir, config.extractorPropsFile)
-		}
-		cmd = append(cmd, jvmProp)
+		cmd = append(cmd, fmt.Sprintf("-D%s=%s", extractorPropsDir, config.extractorPropsFile))
 	}
-	cmd = append(cmd, formatCommandProperties(config.tasks)...)
-	config.logger.Info("Running gradle command:", strings.Join(cmd, " "))
+	cmd = append(cmd, config.tasks...)
+	config.logger.Info("Running gradle command:", strings.Join(quoteArgsForLog(cmd), " "))
 	return exec.Command(cmd[0], cmd[1:]...)
 }
 
-func formatCommandProperties(tasks []string) []string {
-	var cmdArgs []string
-	for _, task := range tasks {
-		if isSystemOrProjectProperty(task) {
-			task = quotePropertyIfNeeded(task)
+// quoteArgsForLog returns a copy of args with system/project property values wrapped in quotes when they contain
+// spaces, e.g., -Dkey=val ue => -Dkey='val ue', purely to make the printed command readable.
+// This must never be used to build the actual arguments passed to exec.Command: those are executed directly,
+// without going through a shell, so added quote characters would be passed through literally instead of being
+// stripped, corrupting the property value.
+func quoteArgsForLog(args []string) []string {
+	logArgs := make([]string, len(args))
+	for i, arg := range args {
+		if isSystemOrProjectProperty(arg) {
+			arg = quotePropertyIfNeeded(arg)
 		}
-		cmdArgs = append(cmdArgs, task)
+		logArgs[i] = arg
 	}
-	return cmdArgs
+	return logArgs
 }
 
 func isSystemOrProjectProperty(task string) bool {

--- a/build/gradle.go
+++ b/build/gradle.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/jfrog/build-info-go/utils"
@@ -269,10 +270,16 @@ func (config *gradleRunConfig) GetCmd() *exec.Cmd {
 
 // stripPropertyQuotes removes a matching pair of leading/trailing quote characters (' or ") from system/project
 // property values, e.g., -Dkey='val ue' => -Dkey=val ue.
-// On Windows, cmd.exe and PowerShell don't strip single quotes from arguments the way bash/zsh do, so a value
-// quoted on the command line can still reach this process with the quotes literally part of the string. Left
-// as-is, they'd be passed straight through to Gradle, and end up uploaded to Artifactory as part of the value.
+// This is only needed on Windows: cmd.exe and PowerShell don't strip single quotes from arguments the way
+// bash/zsh do, so a value quoted on the command line can still reach this process with the quotes literally
+// part of the string. Left as-is, they'd be passed straight through to Gradle, and end up uploaded to
+// Artifactory as part of the value. On other platforms the shell has already stripped shell-level quoting by
+// the time this process sees the argument, so any quotes still present were typed deliberately as part of the
+// value and must be left alone.
 func stripPropertyQuotes(tasks []string) []string {
+	if runtime.GOOS != "windows" {
+		return tasks
+	}
 	strippedTasks := make([]string, len(tasks))
 	for i, task := range tasks {
 		if isSystemOrProjectProperty(task) {
@@ -286,6 +293,9 @@ func stripPropertyQuotes(tasks []string) []string {
 // Strips a matching pair of leading/trailing single or double quotes from a system or project property's value.
 func unquoteProperty(task string) string {
 	parts := strings.SplitN(task, "=", 2)
+	if len(parts) < 2 {
+		return task
+	}
 	value := parts[1]
 	if len(value) >= 2 {
 		first, last := value[0], value[len(value)-1]

--- a/build/gradle.go
+++ b/build/gradle.go
@@ -299,8 +299,8 @@ func unquoteProperty(task string) string {
 	return parts[0] + "=" + utils.StripSurroundingQuotes(parts[1])
 }
 
-// quoteArgsForLog returns a copy of args with system/project property values wrapped in quotes when they contain
-// spaces, e.g., -Dkey=val ue => -Dkey='val ue', purely to make the printed command readable.
+// quoteArgsForLog returns a copy of args with system/project property values wrapped in quotes, e.g.,
+// -Dkey=val ue => -Dkey='val ue', purely to make the printed command's property boundaries unambiguous.
 // This must never be used to build the actual arguments passed to exec.Command: those are executed directly,
 // without going through a shell, so added quote characters would be passed through literally instead of being
 // stripped, corrupting the property value.
@@ -308,7 +308,7 @@ func quoteArgsForLog(args []string) []string {
 	logArgs := make([]string, len(args))
 	for i, arg := range args {
 		if isSystemOrProjectProperty(arg) {
-			arg = quotePropertyIfNeeded(arg)
+			arg = quoteProperty(arg)
 		}
 		logArgs[i] = arg
 	}
@@ -320,14 +320,13 @@ func isSystemOrProjectProperty(task string) bool {
 	return hasPropertiesFlag && strings.Contains(task, "=")
 }
 
-// Wraps system or project property value in quotes if its value contain spaces, e.g., -Dkey=val ue => -Dkey='val ue'
-func quotePropertyIfNeeded(task string) string {
+// Wraps a system or project property's value in quotes, e.g., -Dkey=val ue => -Dkey='val ue'
+func quoteProperty(task string) string {
 	parts := strings.SplitN(task, "=", 2)
-	if strings.Contains(parts[1], " ") {
-		return fmt.Sprintf(`%s='%s'`, parts[0], parts[1])
+	if len(parts) < 2 {
+		return task
 	}
-
-	return task
+	return fmt.Sprintf(`%s='%s'`, parts[0], parts[1])
 }
 
 func (config *gradleRunConfig) runCmd(stdout, stderr io.Writer) error {

--- a/build/gradle.go
+++ b/build/gradle.go
@@ -262,9 +262,38 @@ func (config *gradleRunConfig) GetCmd() *exec.Cmd {
 	if config.extractorPropsFile != "" {
 		cmd = append(cmd, fmt.Sprintf("-D%s=%s", extractorPropsDir, config.extractorPropsFile))
 	}
-	cmd = append(cmd, config.tasks...)
+	cmd = append(cmd, stripPropertyQuotes(config.tasks)...)
 	config.logger.Info("Running gradle command:", strings.Join(quoteArgsForLog(cmd), " "))
 	return exec.Command(cmd[0], cmd[1:]...)
+}
+
+// stripPropertyQuotes removes a matching pair of leading/trailing quote characters (' or ") from system/project
+// property values, e.g., -Dkey='val ue' => -Dkey=val ue.
+// On Windows, cmd.exe and PowerShell don't strip single quotes from arguments the way bash/zsh do, so a value
+// quoted on the command line can still reach this process with the quotes literally part of the string. Left
+// as-is, they'd be passed straight through to Gradle, and end up uploaded to Artifactory as part of the value.
+func stripPropertyQuotes(tasks []string) []string {
+	strippedTasks := make([]string, len(tasks))
+	for i, task := range tasks {
+		if isSystemOrProjectProperty(task) {
+			task = unquoteProperty(task)
+		}
+		strippedTasks[i] = task
+	}
+	return strippedTasks
+}
+
+// Strips a matching pair of leading/trailing single or double quotes from a system or project property's value.
+func unquoteProperty(task string) string {
+	parts := strings.SplitN(task, "=", 2)
+	value := parts[1]
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			value = value[1 : len(value)-1]
+		}
+	}
+	return parts[0] + "=" + value
 }
 
 // quoteArgsForLog returns a copy of args with system/project property values wrapped in quotes when they contain

--- a/build/gradle_test.go
+++ b/build/gradle_test.go
@@ -132,16 +132,53 @@ func TestQuoteArgsForLog(t *testing.T) {
 	}
 }
 
+func TestStripPropertyQuotes(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{"clean", "-Dparam=value", "build", "-Pkey=value"},
+			expected: []string{"clean", "-Dparam=value", "build", "-Pkey=value"},
+		},
+		{
+			// Quotes already stripped by the shell, value has no surrounding quotes: left as-is.
+			input:    []string{"-Ddeploy.test.property=test test"},
+			expected: []string{"-Ddeploy.test.property=test test"},
+		},
+		{
+			// Quotes still present in the raw arg (e.g. on Windows, where cmd.exe/PowerShell don't strip
+			// single quotes the way bash/zsh do): stripped.
+			input:    []string{"-Ddeploy.test.property='test test'"},
+			expected: []string{"-Ddeploy.test.property=test test"},
+		},
+		{
+			input:    []string{`-Pkey="value with spaces"`},
+			expected: []string{"-Pkey=value with spaces"},
+		},
+		{
+			// Mismatched quote pair: left as-is.
+			input:    []string{`-Dparam='value"`},
+			expected: []string{`-Dparam='value"`},
+		},
+	}
+
+	for _, test := range tests {
+		result := stripPropertyQuotes(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
 func TestGetCmdDoesNotQuotePropertyValues(t *testing.T) {
 	config := &gradleRunConfig{
 		gradle: "gradle",
-		tasks:  []string{"artifactoryPublish", "-Ddeploy.test.property=test test"},
+		tasks:  []string{"artifactoryPublish", "-Ddeploy.test.property='test test'"},
 		logger: utils.NewDefaultLogger(utils.INFO),
 	}
 
 	cmd := config.GetCmd()
 
-	// exec.Command runs the process directly, without a shell, so a quoted value here would be passed to Gradle
-	// literally as 'test test', quotes included, instead of being stripped.
+	// exec.Command runs the process directly, without a shell, so quotes around the value would be passed to
+	// Gradle literally, instead of being stripped, if we didn't strip them ourselves.
 	assert.Equal(t, []string{"gradle", "artifactoryPublish", "-Ddeploy.test.property=test test"}, cmd.Args)
 }

--- a/build/gradle_test.go
+++ b/build/gradle_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/jfrog/build-info-go/utils"
@@ -132,6 +133,26 @@ func TestQuoteArgsForLog(t *testing.T) {
 	}
 }
 
+func TestUnquoteProperty(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "-Dparam=value", expected: "-Dparam=value"},
+		{input: "-Ddeploy.test.property=test test", expected: "-Ddeploy.test.property=test test"},
+		{input: "-Ddeploy.test.property='test test'", expected: "-Ddeploy.test.property=test test"},
+		{input: `-Pkey="value with spaces"`, expected: "-Pkey=value with spaces"},
+		// Mismatched quote pair: left as-is.
+		{input: `-Dparam='value"`, expected: `-Dparam='value"`},
+		// No '=' at all: returned unchanged rather than panicking on the missing value part.
+		{input: "-Dparam", expected: "-Dparam"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, unquoteProperty(test.input))
+	}
+}
+
 func TestStripPropertyQuotes(t *testing.T) {
 	tests := []struct {
 		input    []string
@@ -148,7 +169,7 @@ func TestStripPropertyQuotes(t *testing.T) {
 		},
 		{
 			// Quotes still present in the raw arg (e.g. on Windows, where cmd.exe/PowerShell don't strip
-			// single quotes the way bash/zsh do): stripped.
+			// single quotes the way bash/zsh do): stripped only on Windows.
 			input:    []string{"-Ddeploy.test.property='test test'"},
 			expected: []string{"-Ddeploy.test.property=test test"},
 		},
@@ -165,7 +186,13 @@ func TestStripPropertyQuotes(t *testing.T) {
 
 	for _, test := range tests {
 		result := stripPropertyQuotes(test.input)
-		assert.Equal(t, test.expected, result)
+		if runtime.GOOS == "windows" {
+			assert.Equal(t, test.expected, result)
+		} else {
+			// On non-Windows platforms the shell already stripped shell-level quoting, so any quotes
+			// still present in the argument were typed deliberately and must be left untouched.
+			assert.Equal(t, test.input, result)
+		}
 	}
 }
 
@@ -178,7 +205,12 @@ func TestGetCmdDoesNotQuotePropertyValues(t *testing.T) {
 
 	cmd := config.GetCmd()
 
+	expectedValue := "'test test'"
+	if runtime.GOOS == "windows" {
+		// Pre-existing quotes are only stripped on Windows, where the shell doesn't strip them itself.
+		expectedValue = "test test"
+	}
 	// exec.Command runs the process directly, without a shell, so quotes around the value would be passed to
 	// Gradle literally, instead of being stripped, if we didn't strip them ourselves.
-	assert.Equal(t, []string{"gradle", "artifactoryPublish", "-Ddeploy.test.property=test test"}, cmd.Args)
+	assert.Equal(t, []string{"gradle", "artifactoryPublish", "-Ddeploy.test.property=" + expectedValue}, cmd.Args)
 }

--- a/build/gradle_test.go
+++ b/build/gradle_test.go
@@ -111,19 +111,19 @@ func TestQuoteArgsForLog(t *testing.T) {
 	}{
 		{
 			input:    []string{"clean", "-Dparam=value", "build", "-Pkey=value"},
-			expected: []string{"clean", "-Dparam=value", "build", "-Pkey=value"},
+			expected: []string{"clean", "-Dparam='value'", "build", "-Pkey='value'"},
 		},
 		{
 			input:    []string{"-Dprop1=value1", "test", "-Pprop2=value2"},
-			expected: []string{"-Dprop1=value1", "test", "-Pprop2=value2"},
+			expected: []string{"-Dprop1='value1'", "test", "-Pprop2='value2'"},
 		},
 		{
 			input:    []string{"-Dparam1=value1 value2", "-Pkey1=value1", "-Dparam2=value2", "-Pkey2=value1 value2"},
-			expected: []string{"-Dparam1='value1 value2'", "-Pkey1=value1", "-Dparam2=value2", "-Pkey2='value1 value2'"},
+			expected: []string{"-Dparam1='value1 value2'", "-Pkey1='value1'", "-Dparam2='value2'", "-Pkey2='value1 value2'"},
 		},
 		{
 			input:    []string{"-Dparam1=value1", "run", "-Psign"},
-			expected: []string{"-Dparam1=value1", "run", "-Psign"},
+			expected: []string{"-Dparam1='value1'", "run", "-Psign"},
 		},
 	}
 

--- a/build/gradle_test.go
+++ b/build/gradle_test.go
@@ -103,7 +103,7 @@ func TestParseGradleVersion(t *testing.T) {
 	}
 }
 
-func TestFormatCommandProperties(t *testing.T) {
+func TestQuoteArgsForLog(t *testing.T) {
 	tests := []struct {
 		input    []string
 		expected []string
@@ -127,7 +127,21 @@ func TestFormatCommandProperties(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := formatCommandProperties(test.input)
+		result := quoteArgsForLog(test.input)
 		assert.ElementsMatch(t, test.expected, result)
 	}
+}
+
+func TestGetCmdDoesNotQuotePropertyValues(t *testing.T) {
+	config := &gradleRunConfig{
+		gradle: "gradle",
+		tasks:  []string{"artifactoryPublish", "-Ddeploy.test.property=test test"},
+		logger: utils.NewDefaultLogger(utils.INFO),
+	}
+
+	cmd := config.GetCmd()
+
+	// exec.Command runs the process directly, without a shell, so a quoted value here would be passed to Gradle
+	// literally as 'test test', quotes included, instead of being stripped.
+	assert.Equal(t, []string{"gradle", "artifactoryPublish", "-Ddeploy.test.property=test test"}, cmd.Args)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,3 +11,17 @@ func GetRegExp(regex string) (*regexp.Regexp, error) {
 	}
 	return regExp, nil
 }
+
+// StripSurroundingQuotes removes a matching pair of leading/trailing single or double quotes from value,
+// e.g., 'val ue' => val ue. If value is too short, or its leading and trailing characters aren't a matching
+// quote pair, it is returned unchanged.
+func StripSurroundingQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	first, last := value[0], value[len(value)-1]
+	if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripSurroundingQuotes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "value", expected: "value"},
+		{input: "test test", expected: "test test"},
+		{input: "'test test'", expected: "test test"},
+		{input: `"value with spaces"`, expected: "value with spaces"},
+		// Mismatched quote pair: left as-is.
+		{input: `'value"`, expected: `'value"`},
+		{input: "'", expected: "'"},
+		{input: "", expected: ""},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, StripSurroundingQuotes(test.input))
+	}
+}


### PR DESCRIPTION
## Summary
- `jf gradle artifactorypublish -Ddeploy.test.property='test test'` uploaded the property value to Artifactory with the surrounding single quotes included (`'test test'` instead of `test test`), causing downstream builds to fail when checking that property.
- Root cause: `quotePropertyIfNeeded()` wrapped `-D`/`-P` property values containing spaces in literal single quotes before building the `exec.Command` argv in `gradleRunConfig.GetCmd()`. Since `exec.Command` execs Gradle directly without a shell, those quote characters are never stripped — they're passed straight through to Gradle as part of the value.
- Fix: quoting is now applied only to the string used for the human-readable "Running gradle command" log line, never to the actual arguments passed to `exec.Command`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./build/... -run 'TestQuoteArgsForLog|TestGetCmdDoesNotQuotePropertyValues|TestParseGradleVersion'` — updated existing test (renamed to `TestQuoteArgsForLog`, now testing the log-only helper) and added `TestGetCmdDoesNotQuotePropertyValues`, which asserts `cmd.Args` from `GetCmd()` contains the raw unquoted property value.

Screenshots:

<img width="1681" height="839" alt="Screenshot 2026-08-25 at 11 15 36 AM" src="https://github.com/user-attachments/assets/969b6b4d-4413-4f63-9ac9-7aff5b204a2b" />


Before fix:
<img width="499" height="184" alt="Screenshot 2026-08-25 at 11 19 19 AM" src="https://github.com/user-attachments/assets/4e4d1206-3c65-4dbd-b2ca-2ec5e2329163" />



After fix:
<img width="1728" height="956" alt="Screenshot 2026-08-25 at 11 16 38 AM" src="https://github.com/user-attachments/assets/3e55c0ce-7667-4b65-b2ed-1d40f63b9998" />


