### PR TITLE
RTECO-1782: warn on externally-resolved deps and dedupe requestedBy paths

### DIFF
--- a/build/utils/dotnet/dependencies/assetsjson.go
+++ b/build/utils/dotnet/dependencies/assetsjson.go
@@ -151,12 +151,18 @@ func (assets *assets) getAllDependencies(log utils.Log) (map[string]*buildinfo.D
 	// NUGET_PACKAGES path or the SDK fallback folder); checksums are added when the file is
 	// available. This prevents dependencies from being silently dropped (jfrog-cli#600, #1796).
 	privateDeps := assets.getPrivateDependencyNames()
+	var externallyResolved []string
 	for dependencyId, library := range assets.Libraries {
 		if library.Type == "project" {
 			continue
 		}
 		dependencyKey := strings.ToLower(getDependencyIdForBuildInfo(dependencyId))
 		dependency := &buildinfo.Dependency{Id: getDependencyIdForBuildInfo(dependencyId), Type: nupkgType}
+
+		if source := localResolutionSource(packagesPath, library); source != "" {
+			externallyResolved = append(externallyResolved,
+				fmt.Sprintf("%s (source: %s)", getDependencyIdForBuildInfo(dependencyId), source))
+		}
 
 		checksum, err := assets.dependencyChecksum(packagesPath, library, log)
 		if err != nil {
@@ -177,7 +183,68 @@ func (assets *assets) getAllDependencies(log utils.Log) (map[string]*buildinfo.D
 		dependencies[dependencyKey] = dependency
 	}
 
+	warnExternallyResolved(externallyResolved, log)
+
 	return dependencies, nil
+}
+
+// warnExternallyResolved emits a single aggregated warning naming every dependency that NuGet
+// satisfied from a local folder rather than through the configured (Artifactory) feed. One
+// warning is used rather than one per package so a large graph does not bury the log.
+func warnExternallyResolved(externallyResolved []string, log utils.Log) {
+	if len(externallyResolved) == 0 || log == nil {
+		return
+	}
+	sort.Strings(externallyResolved)
+	subject, verb := "dependency was", "dependencies were"
+	if len(externallyResolved) > 1 {
+		subject = verb
+	}
+	log.Warn(fmt.Sprintf(
+		"%d %s resolved outside Artifactory and therefore not curated or scanned:\n  %s\n"+
+			"Such packages are satisfied from a local folder (for example the .NET SDK's FSharp/library-packs "+
+			"or a NuGetFallbackFolder), so no request reached Artifactory and no repository path will be "+
+			"recorded for them in build-info. To route them through Artifactory, build with "+
+			"-p:DisableImplicitLibraryPacksFolder=true (F# projects) or clear the fallback folder.",
+		len(externallyResolved),
+		subject,
+		strings.Join(externallyResolved, "\n  ")))
+}
+
+// nupkgMetadataFileName is written by NuGet next to every extracted package and records the
+// source the package was actually restored from.
+const nupkgMetadataFileName = ".nupkg.metadata"
+
+// localResolutionSource returns the source recorded in a package's .nupkg.metadata when that
+// source is a local directory rather than a remote feed, and "" otherwise (including when the
+// metadata file is missing or unreadable — absence of evidence is not reported as a bypass).
+//
+// Only non-HTTP sources are reported. A remote source cannot be attributed here because this
+// layer does not know which feed URL was injected, so flagging remote URLs would risk false
+// positives; a local folder, by contrast, is unambiguously a path that never reached Artifactory.
+func localResolutionSource(packagesPath string, library library) string {
+	if packagesPath == "" || library.Path == "" {
+		return ""
+	}
+	metadataPath := filepath.Join(packagesPath, library.Path, nupkgMetadataFileName)
+	rel, err := filepath.Rel(packagesPath, metadataPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	content, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return ""
+	}
+	var metadata struct {
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(content, &metadata); err != nil || metadata.Source == "" {
+		return ""
+	}
+	if strings.HasPrefix(metadata.Source, "http://") || strings.HasPrefix(metadata.Source, "https://") {
+		return ""
+	}
+	return metadata.Source
 }
 
 const (

--- a/build/utils/dotnet/dependencies/assetsjson_test.go
+++ b/build/utils/dotnet/dependencies/assetsjson_test.go
@@ -455,3 +455,64 @@ func TestGetChildrenMapBracketRangeVersion(t *testing.T) {
 	// Both children must resolve to the library entry's version, NOT the declared constraint string.
 	assert.ElementsMatch(t, []string{"jquery:3.0.0", "popper.js:1.12.9"}, result["bootstrap:4.0.0"])
 }
+
+// TestLocalResolutionSource covers the detection behind the "resolved outside Artifactory"
+// warning: a package restored from a local folder (the .NET SDK's FSharp/library-packs, a
+// NuGetFallbackFolder) never reaches Artifactory, so it is neither curated nor scanned and
+// gets no repo path in build-info.
+func TestLocalResolutionSource(t *testing.T) {
+	writeMetadata := func(t *testing.T, root, pkgPath, body string) {
+		t.Helper()
+		dir := filepath.Join(root, pkgPath)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, nupkgMetadataFileName), []byte(body), 0o600))
+	}
+
+	t.Run("local folder source is reported", func(t *testing.T) {
+		root := t.TempDir()
+		writeMetadata(t, root, "fsharp.core/10.1.302",
+			`{"version":2,"contentHash":"abc","source":"/usr/local/share/dotnet/sdk/10.0.302/FSharp/library-packs"}`)
+		assert.Equal(t, "/usr/local/share/dotnet/sdk/10.0.302/FSharp/library-packs",
+			localResolutionSource(root, library{Path: "fsharp.core/10.1.302"}))
+	})
+
+	t.Run("https feed source is not reported", func(t *testing.T) {
+		root := t.TempDir()
+		writeMetadata(t, root, "newtonsoft.json/13.0.3",
+			`{"version":2,"source":"https://acme.jfrog.io/artifactory/api/nuget/v3/nuget-virtual/index.json"}`)
+		assert.Empty(t, localResolutionSource(root, library{Path: "newtonsoft.json/13.0.3"}))
+	})
+
+	t.Run("http feed source is not reported", func(t *testing.T) {
+		root := t.TempDir()
+		writeMetadata(t, root, "pkg/1.0.0", `{"version":2,"source":"http://internal/nuget/index.json"}`)
+		assert.Empty(t, localResolutionSource(root, library{Path: "pkg/1.0.0"}))
+	})
+
+	// Absence of evidence must not be reported as a bypass.
+	t.Run("missing metadata file is not reported", func(t *testing.T) {
+		assert.Empty(t, localResolutionSource(t.TempDir(), library{Path: "pkg/1.0.0"}))
+	})
+
+	t.Run("malformed metadata is not reported", func(t *testing.T) {
+		root := t.TempDir()
+		writeMetadata(t, root, "pkg/1.0.0", `not json`)
+		assert.Empty(t, localResolutionSource(root, library{Path: "pkg/1.0.0"}))
+	})
+
+	t.Run("empty source is not reported", func(t *testing.T) {
+		root := t.TempDir()
+		writeMetadata(t, root, "pkg/1.0.0", `{"version":2,"source":""}`)
+		assert.Empty(t, localResolutionSource(root, library{Path: "pkg/1.0.0"}))
+	})
+
+	t.Run("empty inputs are handled", func(t *testing.T) {
+		assert.Empty(t, localResolutionSource("", library{Path: "pkg/1.0.0"}))
+		assert.Empty(t, localResolutionSource(t.TempDir(), library{}))
+	})
+
+	// A library path escaping the packages directory must not be followed.
+	t.Run("path traversal is rejected", func(t *testing.T) {
+		assert.Empty(t, localResolutionSource(t.TempDir(), library{Path: "../../etc"}))
+	})
+}

--- a/build/utils/dotnet/solution/solution.go
+++ b/build/utils/dotnet/solution/solution.go
@@ -193,6 +193,34 @@ func projectVersion(currProject project.Project) string {
 	return ""
 }
 
+// dedupeRequestedByParent keeps a single representative path per distinct immediate parent
+// (path[0]), preferring the shortest path for each. Order of first appearance is preserved so
+// output stays deterministic. Empty paths are dropped.
+func dedupeRequestedByParent(paths [][]string) [][]string {
+	if len(paths) < 2 {
+		return paths
+	}
+	indexByParent := make(map[string]int, len(paths))
+	var deduped [][]string
+	for _, path := range paths {
+		if len(path) == 0 {
+			continue
+		}
+		existing, seen := indexByParent[path[0]]
+		if !seen {
+			indexByParent[path[0]] = len(deduped)
+			deduped = append(deduped, path)
+			continue
+		}
+		// Same immediate parent already recorded - keep whichever chain is shorter, so the
+		// retained path stays the most direct explanation of how this package was pulled in.
+		if len(path) < len(deduped[existing]) {
+			deduped[existing] = path
+		}
+	}
+	return deduped
+}
+
 // Populate requested by field for the input dependencies.
 // parentDependency - The parent dependency
 // dependenciesMap  - The input dependencies map
@@ -214,6 +242,13 @@ func populateRequestedBy(parentDependency buildinfo.Dependency, dependenciesMap 
 			}
 			// Update RequestedBy field from parent's RequestedBy.
 			childDep.UpdateRequestedBy(parentDependency.Id, parentDependency.RequestedBy)
+			// Consumers of requestedBy (Xray's SBOM builder) only read path[0] of each path -
+			// the immediate parent - and reassemble the full tree from every package's own
+			// entry. Keeping several paths that share a path[0] therefore adds no information,
+			// but it does consume the RequestedByMaxLength budget, which can push out a path
+			// carrying a parent not recorded anywhere else and silently drop an SBOM edge.
+			// Collapse to one path per distinct immediate parent, shortest first.
+			childDep.RequestedBy = dedupeRequestedByParent(childDep.RequestedBy)
 
 			// Run recursive call on child dependencies
 			populateRequestedBy(*childDep, dependenciesMap, childrenMap)

--- a/build/utils/dotnet/solution/solution_test.go
+++ b/build/utils/dotnet/solution/solution_test.go
@@ -262,10 +262,14 @@ func TestPopulateRequestedByDeterministic(t *testing.T) {
 		assert.Equal(t, firstResult, result, "Run %d produced different results", i)
 	}
 
-	// Verify expected paths
+	// Verify expected paths.
+	// depD is reached only through depC, so both of the chains that used to be emitted here
+	// ({depC,depA,TestModule} and {depC,depB,TestModule}) share the same immediate parent and
+	// yield the identical SBOM edge depC->depD. Only one is kept now; the depA/depB split is
+	// not lost, it lives on depC's own entry where it actually carries an edge - see
+	// TestDedupeRequestedByPreservesDistinctParents. See also dedupeRequestedByParent.
 	expected := [][]string{
 		{"depC:1", "depA:1", "TestModule"},
-		{"depC:1", "depB:1", "TestModule"},
 	}
 	assert.Equal(t, expected, firstResult)
 }
@@ -763,5 +767,66 @@ func TestDependenciesSourcesAndProjectsPathExist(t *testing.T) {
 		if err == nil {
 			assert.False(t, sol.DependenciesSourcesAndProjectsPathExist())
 		}
+	})
+}
+
+// TestDedupeRequestedByPreservesDistinctParents pins the property the dedupe relies on:
+// collapsing paths that share an immediate parent must never drop a distinct parent, because
+// each distinct path[0] is exactly one edge in Xray's SBOM dependency graph.
+func TestDedupeRequestedByPreservesDistinctParents(t *testing.T) {
+	t.Run("same parent collapses to the shortest chain", func(t *testing.T) {
+		in := [][]string{
+			{"depC:1", "depA:1", "TestModule"},
+			{"depC:1", "depB:1", "TestModule"},
+		}
+		assert.Equal(t, [][]string{{"depC:1", "depA:1", "TestModule"}}, dedupeRequestedByParent(in))
+	})
+
+	t.Run("distinct parents are all kept", func(t *testing.T) {
+		in := [][]string{
+			{"depA:1", "TestModule"},
+			{"depB:1", "TestModule"},
+		}
+		assert.Equal(t, in, dedupeRequestedByParent(in))
+	})
+
+	t.Run("shortest chain wins regardless of order", func(t *testing.T) {
+		in := [][]string{
+			{"depC:1", "depA:1", "TestModule"},
+			{"depC:1", "TestModule"},
+		}
+		assert.Equal(t, [][]string{{"depC:1", "TestModule"}}, dedupeRequestedByParent(in))
+	})
+
+	t.Run("empty paths are dropped", func(t *testing.T) {
+		in := [][]string{{}, {"depA:1"}}
+		assert.Equal(t, [][]string{{"depA:1"}}, dedupeRequestedByParent(in))
+	})
+
+	// A direct dependency's single-element {moduleId} path is what attaches it to the SBOM
+	// graph's root: Xray builds its id->entry map from the module id plus every dependency id,
+	// then turns each path[0] into an edge. Drop that path and the dependency becomes an
+	// orphan node with no edge to the module. The dedupe must never remove it - being the
+	// shortest possible path, it always wins its parent slot.
+	t.Run("direct dependency keeps its module path", func(t *testing.T) {
+		in := [][]string{{"TestModule"}}
+		assert.Equal(t, in, dedupeRequestedByParent(in))
+	})
+
+	t.Run("module path survives alongside transitive paths", func(t *testing.T) {
+		in := [][]string{
+			{"TestModule"},
+			{"depB:1", "TestModule"},
+			{"depC:1", "depB:1", "TestModule"},
+		}
+		assert.Equal(t, in, dedupeRequestedByParent(in))
+	})
+
+	t.Run("module path is never displaced by a longer same-parent path", func(t *testing.T) {
+		in := [][]string{
+			{"TestModule", "somethingElse"},
+			{"TestModule"},
+		}
+		assert.Equal(t, [][]string{{"TestModule"}}, dedupeRequestedByParent(in))
 	})
 }


### PR DESCRIPTION
## What

Two dotnet FlexPack build-info fixes, both found during the RTECO-1782 bug hunt.

### 1. Warn when a dependency is resolved outside Artifactory

NuGet records the source it restored each package from in `.nupkg.metadata`. When that source is a **local folder** rather than the injected Artifactory feed, the package never reaches Artifactory — so it is neither curated nor scanned, and gets no repository path in build-info.

This happens routinely and silently. Every F# project resolves `FSharp.Core` from the SDK's `FSharp/library-packs`:

```jsonc
// fsharp.core/10.1.302/.nupkg.metadata
"source": "/usr/local/share/dotnet/sdk/10.0.302/FSharp/library-packs"

// newtonsoft.json/13.0.3/.nupkg.metadata
"source": "https://acme.jfrog.io/artifactory/api/nuget/v3/nuget-virtual/index.json"
```

The UI showed `No path found (externally resolved or deleted/overwritten)` with no explanation. The collector's checksum was correct all along — it hashed the real resolved file. What was missing was any signal that the package bypassed Artifactory.

Now one aggregated warning names them:

```
[Warn] 1 dependency was resolved outside Artifactory and therefore not curated or scanned:
  FSharp.Core:10.1.302 (source: /usr/local/share/dotnet/sdk/10.0.302/FSharp/library-packs)
  ... build with -p:DisableImplicitLibraryPacksFolder=true (F# projects) or clear the fallback folder.
```

**Scoping:** only non-HTTP sources are reported. This layer doesn't know which feed URL was injected, so flagging remote URLs would risk false positives; a local folder is unambiguous.

### 2. Deduplicate `requestedBy` paths by immediate parent

Xray's SBOM builder reads **only `path[0]`** of each path — the immediate parent — and reassembles the tree from every package's own entry. Paths sharing a `path[0]` therefore carry no extra information, but they *do* consume the `RequestedByMaxLength` (15) budget. That can push out a parent recorded nowhere else and **silently drop an SBOM edge**.

Measured on a sample solution, before and after:

```
before: 58 paths emitted, 33 distinct parents  -> 25 redundant
after:  33 paths emitted, 33 distinct parents  ->  0 redundant
```

43% smaller payload, **identical edge set**. `Microsoft.Extensions.DependencyInjection.Abstractions` was sitting on exactly 15 paths for 6 distinct parents — at the cap, with 9 slots wasted.

## Invariant worth reviewing

A direct dependency's single-element `{moduleId}` path is what attaches it to the SBOM graph **root** — Xray builds its id→entry map from the module id plus every dependency id. Strip it and direct dependencies become orphan nodes. Being the shortest possible path it always wins its parent slot, and three regression tests pin that, including the adversarial case where a longer path shares the module as its `path[0]`.

## ⚠️ One existing test expectation changed

`TestPopulateRequestedByDeterministic` expected two paths for `depD`:

```go
{"depC:1", "depA:1", "TestModule"}
{"depC:1", "depB:1", "TestModule"}
```

Both share `path[0] = depC:1` and so produce the **same** edge `depC→depD`. One is kept now. The depA/depB distinction is not lost — it lives on `depC`'s own entry, where it genuinely carries two edges.

Please sanity-check this one: changing a test to match a behaviour change deserves a second pair of eyes.

## Testing

- `TestLocalResolutionSource` — 8 cases, including that missing/malformed metadata is **not** reported (absence of evidence is not a bypass) and that path traversal is rejected
- `TestDedupeRequestedByPreservesDistinctParents` — 7 cases covering the direct-dependency invariant above
- `gofmt`, `go build ./...`, `go vet`, `golangci-lint` — all clean; full `build/utils/dotnet/...` suite passes
- Verified end-to-end against a live Artifactory across 8 project types (csproj, fsproj, vbproj, sln, slnx, CPM, packable lib, lockfile)

> **Note:** `gosec` could not be run — it fails with `internal error: package "encoding/json" without types` under this Go toolchain. That check is unverified rather than passing.

## Merge order

This is the **first** of three RTECO-1782 PRs. `jfrog-cli` needs this merged and bumped, because `dotnet_native_test.go` asserts the dedupe behaviour.

1. **build-info-go** ← this PR
2. jfrog-cli-artifactory
3. jfrog-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)
