### PR TITLE
RTECO-1362 - Add strict mode for npm build-info dependency resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bi.exe
 
 # Gradle
 .gradle
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ bi.exe
 
 # Gradle
 .gradle
-.worktrees

--- a/build/npm.go
+++ b/build/npm.go
@@ -19,7 +19,8 @@ type NpmModule struct {
 	executablePath   string
 	npmArgs          []string
 	collectBuildInfo bool
-	failOnMissingDeps bool
+	// Granular strict-mode value for missing dependencies. See NpmTreeDepListParam.FailOnMissingDeps.
+	failOnMissingDeps string
 }
 
 // Pass an empty string for srcPath to find the npm project in the working directory.
@@ -97,11 +98,11 @@ func (nm *NpmModule) SetCollectBuildInfo(collectBuildInfo bool) {
 	nm.collectBuildInfo = collectBuildInfo
 }
 
-func (nm *NpmModule) SetFailOnMissingDeps(failOnMissingDeps bool) {
+func (nm *NpmModule) SetFailOnMissingDeps(failOnMissingDeps string) {
 	nm.failOnMissingDeps = failOnMissingDeps
 }
 
-func (nm *NpmModule) GetFailOnMissingDeps() bool {
+func (nm *NpmModule) GetFailOnMissingDeps() string {
 	return nm.failOnMissingDeps
 }
 

--- a/build/npm.go
+++ b/build/npm.go
@@ -19,6 +19,7 @@ type NpmModule struct {
 	executablePath   string
 	npmArgs          []string
 	collectBuildInfo bool
+	failOnMissingDeps bool
 }
 
 // Pass an empty string for srcPath to find the npm project in the working directory.
@@ -75,7 +76,7 @@ func (nm *NpmModule) CalcDependencies() error {
 		return errors.New("a build name must be provided in order to collect the project's dependencies")
 	}
 	buildInfoDependencies, err := buildutils.CalculateNpmDependenciesList(nm.executablePath, nm.srcPath, nm.name,
-		buildutils.NpmTreeDepListParam{Args: nm.npmArgs}, true, nm.containingBuild.logger)
+		buildutils.NpmTreeDepListParam{Args: nm.npmArgs, FailOnMissingDeps: nm.failOnMissingDeps}, true, nm.containingBuild.logger)
 	if err != nil {
 		return err
 	}
@@ -94,6 +95,14 @@ func (nm *NpmModule) SetNpmArgs(npmArgs []string) {
 
 func (nm *NpmModule) SetCollectBuildInfo(collectBuildInfo bool) {
 	nm.collectBuildInfo = collectBuildInfo
+}
+
+func (nm *NpmModule) SetFailOnMissingDeps(failOnMissingDeps bool) {
+	nm.failOnMissingDeps = failOnMissingDeps
+}
+
+func (nm *NpmModule) GetFailOnMissingDeps() bool {
+	return nm.failOnMissingDeps
 }
 
 func (nm *NpmModule) AddArtifacts(artifacts ...entities.Artifact) error {

--- a/build/npm.go
+++ b/build/npm.go
@@ -19,8 +19,8 @@ type NpmModule struct {
 	executablePath   string
 	npmArgs          []string
 	collectBuildInfo bool
-	// Granular strict-mode value for missing dependencies. See NpmTreeDepListParam.FailOnMissingDeps.
-	failOnMissingDeps string
+	// Granular strict-mode value for uncollected dependencies. See buildutils.CalculateNpmDependenciesList.
+	failOnUncollectedDeps string
 }
 
 // Pass an empty string for srcPath to find the npm project in the working directory.
@@ -77,7 +77,7 @@ func (nm *NpmModule) CalcDependencies() error {
 		return errors.New("a build name must be provided in order to collect the project's dependencies")
 	}
 	buildInfoDependencies, err := buildutils.CalculateNpmDependenciesList(nm.executablePath, nm.srcPath, nm.name,
-		buildutils.NpmTreeDepListParam{Args: nm.npmArgs, FailOnMissingDeps: nm.failOnMissingDeps}, true, nm.containingBuild.logger)
+		buildutils.NpmTreeDepListParam{Args: nm.npmArgs}, true, nm.failOnUncollectedDeps, nm.containingBuild.logger)
 	if err != nil {
 		return err
 	}
@@ -98,12 +98,12 @@ func (nm *NpmModule) SetCollectBuildInfo(collectBuildInfo bool) {
 	nm.collectBuildInfo = collectBuildInfo
 }
 
-func (nm *NpmModule) SetFailOnMissingDeps(failOnMissingDeps string) {
-	nm.failOnMissingDeps = failOnMissingDeps
+func (nm *NpmModule) SetFailOnUncollectedDeps(failOnUncollectedDeps string) {
+	nm.failOnUncollectedDeps = failOnUncollectedDeps
 }
 
-func (nm *NpmModule) GetFailOnMissingDeps() string {
-	return nm.failOnMissingDeps
+func (nm *NpmModule) GetFailOnUncollectedDeps() string {
+	return nm.failOnUncollectedDeps
 }
 
 func (nm *NpmModule) AddArtifacts(artifacts ...entities.Artifact) error {

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -23,6 +23,24 @@ import (
 
 const npmInstallCommand = "install"
 
+// Granular values accepted by the --fail-on-missing-deps flag (NpmTreeDepListParam.FailOnMissingDeps).
+// The flag also accepts a comma-separated combination of the granular values, e.g. "peer,optional,bundle".
+const (
+	failOnMissingDepsAll      = "all"
+	failOnMissingDepsRegular  = "regular"
+	failOnMissingDepsPeer     = "peer"
+	failOnMissingDepsOptional = "optional"
+	failOnMissingDepsBundle   = "bundle"
+)
+
+// Dependency type identifiers used internally in handleMissingDeps
+const (
+	depTypePeer     = "peerDependency"
+	depTypeBundle   = "bundleDependencies"
+	depTypeOptional = "optionalDependencies"
+	depTypeRegular  = "regular"
+)
+
 // CalculateNpmDependenciesList gets an npm project's dependencies.
 func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmParams NpmTreeDepListParam, calculateChecksums bool, log utils.Log) ([]entities.Dependency, error) {
 	if log == nil {
@@ -265,23 +283,13 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 	return version.NewVersion(string(versionData)), nil
 }
 
-// Granular values accepted by the --fail-on-missing-deps flag (NpmTreeDepListParam.FailOnMissingDeps).
-// The flag also accepts a comma-separated combination of the granular values, e.g. "peer,optional,bundle".
-const (
-	failOnMissingDepsAll      = "all"
-	failOnMissingDepsRegular  = "regular"
-	failOnMissingDepsPeer     = "peer"
-	failOnMissingDepsOptional = "optional"
-	failOnMissingDepsBundle   = "bundle"
-)
-
 // depTypeToFlagValue maps the internal dependency-type identifiers (as passed to handleMissingDeps)
 // to the granular flag value that governs them.
 var depTypeToFlagValue = map[string]string{
-	"peerDependency":       failOnMissingDepsPeer,
-	"bundleDependencies":   failOnMissingDepsBundle,
-	"optionalDependencies": failOnMissingDepsOptional,
-	"regular":              failOnMissingDepsRegular,
+	depTypePeer:     failOnMissingDepsPeer,
+	depTypeBundle:   failOnMissingDepsBundle,
+	depTypeOptional: failOnMissingDepsOptional,
+	depTypeRegular:  failOnMissingDepsRegular,
 }
 
 // shouldFailOnMissingDeps returns true if the given dependency type should fail the build,

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -86,7 +86,7 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 				// Seems like the compatibility upgrades may result in dependencies losing their integrity.
 				// We use the integrity to get the dependencies tarball
 				otherMissingDeps = append(otherMissingDeps, dep.Id)
-				log.Debug(fmt.Sprintf("couldn't calculate checksum for %s: %v", dep.Id, err))
+				log.Debug("couldn't calculate checksum for " + dep.Id + ". Error: '" + err.Error() + "'.")
 				continue
 			}
 		}
@@ -97,16 +97,16 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 	// Collect all errors so users see the complete picture of what's missing
 	var allErrors []string
 
-	if err := handleMissingDeps("peerDependency", missingPeerDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypePeer, missingPeerDeps, npmParams.FailOnMissingDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps("bundleDependencies", missingBundledDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeBundle, missingBundledDeps, npmParams.FailOnMissingDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps("optionalDependencies", missingOptionalDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeOptional, missingOptionalDeps, npmParams.FailOnMissingDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps("regular", otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeRegular, otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
 	if len(allErrors) > 0 {
@@ -327,14 +327,8 @@ func handleMissingDeps(depType string, missingDeps []string, failOnMissingDeps s
 
 	if shouldFailOnMissingDeps(depType, failOnMissingDeps) {
 		// When the flag applies to this dependency type, fail with an error.
-		if depType == depTypeRegular {
-			message := fmt.Sprintf("The following dependencies are missing from npm cache and will not be included in the build-info: '%s'", strings.Join(missingDeps, ","))
-			return errors.New(message)
-		} else {
-			// For peer/bundle/optional: use exact format
-			message := fmt.Sprintf("The following %s were not found by 'npm ls' and will not be included in the build-info: '%s'", depType, strings.Join(missingDeps, ","))
-			return errors.New(message)
-		}
+		message := fmt.Sprintf("The following %s are missing in the npm cache and will not be included in the build-info: '%s'", depType, strings.Join(missingDeps, ","))
+		return errors.New(message)
 	}
 
 	// When the flag doesn't apply to this dependency type, use original logging behavior (backward compatible):
@@ -827,4 +821,3 @@ func GetNpmConfigCache(srcPath, executablePath string, npmArgs []string, log uti
 func printMissingDependenciesWarning(dependencyType string, dependencies []string, log utils.Log) {
 	log.Debug("The following dependencies will not be included in the build-info, because the 'npm ls' command did not return their integrity.\nThe reason why the version wasn't returned may be because the package is a '" + dependencyType + "', which was not manually installed.\nIt is therefore okay to skip this dependency: " + strings.Join(dependencies, ","))
 }
-

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -327,7 +327,7 @@ func handleMissingDeps(depType string, missingDeps []string, failOnMissingDeps s
 
 	if shouldFailOnMissingDeps(depType, failOnMissingDeps) {
 		// When the flag applies to this dependency type, fail with an error.
-		if depType == "regular" {
+		if depType == depTypeRegular {
 			message := fmt.Sprintf("The following dependencies are missing from npm cache and will not be included in the build-info: '%s'", strings.Join(missingDeps, ","))
 			return errors.New(message)
 		} else {
@@ -340,10 +340,10 @@ func handleMissingDeps(depType string, missingDeps []string, failOnMissingDeps s
 	// When the flag doesn't apply to this dependency type, use original logging behavior (backward compatible):
 	// - peer/bundled/optional: DEBUG level logging (via printMissingDependenciesWarning)
 	// - regular: WARN level logging
-	if depType == "peerDependency" || depType == "bundleDependencies" || depType == "optionalDependencies" {
+	if depType == depTypePeer || depType == depTypeBundle || depType == depTypeOptional {
 		printMissingDependenciesWarning(depType, missingDeps, log)
 	} else {
-		// For "regular" type: use WARN level (original behavior when flag not set)
+		// For depTypeRegular: use WARN level (original behavior when flag not set)
 		message := fmt.Sprintf("The following dependencies are missing in npm cache and will not be included in the build-info: '%s'", strings.Join(missingDeps, ","))
 		log.Warn(message)
 	}

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -84,8 +84,8 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 	if len(missingOptionalDeps) > 0 {
 		printMissingDependenciesWarning("optionalDependencies", missingOptionalDeps, log)
 	}
-	if len(otherMissingDeps) > 0 {
-		log.Warn("The following dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(otherMissingDeps, ",") + "'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'.")
+	if err := handleOtherMissingDeps(otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
+		return nil, err
 	}
 	return dependenciesList, nil
 }
@@ -257,6 +257,20 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 	return version.NewVersion(string(versionData)), nil
 }
 
+// handleOtherMissingDeps handles missing dependencies based on the strict mode flag.
+// If failOnMissingDeps is true, returns an error. Otherwise, logs a warning.
+func handleOtherMissingDeps(otherMissingDeps []string, failOnMissingDeps bool, log utils.Log) error {
+	if len(otherMissingDeps) == 0 {
+		return nil
+	}
+	message := "The following dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(otherMissingDeps, ",") + "'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'."
+	if failOnMissingDeps {
+		return errors.New(message)
+	}
+	log.Warn(message)
+	return nil
+}
+
 type NpmTreeDepListParam struct {
 	// Required for the 'install' and 'ls' commands that could be triggered during the construction of the NPM dependency tree
 	Args []string
@@ -266,6 +280,8 @@ type NpmTreeDepListParam struct {
 	IgnoreNodeModules bool
 	// Rewrite package-lock.json, if exists.
 	OverwritePackageLock bool
+	// Fail the build if a dependency's tarball can't be resolved from the npm cache
+	FailOnMissingDeps bool
 }
 
 // npm >=7 ls results for a single dependency

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -75,16 +75,17 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 
 		dependenciesList = append(dependenciesList, dep.Dependency)
 	}
-	if len(missingPeerDeps) > 0 {
-		printMissingDependenciesWarning("peerDependency", missingPeerDeps, log)
+	// Apply --fail-on-missing-deps flag to ALL missing dependency types (peer, bundled, optional, other)
+	if err := handleMissingDeps("peerDependency", missingPeerDeps, npmParams.FailOnMissingDeps, log); err != nil {
+		return nil, err
 	}
-	if len(missingBundledDeps) > 0 {
-		printMissingDependenciesWarning("bundleDependencies", missingBundledDeps, log)
+	if err := handleMissingDeps("bundleDependencies", missingBundledDeps, npmParams.FailOnMissingDeps, log); err != nil {
+		return nil, err
 	}
-	if len(missingOptionalDeps) > 0 {
-		printMissingDependenciesWarning("optionalDependencies", missingOptionalDeps, log)
+	if err := handleMissingDeps("optionalDependencies", missingOptionalDeps, npmParams.FailOnMissingDeps, log); err != nil {
+		return nil, err
 	}
-	if err := handleOtherMissingDeps(otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps("other", otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
 		return nil, err
 	}
 	return dependenciesList, nil
@@ -257,17 +258,30 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 	return version.NewVersion(string(versionData)), nil
 }
 
-// handleOtherMissingDeps handles missing dependencies based on the strict mode flag.
-// If failOnMissingDeps is true, returns an error. Otherwise, logs a warning.
-func handleOtherMissingDeps(otherMissingDeps []string, failOnMissingDeps bool, log utils.Log) error {
-	if len(otherMissingDeps) == 0 {
+// handleMissingDeps handles missing dependencies based on the strict mode flag.
+// If failOnMissingDeps is true, returns an error for ANY missing dependency type.
+// Otherwise, logs a warning.
+func handleMissingDeps(depType string, missingDeps []string, failOnMissingDeps bool, log utils.Log) error {
+	if len(missingDeps) == 0 {
 		return nil
 	}
-	message := "The following dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(otherMissingDeps, ",") + "'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'."
+
 	if failOnMissingDeps {
+		// When strict mode is enabled, always fail with an error for any missing dependency type
+		message := "The following " + depType + " dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(missingDeps, ",") + "'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'."
 		return errors.New(message)
 	}
-	log.Warn(message)
+
+	// When strict mode is NOT enabled, use original logging behavior (backward compatible):
+	// - peer/bundled/optional: DEBUG level logging (via printMissingDependenciesWarning)
+	// - other: WARN level logging
+	if depType == "peerDependency" || depType == "bundleDependencies" || depType == "optionalDependencies" {
+		printMissingDependenciesWarning(depType, missingDeps, log)
+	} else {
+		// For "other" type: use WARN level (original behavior)
+		message := "The following " + depType + " dependencies will not be included in the build-info, because they are missing in the npm cache: '" + strings.Join(missingDeps, ",") + "'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'."
+		log.Warn(message)
+	}
 	return nil
 }
 

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -23,14 +23,14 @@ import (
 
 const npmInstallCommand = "install"
 
-// Granular values accepted by the --fail-on-missing-deps flag (NpmTreeDepListParam.FailOnMissingDeps).
+// Granular values accepted by the --fail-on-uncollected-deps flag (passed to CalculateNpmDependenciesList).
 // The flag also accepts a comma-separated combination of the granular values, e.g. "peer,optional,bundle".
 const (
-	failOnMissingDepsAll      = "all"
-	failOnMissingDepsRegular  = "regular"
-	failOnMissingDepsPeer     = "peer"
-	failOnMissingDepsOptional = "optional"
-	failOnMissingDepsBundle   = "bundle"
+	failOnUncollectedDepsAll      = "all"
+	failOnUncollectedDepsRegular  = "regular"
+	failOnUncollectedDepsPeer     = "peer"
+	failOnUncollectedDepsOptional = "optional"
+	failOnUncollectedDepsBundle   = "bundle"
 )
 
 // Dependency type identifiers used internally in handleMissingDeps
@@ -42,7 +42,9 @@ const (
 )
 
 // CalculateNpmDependenciesList gets an npm project's dependencies.
-func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmParams NpmTreeDepListParam, calculateChecksums bool, log utils.Log) ([]entities.Dependency, error) {
+// failOnUncollectedDeps controls whether the build fails when a dependency's integrity/checksum can't be
+// collected for build-info. See the failOnUncollectedDeps* constants above.
+func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmParams NpmTreeDepListParam, calculateChecksums bool, failOnUncollectedDeps string, log utils.Log) ([]entities.Dependency, error) {
 	if log == nil {
 		log = &utils.NullLog{}
 	}
@@ -93,20 +95,20 @@ func CalculateNpmDependenciesList(executablePath, srcPath, moduleId string, npmP
 
 		dependenciesList = append(dependenciesList, dep.Dependency)
 	}
-	// Apply --fail-on-missing-deps flag to ALL missing dependency types
+	// Apply --fail-on-uncollected-deps flag to ALL missing dependency types
 	// Collect all errors so users see the complete picture of what's missing
 	var allErrors []string
 
-	if err := handleMissingDeps(depTypePeer, missingPeerDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypePeer, missingPeerDeps, failOnUncollectedDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps(depTypeBundle, missingBundledDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeBundle, missingBundledDeps, failOnUncollectedDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps(depTypeOptional, missingOptionalDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeOptional, missingOptionalDeps, failOnUncollectedDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
-	if err := handleMissingDeps(depTypeRegular, otherMissingDeps, npmParams.FailOnMissingDeps, log); err != nil {
+	if err := handleMissingDeps(depTypeRegular, otherMissingDeps, failOnUncollectedDeps, log); err != nil {
 		allErrors = append(allErrors, err.Error())
 	}
 	if len(allErrors) > 0 {
@@ -286,23 +288,23 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 // depTypeToFlagValue maps the internal dependency-type identifiers (as passed to handleMissingDeps)
 // to the granular flag value that governs them.
 var depTypeToFlagValue = map[string]string{
-	depTypePeer:     failOnMissingDepsPeer,
-	depTypeBundle:   failOnMissingDepsBundle,
-	depTypeOptional: failOnMissingDepsOptional,
-	depTypeRegular:  failOnMissingDepsRegular,
+	depTypePeer:     failOnUncollectedDepsPeer,
+	depTypeBundle:   failOnUncollectedDepsBundle,
+	depTypeOptional: failOnUncollectedDepsOptional,
+	depTypeRegular:  failOnUncollectedDepsRegular,
 }
 
-// shouldFailOnMissingDeps returns true if the given dependency type should fail the build,
-// according to the granular flagValue supplied to --fail-on-missing-deps.
+// shouldFailOnUncollectedDeps returns true if the given dependency type should fail the build,
+// according to the granular flagValue supplied to --fail-on-uncollected-deps.
 // flagValue can be:
 //   - "" (empty): never fail (backward compatible default)
 //   - "all": fail for every dependency type
 //   - a comma-separated combination of "regular", "peer", "optional", "bundle"
-func shouldFailOnMissingDeps(depType, flagValue string) bool {
+func shouldFailOnUncollectedDeps(depType, flagValue string) bool {
 	if flagValue == "" {
 		return false
 	}
-	if flagValue == failOnMissingDepsAll {
+	if flagValue == failOnUncollectedDepsAll {
 		return true
 	}
 	wantedValue, ok := depTypeToFlagValue[depType]
@@ -317,29 +319,36 @@ func shouldFailOnMissingDeps(depType, flagValue string) bool {
 	return false
 }
 
-// handleMissingDeps handles missing dependencies based on the granular --fail-on-missing-deps flag value.
-// If shouldFailOnMissingDeps(depType, failOnMissingDeps) is true, returns an error for that dependency type.
+// handleMissingDeps handles missing dependencies based on the granular --fail-on-uncollected-deps flag value.
+// If shouldFailOnUncollectedDeps(depType, failOnUncollectedDeps) is true, returns an error for that dependency type.
 // Otherwise, logs a warning.
-func handleMissingDeps(depType string, missingDeps []string, failOnMissingDeps string, log utils.Log) error {
+func handleMissingDeps(depType string, missingDeps []string, failOnUncollectedDeps string, log utils.Log) error {
 	if len(missingDeps) == 0 {
 		return nil
 	}
 
-	if shouldFailOnMissingDeps(depType, failOnMissingDeps) {
-		// When the flag applies to this dependency type, fail with an error.
-		message := fmt.Sprintf("The following %s are missing in the npm cache and will not be included in the build-info: '%s'", depType, strings.Join(missingDeps, ","))
+	if shouldFailOnUncollectedDeps(depType, failOnUncollectedDeps) {
+		var message string
+		switch depType {
+		case depTypePeer, depTypeBundle:
+			message = fmt.Sprintf("The following %s could not be included in the build-info, because 'npm ls' did not return their integrity: '%s'", depType, strings.Join(missingDeps, ","))
+		case depTypeOptional:
+			message = fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", depType, strings.Join(missingDeps, ","))
+		default:
+			// depTypeRegular is an internal bucket name, not a real npm-facing term like the others -
+			// say "dependencies" instead of surfacing it verbatim.
+			message = fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", strings.Join(missingDeps, ","))
+		}
 		return errors.New(message)
 	}
 
-	// When the flag doesn't apply to this dependency type, use original logging behavior (backward compatible):
-	// - peer/bundled/optional: DEBUG level logging (via printMissingDependenciesWarning)
-	// - regular: WARN level logging
-	if depType == depTypePeer || depType == depTypeBundle || depType == depTypeOptional {
+	switch depType {
+	case depTypePeer, depTypeBundle:
 		printMissingDependenciesWarning(depType, missingDeps, log)
-	} else {
-		// For depTypeRegular: use WARN level (original behavior when flag not set)
-		message := fmt.Sprintf("The following dependencies are missing in npm cache and will not be included in the build-info: '%s'", strings.Join(missingDeps, ","))
-		log.Warn(message)
+	case depTypeOptional:
+		log.Debug(fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", depType, strings.Join(missingDeps, ",")))
+	default:
+		log.Warn(fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", strings.Join(missingDeps, ",")))
 	}
 	return nil
 }
@@ -353,11 +362,6 @@ type NpmTreeDepListParam struct {
 	IgnoreNodeModules bool
 	// Rewrite package-lock.json, if exists.
 	OverwritePackageLock bool
-	// Fail the build if a dependency's tarball can't be resolved from the npm cache.
-	// Granular string value: "" (never fail, default), "all" (fail for every missing dependency type),
-	// or a comma-separated combination of "regular", "peer", "optional", "bundle"
-	// (e.g. "peer,optional,bundle") to fail only for the specified types.
-	FailOnMissingDeps string
 }
 
 // npm >=7 ls results for a single dependency

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -41,6 +41,15 @@ const (
 	depTypeRegular  = "regular"
 )
 
+// depTypeToFlagValue maps the internal dependency-type identifiers (as passed to handleMissingDeps)
+// to the granular flag value that governs them.
+var depTypeToFlagValue = map[string]string{
+	depTypePeer:     failOnUncollectedDepsPeer,
+	depTypeBundle:   failOnUncollectedDepsBundle,
+	depTypeOptional: failOnUncollectedDepsOptional,
+	depTypeRegular:  failOnUncollectedDepsRegular,
+}
+
 // CalculateNpmDependenciesList gets an npm project's dependencies.
 // failOnUncollectedDeps controls whether the build fails when a dependency's integrity/checksum can't be
 // collected for build-info. See the failOnUncollectedDeps* constants above.
@@ -283,15 +292,6 @@ func GetNpmVersion(executablePath string, log utils.Log) (*version.Version, erro
 		return nil, err
 	}
 	return version.NewVersion(string(versionData)), nil
-}
-
-// depTypeToFlagValue maps the internal dependency-type identifiers (as passed to handleMissingDeps)
-// to the granular flag value that governs them.
-var depTypeToFlagValue = map[string]string{
-	depTypePeer:     failOnUncollectedDepsPeer,
-	depTypeBundle:   failOnUncollectedDepsBundle,
-	depTypeOptional: failOnUncollectedDepsOptional,
-	depTypeRegular:  failOnUncollectedDepsRegular,
 }
 
 // shouldFailOnUncollectedDeps returns true if the given dependency type should fail the build,

--- a/build/utils/npm.go
+++ b/build/utils/npm.go
@@ -327,28 +327,33 @@ func handleMissingDeps(depType string, missingDeps []string, failOnUncollectedDe
 		return nil
 	}
 
+	// The flag targets this dependency type: throw an error instead of just logging.
 	if shouldFailOnUncollectedDeps(depType, failOnUncollectedDeps) {
 		var message string
 		switch depType {
 		case depTypePeer, depTypeBundle:
 			message = fmt.Sprintf("The following %s could not be included in the build-info, because 'npm ls' did not return their integrity: '%s'", depType, strings.Join(missingDeps, ","))
 		case depTypeOptional:
-			message = fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", depType, strings.Join(missingDeps, ","))
+			message = fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'.", depType, strings.Join(missingDeps, ","))
 		default:
 			// depTypeRegular is an internal bucket name, not a real npm-facing term like the others -
 			// say "dependencies" instead of surfacing it verbatim.
-			message = fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", strings.Join(missingDeps, ","))
+			message = fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'.", strings.Join(missingDeps, ","))
 		}
 		return errors.New(message)
 	}
 
+	// The flag doesn't target this dependency type: log instead of failing.
 	switch depType {
 	case depTypePeer, depTypeBundle:
+		// Legacy DEBUG-level logging, unchanged from before this flag existed.
 		printMissingDependenciesWarning(depType, missingDeps, log)
 	case depTypeOptional:
-		log.Debug(fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", depType, strings.Join(missingDeps, ",")))
+		// DEBUG: an unresolvable optional dependency is expected/benign, not necessarily a problem.
+		log.Debug(fmt.Sprintf("The following %s could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'.", depType, strings.Join(missingDeps, ",")))
 	default:
-		log.Warn(fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'", strings.Join(missingDeps, ",")))
+		// WARN: legacy behavior for an unexpected cache/tarball resolution failure.
+		log.Warn(fmt.Sprintf("The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache: '%s'.\nHint: Try deleting 'node_modules' and/or 'package-lock.json'.", strings.Join(missingDeps, ",")))
 	}
 	return nil
 }

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -766,3 +766,102 @@ func TestNpmIsNonRegistryLocator(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleOtherMissingDeps(t *testing.T) {
+	testcases := []struct {
+		name                string
+		missingDeps         []string
+		failOnMissingDeps   bool
+		expectError         bool
+		expectedErrorPrefix string
+		shouldContainDeps   bool
+	}{
+		{"no missing deps, strict mode off", []string{}, false, false, "", false},
+		{"no missing deps, strict mode on", []string{}, true, false, "", false},
+		{"missing deps, strict mode off", []string{"dep1", "dep2"}, false, false, "", false},
+		{"missing deps, strict mode on", []string{"dep1", "dep2"}, true, true, "The following dependencies will not be included", true},
+		{"single missing dep, strict mode on", []string{"lodash@4.17.21"}, true, true, "The following dependencies will not be included", true},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := handleOtherMissingDeps(tc.missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
+			if tc.expectError {
+				assert.NotNil(t, err, "Expected error but got nil")
+				assert.True(t, strings.HasPrefix(err.Error(), tc.expectedErrorPrefix), "Error message doesn't start with expected prefix")
+				// Verify actual dependency names are in the error message
+				if tc.shouldContainDeps {
+					for _, dep := range tc.missingDeps {
+						assert.Contains(t, err.Error(), dep, "Error should contain the missing dependency name")
+					}
+				}
+			} else {
+				assert.Nil(t, err, "Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCalculateNpmDependenciesListIntegration tests the full flow with FailOnMissingDeps flag
+func TestCalculateNpmDependenciesListIntegration(t *testing.T) {
+	// This integration test verifies that CalculateNpmDependenciesList correctly
+	// calls handleOtherMissingDeps with the flag value, ensuring the threading works end-to-end
+	testcases := []struct {
+		name              string
+		failOnMissingDeps bool
+		hasMissingDeps    bool
+		expectError       bool
+		description       string
+	}{
+		{
+			name:              "strict mode off with missing deps",
+			failOnMissingDeps: false,
+			hasMissingDeps:    true,
+			expectError:       false,
+			description:       "Should succeed with warning when strict mode is off",
+		},
+		{
+			name:              "strict mode on with missing deps",
+			failOnMissingDeps: true,
+			hasMissingDeps:    true,
+			expectError:       true,
+			description:       "Should fail when strict mode is on and deps are missing",
+		},
+		{
+			name:              "strict mode on without missing deps",
+			failOnMissingDeps: true,
+			hasMissingDeps:    false,
+			expectError:       false,
+			description:       "Should succeed when all deps can be resolved",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a minimal test to verify the flag is properly threaded through
+			// This simulates the behavior without requiring full npm project setup
+
+			// Test the flow: flag → params → handler
+			params := NpmTreeDepListParam{
+				Args:                []string{},
+				FailOnMissingDeps:    tc.failOnMissingDeps,
+				IgnoreNodeModules:    false,
+				OverwritePackageLock: false,
+			}
+
+			// Simulate missing deps scenario
+			var missingDeps []string
+			if tc.hasMissingDeps {
+				missingDeps = []string{"missing-pkg@1.0.0"}
+			}
+
+			// Call the handler directly to verify the integration
+			err := handleOtherMissingDeps(missingDeps, params.FailOnMissingDeps, &utils.NullLog{})
+
+			if tc.expectError {
+				assert.NotNil(t, err, tc.description)
+			} else {
+				assert.Nil(t, err, tc.description)
+			}
+		})
+	}
+}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -782,35 +782,35 @@ func TestHandleMissingDeps(t *testing.T) {
 		{"peerDeps: no missing, strict off", "peerDependency", []string{}, "", false, "", false},
 		{"peerDeps: no missing, strict on", "peerDependency", []string{}, "all", false, "", false},
 		{"peerDeps: missing, strict off", "peerDependency", []string{"react@16"}, "", false, "", false},
-		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "The following peerDependency were not found", true},
+		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "The following peerDependency are missing in the npm cache", true},
 
 		// Bundled dependency tests
 		{"bundledDeps: no missing, strict off", "bundleDependencies", []string{}, "", false, "", false},
 		{"bundledDeps: no missing, strict on", "bundleDependencies", []string{}, "all", false, "", false},
 		{"bundledDeps: missing, strict off", "bundleDependencies", []string{"pkg@1.0"}, "", false, "", false},
-		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "The following bundleDependencies were not found", true},
+		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "The following bundleDependencies are missing in the npm cache", true},
 
 		// Optional dependency tests
 		{"optionalDeps: no missing, strict off", "optionalDependencies", []string{}, "", false, "", false},
 		{"optionalDeps: no missing, strict on", "optionalDependencies", []string{}, "all", false, "", false},
 		{"optionalDeps: missing, strict off", "optionalDependencies", []string{"optional@1.0"}, "", false, "", false},
-		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "The following optionalDependencies were not found", true},
+		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "The following optionalDependencies are missing in the npm cache", true},
 
 		// Regular dependency tests
 		{"regularDeps: no missing, strict off", "regular", []string{}, "", false, "", false},
 		{"regularDeps: no missing, strict on", "regular", []string{}, "all", false, "", false},
 		{"regularDeps: missing, strict off", "regular", []string{"express@4.17"}, "", false, "", false},
-		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "The following dependencies are missing from npm cache", true},
+		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "The following regular are missing in the npm cache", true},
 
 		// Multiple deps test
-		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "The following dependencies are missing from npm cache", true},
+		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "The following regular are missing in the npm cache", true},
 
 		// Granular flag tests
-		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "The following peerDependency were not found", true},
+		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "The following peerDependency are missing in the npm cache", true},
 		{"bundledDeps: missing, granular peer only (not matched)", "bundleDependencies", []string{"pkg@1.0"}, "peer", false, "", false},
-		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "The following dependencies are missing from npm cache", true},
-		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "The following optionalDependencies were not found", true},
-		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "The following bundleDependencies were not found", true},
+		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "The following regular are missing in the npm cache", true},
+		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "The following optionalDependencies are missing in the npm cache", true},
+		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "The following bundleDependencies are missing in the npm cache", true},
 		{"regularDeps: missing, granular combo (not matched)", "regular", []string{"express@4.17"}, "peer,optional,bundle", false, "", false},
 	}
 	for _, tc := range testcases {

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -782,35 +782,35 @@ func TestHandleMissingDeps(t *testing.T) {
 		{"peerDeps: no missing, strict off", "peerDependency", []string{}, "", false, "", false},
 		{"peerDeps: no missing, strict on", "peerDependency", []string{}, "all", false, "", false},
 		{"peerDeps: missing, strict off", "peerDependency", []string{"react@16"}, "", false, "", false},
-		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "Missing peerDependency", true},
+		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "The following peerDependency were not found", true},
 
 		// Bundled dependency tests
 		{"bundledDeps: no missing, strict off", "bundleDependencies", []string{}, "", false, "", false},
 		{"bundledDeps: no missing, strict on", "bundleDependencies", []string{}, "all", false, "", false},
 		{"bundledDeps: missing, strict off", "bundleDependencies", []string{"pkg@1.0"}, "", false, "", false},
-		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "Missing bundleDependencies", true},
+		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "The following bundleDependencies were not found", true},
 
 		// Optional dependency tests
 		{"optionalDeps: no missing, strict off", "optionalDependencies", []string{}, "", false, "", false},
 		{"optionalDeps: no missing, strict on", "optionalDependencies", []string{}, "all", false, "", false},
 		{"optionalDeps: missing, strict off", "optionalDependencies", []string{"optional@1.0"}, "", false, "", false},
-		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "Missing optionalDependencies", true},
+		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "The following optionalDependencies were not found", true},
 
 		// Regular dependency tests
 		{"regularDeps: no missing, strict off", "regular", []string{}, "", false, "", false},
 		{"regularDeps: no missing, strict on", "regular", []string{}, "all", false, "", false},
 		{"regularDeps: missing, strict off", "regular", []string{"express@4.17"}, "", false, "", false},
-		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "Missing regular", true},
+		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "The following dependencies are missing from npm cache", true},
 
 		// Multiple deps test
-		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "Missing regular", true},
+		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "The following dependencies are missing from npm cache", true},
 
 		// Granular flag tests
-		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "Missing peerDependency", true},
+		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "The following peerDependency were not found", true},
 		{"bundledDeps: missing, granular peer only (not matched)", "bundleDependencies", []string{"pkg@1.0"}, "peer", false, "", false},
-		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "Missing regular", true},
-		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "Missing optionalDependencies", true},
-		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "Missing bundleDependencies", true},
+		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "The following dependencies are missing from npm cache", true},
+		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "The following optionalDependencies were not found", true},
+		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "The following bundleDependencies were not found", true},
 		{"regularDeps: missing, granular combo (not matched)", "regular", []string{"express@4.17"}, "peer,optional,bundle", false, "", false},
 	}
 	for _, tc := range testcases {

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -767,31 +767,55 @@ func TestNpmIsNonRegistryLocator(t *testing.T) {
 	}
 }
 
-func TestHandleOtherMissingDeps(t *testing.T) {
+// TestHandleMissingDeps tests the generic handler for all missing dependency types
+func TestHandleMissingDeps(t *testing.T) {
 	testcases := []struct {
 		name                string
+		depType             string
 		missingDeps         []string
 		failOnMissingDeps   bool
 		expectError         bool
 		expectedErrorPrefix string
 		shouldContainDeps   bool
 	}{
-		{"no missing deps, strict mode off", []string{}, false, false, "", false},
-		{"no missing deps, strict mode on", []string{}, true, false, "", false},
-		{"missing deps, strict mode off", []string{"dep1", "dep2"}, false, false, "", false},
-		{"missing deps, strict mode on", []string{"dep1", "dep2"}, true, true, "The following dependencies will not be included", true},
-		{"single missing dep, strict mode on", []string{"lodash@4.17.21"}, true, true, "The following dependencies will not be included", true},
+		// Peer dependency tests
+		{"peerDeps: no missing, strict off", "peerDependency", []string{}, false, false, "", false},
+		{"peerDeps: no missing, strict on", "peerDependency", []string{}, true, false, "", false},
+		{"peerDeps: missing, strict off", "peerDependency", []string{"react@16"}, false, false, "", false},
+		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, true, true, "The following peerDependency", true},
+
+		// Bundled dependency tests
+		{"bundledDeps: no missing, strict off", "bundleDependencies", []string{}, false, false, "", false},
+		{"bundledDeps: no missing, strict on", "bundleDependencies", []string{}, true, false, "", false},
+		{"bundledDeps: missing, strict off", "bundleDependencies", []string{"pkg@1.0"}, false, false, "", false},
+		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, true, true, "The following bundleDependencies", true},
+
+		// Optional dependency tests
+		{"optionalDeps: no missing, strict off", "optionalDependencies", []string{}, false, false, "", false},
+		{"optionalDeps: no missing, strict on", "optionalDependencies", []string{}, true, false, "", false},
+		{"optionalDeps: missing, strict off", "optionalDependencies", []string{"optional@1.0"}, false, false, "", false},
+		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, true, true, "The following optionalDependencies", true},
+
+		// Other dependency tests
+		{"otherDeps: no missing, strict off", "other", []string{}, false, false, "", false},
+		{"otherDeps: no missing, strict on", "other", []string{}, true, false, "", false},
+		{"otherDeps: missing, strict off", "other", []string{"express@4.17"}, false, false, "", false},
+		{"otherDeps: missing, strict on", "other", []string{"express@4.17"}, true, true, "The following other", true},
+
+		// Multiple deps test
+		{"multiple deps, strict on", "other", []string{"dep1", "dep2", "dep3"}, true, true, "The following other", true},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := handleOtherMissingDeps(tc.missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
+			err := handleMissingDeps(tc.depType, tc.missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
 			if tc.expectError {
 				assert.NotNil(t, err, "Expected error but got nil")
-				assert.True(t, strings.HasPrefix(err.Error(), tc.expectedErrorPrefix), "Error message doesn't start with expected prefix")
+				assert.True(t, strings.HasPrefix(err.Error(), tc.expectedErrorPrefix),
+					"Error message doesn't start with expected prefix. Got: %v", err.Error())
 				// Verify actual dependency names are in the error message
 				if tc.shouldContainDeps {
 					for _, dep := range tc.missingDeps {
-						assert.Contains(t, err.Error(), dep, "Error should contain the missing dependency name")
+						assert.Contains(t, err.Error(), dep, "Error should contain the missing dependency name: %s", dep)
 					}
 				}
 			} else {
@@ -800,54 +824,99 @@ func TestHandleOtherMissingDeps(t *testing.T) {
 		})
 	}
 }
-
 // TestCalculateNpmDependenciesListIntegration tests the full flow with FailOnMissingDeps flag
+// This verifies that ALL 4 missing dependency types (peer, bundled, optional, other) are now
+// properly checked by the flag, as per the fixed implementation
 func TestCalculateNpmDependenciesListIntegration(t *testing.T) {
-	// This integration test verifies that CalculateNpmDependenciesList correctly
-	// calls handleOtherMissingDeps with the flag value, ensuring the threading works end-to-end
 	testcases := []struct {
 		name              string
+		depType           string
 		failOnMissingDeps bool
 		hasMissingDeps    bool
 		expectError       bool
 		description       string
 	}{
+		// Test all 4 dependency types with flag OFF (should not error)
 		{
-			name:              "strict mode off with missing deps",
+			name:              "peerDeps: strict off with missing",
+			depType:           "peerDependency",
 			failOnMissingDeps: false,
 			hasMissingDeps:    true,
 			expectError:       false,
 			description:       "Should succeed with warning when strict mode is off",
 		},
 		{
-			name:              "strict mode on with missing deps",
+			name:              "bundledDeps: strict off with missing",
+			depType:           "bundleDependencies",
+			failOnMissingDeps: false,
+			hasMissingDeps:    true,
+			expectError:       false,
+			description:       "Should succeed with warning when strict mode is off",
+		},
+		{
+			name:              "optionalDeps: strict off with missing",
+			depType:           "optionalDependencies",
+			failOnMissingDeps: false,
+			hasMissingDeps:    true,
+			expectError:       false,
+			description:       "Should succeed with warning when strict mode is off",
+		},
+		{
+			name:              "otherDeps: strict off with missing",
+			depType:           "other",
+			failOnMissingDeps: false,
+			hasMissingDeps:    true,
+			expectError:       false,
+			description:       "Should succeed with warning when strict mode is off",
+		},
+
+		// Test all 4 dependency types with flag ON (should error if missing)
+		{
+			name:              "peerDeps: strict on with missing",
+			depType:           "peerDependency",
 			failOnMissingDeps: true,
 			hasMissingDeps:    true,
 			expectError:       true,
-			description:       "Should fail when strict mode is on and deps are missing",
+			description:       "Should fail when strict mode is on and peer deps are missing",
 		},
 		{
-			name:              "strict mode on without missing deps",
+			name:              "bundledDeps: strict on with missing",
+			depType:           "bundleDependencies",
+			failOnMissingDeps: true,
+			hasMissingDeps:    true,
+			expectError:       true,
+			description:       "Should fail when strict mode is on and bundled deps are missing",
+		},
+		{
+			name:              "optionalDeps: strict on with missing",
+			depType:           "optionalDependencies",
+			failOnMissingDeps: true,
+			hasMissingDeps:    true,
+			expectError:       true,
+			description:       "Should fail when strict mode is on and optional deps are missing",
+		},
+		{
+			name:              "otherDeps: strict on with missing",
+			depType:           "other",
+			failOnMissingDeps: true,
+			hasMissingDeps:    true,
+			expectError:       true,
+			description:       "Should fail when strict mode is on and other deps are missing",
+		},
+
+		// Test all types with flag ON but no missing deps (should succeed)
+		{
+			name:              "all types: strict on without missing",
+			depType:           "other",
 			failOnMissingDeps: true,
 			hasMissingDeps:    false,
 			expectError:       false,
-			description:       "Should succeed when all deps can be resolved",
+			description:       "Should succeed when all deps can be resolved even in strict mode",
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a minimal test to verify the flag is properly threaded through
-			// This simulates the behavior without requiring full npm project setup
-
-			// Test the flow: flag → params → handler
-			params := NpmTreeDepListParam{
-				Args:                []string{},
-				FailOnMissingDeps:    tc.failOnMissingDeps,
-				IgnoreNodeModules:    false,
-				OverwritePackageLock: false,
-			}
-
 			// Simulate missing deps scenario
 			var missingDeps []string
 			if tc.hasMissingDeps {
@@ -855,10 +924,12 @@ func TestCalculateNpmDependenciesListIntegration(t *testing.T) {
 			}
 
 			// Call the handler directly to verify the integration
-			err := handleOtherMissingDeps(missingDeps, params.FailOnMissingDeps, &utils.NullLog{})
+			// The flag is now checked for ALL dependency types via handleMissingDeps
+			err := handleMissingDeps(tc.depType, missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
 
 			if tc.expectError {
 				assert.NotNil(t, err, tc.description)
+				assert.Contains(t, err.Error(), "missing in the npm cache", "Error message should reference npm cache")
 			} else {
 				assert.Nil(t, err, tc.description)
 			}

--- a/build/utils/npm_test.go
+++ b/build/utils/npm_test.go
@@ -248,7 +248,7 @@ func TestDependencyWithNoIntegrity(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "jfrogtest", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "jfrogtest", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 
 	assert.Greaterf(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -366,7 +366,7 @@ func TestDependenciesTreeDifferentBetweenOKs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "bundle-dependencies", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "bundle-dependencies", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 
 	assert.Greater(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -374,7 +374,7 @@ func TestDependenciesTreeDifferentBetweenOKs(t *testing.T) {
 	// Remove node_modules directory, then calculate dependencies by package-lock.
 	assert.NoError(t, utils.RemoveTempDir(filepath.Join(projectPath, "node_modules")))
 
-	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 
 	// Asserting there is at least one dependency.
@@ -405,7 +405,7 @@ func TestNpmProdFlag(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Calculate dependencies with scope.
-			dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+			dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 			assert.NoError(t, err)
 			assert.Len(t, dependencies, entry.totalDeps)
 		}()
@@ -503,7 +503,7 @@ func TestCalculateNpmDependenciesListWithoutDependencies(t *testing.T) {
 
 	// The actual regression check.
 	dependencies, err := CalculateNpmDependenciesList("npm", tempDir, "no-deps-project",
-		NpmTreeDepListParam{Args: npmArgs}, true, logger)
+		NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 	assert.Empty(t, dependencies)
 }
@@ -517,7 +517,7 @@ func validateDependencies(t *testing.T, projectPath string, npmArgs []string) {
 	assert.NoError(t, err)
 
 	// Calculate dependencies.
-	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	dependencies, err := CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 
 	assert.Greater(t, len(dependencies), 0, "Error: dependencies are not found!")
@@ -525,7 +525,7 @@ func validateDependencies(t *testing.T, projectPath string, npmArgs []string) {
 	// Remove node_modules directory, then calculate dependencies by package-lock.
 	assert.NoError(t, utils.RemoveTempDir(filepath.Join(projectPath, "node_modules")))
 
-	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, logger)
+	dependencies, err = CalculateNpmDependenciesList("npm", projectPath, "build-info-go-tests", NpmTreeDepListParam{Args: npmArgs}, true, "", logger)
 	assert.NoError(t, err)
 
 	// Asserting there is at least one dependency.
@@ -770,52 +770,52 @@ func TestNpmIsNonRegistryLocator(t *testing.T) {
 // TestHandleMissingDeps tests the generic handler for all missing dependency types
 func TestHandleMissingDeps(t *testing.T) {
 	testcases := []struct {
-		name                string
-		depType             string
-		missingDeps         []string
-		failOnMissingDeps   string
-		expectError         bool
-		expectedErrorPrefix string
-		shouldContainDeps   bool
+		name                  string
+		depType               string
+		missingDeps           []string
+		failOnUncollectedDeps string
+		expectError           bool
+		expectedErrorPrefix   string
+		shouldContainDeps     bool
 	}{
 		// Peer dependency tests
 		{"peerDeps: no missing, strict off", "peerDependency", []string{}, "", false, "", false},
 		{"peerDeps: no missing, strict on", "peerDependency", []string{}, "all", false, "", false},
 		{"peerDeps: missing, strict off", "peerDependency", []string{"react@16"}, "", false, "", false},
-		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "The following peerDependency are missing in the npm cache", true},
+		{"peerDeps: missing, strict on", "peerDependency", []string{"react@16"}, "all", true, "The following peerDependency could not be included in the build-info, because 'npm ls' did not return their integrity", true},
 
 		// Bundled dependency tests
 		{"bundledDeps: no missing, strict off", "bundleDependencies", []string{}, "", false, "", false},
 		{"bundledDeps: no missing, strict on", "bundleDependencies", []string{}, "all", false, "", false},
 		{"bundledDeps: missing, strict off", "bundleDependencies", []string{"pkg@1.0"}, "", false, "", false},
-		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "The following bundleDependencies are missing in the npm cache", true},
+		{"bundledDeps: missing, strict on", "bundleDependencies", []string{"pkg@1.0"}, "all", true, "The following bundleDependencies could not be included in the build-info, because 'npm ls' did not return their integrity", true},
 
 		// Optional dependency tests
 		{"optionalDeps: no missing, strict off", "optionalDependencies", []string{}, "", false, "", false},
 		{"optionalDeps: no missing, strict on", "optionalDependencies", []string{}, "all", false, "", false},
 		{"optionalDeps: missing, strict off", "optionalDependencies", []string{"optional@1.0"}, "", false, "", false},
-		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "The following optionalDependencies are missing in the npm cache", true},
+		{"optionalDeps: missing, strict on", "optionalDependencies", []string{"optional@1.0"}, "all", true, "The following optionalDependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache", true},
 
 		// Regular dependency tests
 		{"regularDeps: no missing, strict off", "regular", []string{}, "", false, "", false},
 		{"regularDeps: no missing, strict on", "regular", []string{}, "all", false, "", false},
 		{"regularDeps: missing, strict off", "regular", []string{"express@4.17"}, "", false, "", false},
-		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "The following regular are missing in the npm cache", true},
+		{"regularDeps: missing, strict on", "regular", []string{"express@4.17"}, "all", true, "The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache", true},
 
 		// Multiple deps test
-		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "The following regular are missing in the npm cache", true},
+		{"multiple deps, strict on", "regular", []string{"dep1", "dep2", "dep3"}, "all", true, "The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache", true},
 
 		// Granular flag tests
-		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "The following peerDependency are missing in the npm cache", true},
+		{"peerDeps: missing, granular peer only", "peerDependency", []string{"react@16"}, "peer", true, "The following peerDependency could not be included in the build-info, because 'npm ls' did not return their integrity", true},
 		{"bundledDeps: missing, granular peer only (not matched)", "bundleDependencies", []string{"pkg@1.0"}, "peer", false, "", false},
-		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "The following regular are missing in the npm cache", true},
-		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "The following optionalDependencies are missing in the npm cache", true},
-		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "The following bundleDependencies are missing in the npm cache", true},
+		{"regularDeps: missing, granular regular", "regular", []string{"express@4.17"}, "regular", true, "The following dependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache", true},
+		{"optionalDeps: missing, granular combo", "optionalDependencies", []string{"optional@1.0"}, "peer,optional,bundle", true, "The following optionalDependencies could not be included in the build-info, because their tarball could not be resolved from the npm cache", true},
+		{"bundledDeps: missing, granular combo", "bundleDependencies", []string{"pkg@1.0"}, "peer,optional,bundle", true, "The following bundleDependencies could not be included in the build-info, because 'npm ls' did not return their integrity", true},
 		{"regularDeps: missing, granular combo (not matched)", "regular", []string{"express@4.17"}, "peer,optional,bundle", false, "", false},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := handleMissingDeps(tc.depType, tc.missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
+			err := handleMissingDeps(tc.depType, tc.missingDeps, tc.failOnUncollectedDeps, &utils.NullLog{})
 			if tc.expectError {
 				assert.NotNil(t, err, "Expected error but got nil")
 				assert.True(t, strings.HasPrefix(err.Error(), tc.expectedErrorPrefix),
@@ -833,112 +833,112 @@ func TestHandleMissingDeps(t *testing.T) {
 	}
 }
 
-// TestCalculateNpmDependenciesListIntegration tests the full flow with FailOnMissingDeps flag
+// TestCalculateNpmDependenciesListIntegration tests the full flow with the failOnUncollectedDeps flag
 // This verifies that ALL 4 missing dependency types (peer, bundled, optional, other) are now
 // properly checked by the flag, as per the fixed implementation
 func TestCalculateNpmDependenciesListIntegration(t *testing.T) {
 	testcases := []struct {
-		name              string
-		depType           string
-		failOnMissingDeps string
-		hasMissingDeps    bool
-		expectError       bool
-		description       string
+		name                  string
+		depType               string
+		failOnUncollectedDeps string
+		hasMissingDeps        bool
+		expectError           bool
+		description           string
 	}{
 		// Test all 4 dependency types with flag OFF (should not error)
 		{
-			name:              "peerDeps: strict off with missing",
-			depType:           "peerDependency",
-			failOnMissingDeps: "",
-			hasMissingDeps:    true,
-			expectError:       false,
-			description:       "Should succeed with warning when strict mode is off",
+			name:                  "peerDeps: strict off with missing",
+			depType:               "peerDependency",
+			failOnUncollectedDeps: "",
+			hasMissingDeps:        true,
+			expectError:           false,
+			description:           "Should succeed with warning when strict mode is off",
 		},
 		{
-			name:              "bundledDeps: strict off with missing",
-			depType:           "bundleDependencies",
-			failOnMissingDeps: "",
-			hasMissingDeps:    true,
-			expectError:       false,
-			description:       "Should succeed with warning when strict mode is off",
+			name:                  "bundledDeps: strict off with missing",
+			depType:               "bundleDependencies",
+			failOnUncollectedDeps: "",
+			hasMissingDeps:        true,
+			expectError:           false,
+			description:           "Should succeed with warning when strict mode is off",
 		},
 		{
-			name:              "optionalDeps: strict off with missing",
-			depType:           "optionalDependencies",
-			failOnMissingDeps: "",
-			hasMissingDeps:    true,
-			expectError:       false,
-			description:       "Should succeed with warning when strict mode is off",
+			name:                  "optionalDeps: strict off with missing",
+			depType:               "optionalDependencies",
+			failOnUncollectedDeps: "",
+			hasMissingDeps:        true,
+			expectError:           false,
+			description:           "Should succeed with warning when strict mode is off",
 		},
 		{
-			name:              "regularDeps: strict off with missing",
-			depType:           "regular",
-			failOnMissingDeps: "",
-			hasMissingDeps:    true,
-			expectError:       false,
-			description:       "Should succeed with warning when strict mode is off",
+			name:                  "regularDeps: strict off with missing",
+			depType:               "regular",
+			failOnUncollectedDeps: "",
+			hasMissingDeps:        true,
+			expectError:           false,
+			description:           "Should succeed with warning when strict mode is off",
 		},
 
 		// Test all 4 dependency types with flag ON (should error if missing)
 		{
-			name:              "peerDeps: strict on with missing",
-			depType:           "peerDependency",
-			failOnMissingDeps: "all",
-			hasMissingDeps:    true,
-			expectError:       true,
-			description:       "Should fail when strict mode is on and peer deps are missing",
+			name:                  "peerDeps: strict on with missing",
+			depType:               "peerDependency",
+			failOnUncollectedDeps: "all",
+			hasMissingDeps:        true,
+			expectError:           true,
+			description:           "Should fail when strict mode is on and peer deps are missing",
 		},
 		{
-			name:              "bundledDeps: strict on with missing",
-			depType:           "bundleDependencies",
-			failOnMissingDeps: "all",
-			hasMissingDeps:    true,
-			expectError:       true,
-			description:       "Should fail when strict mode is on and bundled deps are missing",
+			name:                  "bundledDeps: strict on with missing",
+			depType:               "bundleDependencies",
+			failOnUncollectedDeps: "all",
+			hasMissingDeps:        true,
+			expectError:           true,
+			description:           "Should fail when strict mode is on and bundled deps are missing",
 		},
 		{
-			name:              "optionalDeps: strict on with missing",
-			depType:           "optionalDependencies",
-			failOnMissingDeps: "all",
-			hasMissingDeps:    true,
-			expectError:       true,
-			description:       "Should fail when strict mode is on and optional deps are missing",
+			name:                  "optionalDeps: strict on with missing",
+			depType:               "optionalDependencies",
+			failOnUncollectedDeps: "all",
+			hasMissingDeps:        true,
+			expectError:           true,
+			description:           "Should fail when strict mode is on and optional deps are missing",
 		},
 		{
-			name:              "regularDeps: strict on with missing",
-			depType:           "regular",
-			failOnMissingDeps: "all",
-			hasMissingDeps:    true,
-			expectError:       true,
-			description:       "Should fail when strict mode is on and regular deps are missing",
+			name:                  "regularDeps: strict on with missing",
+			depType:               "regular",
+			failOnUncollectedDeps: "all",
+			hasMissingDeps:        true,
+			expectError:           true,
+			description:           "Should fail when strict mode is on and regular deps are missing",
 		},
 
 		// Test all types with flag ON but no missing deps (should succeed)
 		{
-			name:              "all types: strict on without missing",
-			depType:           "regular",
-			failOnMissingDeps: "all",
-			hasMissingDeps:    false,
-			expectError:       false,
-			description:       "Should succeed when all deps can be resolved even in strict mode",
+			name:                  "all types: strict on without missing",
+			depType:               "regular",
+			failOnUncollectedDeps: "all",
+			hasMissingDeps:        false,
+			expectError:           false,
+			description:           "Should succeed when all deps can be resolved even in strict mode",
 		},
 
 		// Granular flag tests within the integration test
 		{
-			name:              "peerDeps: granular peer with missing",
-			depType:           "peerDependency",
-			failOnMissingDeps: "peer",
-			hasMissingDeps:    true,
-			expectError:       true,
-			description:       "Should fail when granular flag targets peer and peer deps are missing",
+			name:                  "peerDeps: granular peer with missing",
+			depType:               "peerDependency",
+			failOnUncollectedDeps: "peer",
+			hasMissingDeps:        true,
+			expectError:           true,
+			description:           "Should fail when granular flag targets peer and peer deps are missing",
 		},
 		{
-			name:              "bundledDeps: granular peer with missing (not matched)",
-			depType:           "bundleDependencies",
-			failOnMissingDeps: "peer",
-			hasMissingDeps:    true,
-			expectError:       false,
-			description:       "Should succeed with warning when granular flag doesn't target this dependency type",
+			name:                  "bundledDeps: granular peer with missing (not matched)",
+			depType:               "bundleDependencies",
+			failOnUncollectedDeps: "peer",
+			hasMissingDeps:        true,
+			expectError:           false,
+			description:           "Should succeed with warning when granular flag doesn't target this dependency type",
 		},
 	}
 
@@ -952,11 +952,11 @@ func TestCalculateNpmDependenciesListIntegration(t *testing.T) {
 
 			// Call the handler directly to verify the integration
 			// The flag is now checked for ALL dependency types via handleMissingDeps
-			err := handleMissingDeps(tc.depType, missingDeps, tc.failOnMissingDeps, &utils.NullLog{})
+			err := handleMissingDeps(tc.depType, missingDeps, tc.failOnUncollectedDeps, &utils.NullLog{})
 
 			if tc.expectError {
 				assert.NotNil(t, err, tc.description)
-				assert.Contains(t, err.Error(), "missing in the npm cache", "Error message should reference npm cache")
+				assert.Contains(t, err.Error(), "could not be included in the build-info", "Error message should explain why the dependency was dropped")
 			} else {
 				assert.Nil(t, err, tc.description)
 			}


### PR DESCRIPTION
## Summary
Add a granular `failOnUncollectedDeps` policy to npm build-info collection. When set, collection fails if a dependency’s integrity/checksum cannot be included in build-info, instead of only logging and publishing a partial module.
- New `CalculateNpmDependenciesList` argument (not part of `NpmTreeDepListParam`): `""` (never fail), `"all"`, or a comma-separated list of `regular`, `peer`, `optional`, `bundle`.
- `handleMissingDeps` applies that policy to all four buckets. Errors are joined so the user sees every missing type at once.
- Without the flag, behavior is unchanged: command succeeds, partial build-info is saved. Peer/bundle still Debug via `printMissingDependenciesWarning`. Optional is Debug and regular is Warn, both using the legacy “will not be included … missing in the npm cache” wording plus the `node_modules` / `package-lock.json` hint (optional’s old “npm ls did not return integrity” text was wrong — optional fails on cache/checksum, same as regular).
- With the flag, optional/regular errors use that same cache sentence; peer/bundle errors still say `npm ls` did not return integrity.


- [x] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Appropriate label is added to the PR for auto generate release notes.
-----
