### PR TITLE
RTECO-1424: Guard -DuniqueVersion passthrough to the Maven extractor

### DIFF
--- a/build/maven_test.go
+++ b/build/maven_test.go
@@ -212,3 +212,26 @@ func TestCommandWithRootProjectDir(t *testing.T) {
 	assert.Contains(t, cmd.Args, "myMavenOpt2")
 	assert.Contains(t, cmd.Args, "-Dmaven.multiModuleProjectDirectory=myRootProjectDir")
 }
+
+// The Maven extractor decides unique-vs-non-unique snapshots from the -DuniqueVersion system property.
+// jf mvn does not translate that flag; it forwards the user's raw goals to the extractor's Maven command
+// line, where Maven turns -DuniqueVersion into a session user property. This test guards that passthrough.
+func TestUniqueVersionGoalPassedThrough(t *testing.T) {
+	for _, uniqueVersionArg := range []string{"-DuniqueVersion=false", "-DuniqueVersion=true"} {
+		t.Run(uniqueVersionArg, func(t *testing.T) {
+			mvnc := &mvnRunConfig{
+				java:                "myJava",
+				plexusClassworlds:   "myPlexus",
+				cleassworldsConfig:  "myCleassworldsConfig",
+				mavenHome:           "myMavenHome",
+				pluginDependencies:  "myPluginDependencies",
+				workspace:           "myWorkspace",
+				goals:               []string{"deploy", uniqueVersionArg},
+				buildInfoProperties: "myBuildInfoProperties",
+			}
+			cmd := mvnc.GetCmd()
+			assert.Contains(t, cmd.Args, "deploy")
+			assert.Contains(t, cmd.Args, uniqueVersionArg)
+		})
+	}
+}


### PR DESCRIPTION
### Context
The unique-snapshot fix for the extractor flow lives in the Maven Build Info Extractor: **jfrog/build-info#862**. That extractor reads `-DuniqueVersion` from Maven's session user properties and defaults snapshots to unique timestamped names (matching Maven 3).

### This PR
`jf mvn` does not translate `-DuniqueVersion`; it forwards the user's raw goals to the extractor's Maven command line, where Maven turns `-DuniqueVersion` into a session user property. `TestUniqueVersionGoalPassedThrough` locks in that contract so a future change to goal handling cannot silently drop the flag before it reaches the extractor.

No production code changes — test only.

### Follow-up (separate commit, do not merge until the extractor is released)
Bump `MavenExtractorDependencyVersion` in `build/maven.go` from `2.43.9` to the release containing jfrog/build-info#862. That version string is what makes `jf mvn` download and use the fixed jar; it is the only remaining change needed for the fix to reach end users, and it carries no behavior of its own.
