### PR TITLE
Add GitHub Actions release workflow (JFrog Pipelines EOL migration)

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release script for build-info-go.
+# Ported from the (now EOL) JFrog Pipelines pipeline "release_build_info_go"
+# defined in release/pipelines.yml.
+#
+# Runnable both as a GitHub Actions step (.github/workflows/release.yml) and
+# directly on a developer machine, provided the following are exported:
+#
+#   NEXT_VERSION           - version to release (e.g. 1.2.3)
+#   JFROG_CLI_BUILD_NAME    - build name used for build-info collection
+#   JFROG_CLI_BUILD_NUMBER  - build number used for build-info collection
+#   IL_AUTOMATION_TOKEN     - GitHub token used to push to origin
+#                             (secrets.IL_AUTOMATION_TOKEN in CI)
+#
+# Prerequisites (handled by dedicated setup steps in CI):
+#   - repo checked out on `main` with full history (fetch-depth: 0)
+#   - Go toolchain installed (matching go.mod)
+#   - `jf` (JFrog CLI) installed and configured against Artifactory
+#     (e.g. via `jf c add`, or the jfrog/setup-jfrog-cli action in CI)
+
+# Always remove the JFrog CLI config on exit, mirroring the `if: always()`
+# cleanup step from the original workflow.
+trap 'jf c rm --quiet' EXIT
+
+test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "0.0.0"
+
+git checkout main
+git config user.name "jfrog-ecosystem-integration-env"
+git config user.email "eco-system@jfrog.com"
+git remote set-url origin "https://${IL_AUTOMATION_TOKEN}@github.com/jfrog/build-info-go.git"
+git fetch origin dev
+git merge origin/dev
+
+jf goc --repo-resolve ecosys-go-remote
+
+jf audit
+
+release/build.sh "$NEXT_VERSION"
+
+jf rt bag
+jf rt bce
+jf rt bp "$JFROG_CLI_BUILD_NAME" "$JFROG_CLI_BUILD_NUMBER"
+
+./buildscripts/build.sh
+chmod u+x bi
+./bi go > build-info.json
+git add build-info.json
+git commit -m "Update build-info.json file"
+
+git tag "v${NEXT_VERSION}"
+
+jf ds rbc ecosystem-build-info-go "$NEXT_VERSION" --spec="release/specs/bi-rbc-spec.json" --spec-vars="VERSION=$NEXT_VERSION" --sign
+jf ds rbd ecosystem-build-info-go "$NEXT_VERSION" --site="releases.jfrog.io" --sync
+
+git clean -fd
+git push
+git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+# Ported from the (now EOL) JFrog Pipelines pipeline "release_build_info_go"
+# defined in release/pipelines.yml. Triggered manually with the version to
+# release.
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: 'Version to release (e.g. 1.2.3)'
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CI: true
+  JFROG_CLI_BUILD_NAME: ecosystem-build-info-go-release
+  JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+  JFROG_CLI_BUILD_PROJECT: ecosys
+  NEXT_VERSION: ${{ github.event.inputs.next_version }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Make sure version provided
+        run: |
+          test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "0.0.0"
+
+      - name: Configure Git and merge from dev
+        run: |
+          git checkout main
+          git config user.name "jfrog-ecosystem-integration-env"
+          git config user.email "eco-system@jfrog.com"
+          git remote set-url origin https://${{ secrets.IL_AUTOMATION_TOKEN }}@github.com/jfrog/build-info-go.git
+          git fetch origin dev
+          git merge origin/dev
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Behavior change from the original JFrog Pipelines version, which
+      # bootstrapped the CLI via `curl -fL https://install-cli.jfrog.io | sh`
+      # inside a custom runtime image. Here we use the official setup action,
+      # which also configures a JFrog CLI server (env vars below) so no
+      # separate `jf c add` step is needed.
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ secrets.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Configure Go resolution repo
+        run: jf goc --repo-resolve ecosys-go-remote
+
+      - name: Audit
+        run: jf audit
+
+      - name: Build and upload
+        run: release/build.sh "$NEXT_VERSION"
+
+      - name: Collect and publish build info
+        run: |
+          jf rt bag
+          jf rt bce
+          jf rt bp "$JFROG_CLI_BUILD_NAME" "$JFROG_CLI_BUILD_NUMBER"
+
+      - name: Update build-info.json
+        run: |
+          ./buildscripts/build.sh
+          chmod u+x bi
+          ./bi go > build-info.json
+          git add build-info.json
+          git commit -m "Update build-info.json file"
+
+      - name: Create Git tag
+        run: git tag "v${NEXT_VERSION}"
+
+      - name: Distribute release bundle
+        run: |
+          jf ds rbc ecosystem-build-info-go "$NEXT_VERSION" --spec="release/specs/bi-rbc-spec.json" --spec-vars="VERSION=$NEXT_VERSION" --sign
+          jf ds rbd ecosystem-build-info-go "$NEXT_VERSION" --site="releases.jfrog.io" --sync
+
+      - name: Push to main
+        run: |
+          git clean -fd
+          git push
+          git push --tags
+
+      - name: Remove JFrog CLI config
+        if: always()
+        run: jf c rm --quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ secrets.ARTIFACTORY_URL }}
-          JF_USER: ${{ secrets.ARTIFACTORY_USER }}
-          JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
+          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_APIKEY }}
 
       # Runs the full release: version check, merge dev into main, Go
       # audit/build/upload, build-info collection and publish, git tag,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,6 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Make sure version provided
-        run: |
-          test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "0.0.0"
-
-      - name: Configure Git and merge from dev
-        run: |
-          git checkout main
-          git config user.name "jfrog-ecosystem-integration-env"
-          git config user.email "eco-system@jfrog.com"
-          git remote set-url origin https://${{ secrets.IL_AUTOMATION_TOKEN }}@github.com/jfrog/build-info-go.git
-          git fetch origin dev
-          git merge origin/dev
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -60,43 +47,12 @@ jobs:
           JF_USER: ${{ secrets.ARTIFACTORY_USER }}
           JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
 
-      - name: Configure Go resolution repo
-        run: jf goc --repo-resolve ecosys-go-remote
-
-      - name: Audit
-        run: jf audit
-
-      - name: Build and upload
-        run: release/build.sh "$NEXT_VERSION"
-
-      - name: Collect and publish build info
-        run: |
-          jf rt bag
-          jf rt bce
-          jf rt bp "$JFROG_CLI_BUILD_NAME" "$JFROG_CLI_BUILD_NUMBER"
-
-      - name: Update build-info.json
-        run: |
-          ./buildscripts/build.sh
-          chmod u+x bi
-          ./bi go > build-info.json
-          git add build-info.json
-          git commit -m "Update build-info.json file"
-
-      - name: Create Git tag
-        run: git tag "v${NEXT_VERSION}"
-
-      - name: Distribute release bundle
-        run: |
-          jf ds rbc ecosystem-build-info-go "$NEXT_VERSION" --spec="release/specs/bi-rbc-spec.json" --spec-vars="VERSION=$NEXT_VERSION" --sign
-          jf ds rbd ecosystem-build-info-go "$NEXT_VERSION" --site="releases.jfrog.io" --sync
-
-      - name: Push to main
-        run: |
-          git clean -fd
-          git push
-          git push --tags
-
-      - name: Remove JFrog CLI config
-        if: always()
-        run: jf c rm --quiet
+      # Runs the full release: version check, merge dev into main, Go
+      # audit/build/upload, build-info collection and publish, git tag,
+      # release bundle distribution, and push to main. See
+      # .github/scripts/release.sh, which can also be run directly on a
+      # developer machine (export the same env vars used here).
+      - name: Release
+        run: .github/scripts/release.sh
+        env:
+          IL_AUTOMATION_TOKEN: ${{ secrets.IL_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Summary

Ports the `release_build_info_go` JFrog Pipelines pipeline (defined in `release/pipelines.yml`) to a GitHub Actions workflow at `.github/workflows/release.yml`, as part of the org-wide migration off JFrog Pipelines (EOL).

The workflow is triggered manually (`workflow_dispatch`) with a `next_version` input (replaces the pipeline's `NEXT_VERSION` env var), and faithfully ports every step:

- Merge `dev` into `main`
- `jf audit`
- Build and upload (`release/build.sh`)
- Collect/publish build info (`jf rt bag`, `jf rt bce`, `jf rt bp`)
- Regenerate `build-info.json` and commit it
- Tag the release commit (`vX.Y.Z`)
- Signed release-bundle create + distribute (`jf ds rbc --sign`, `jf ds rbd --sync`)
- Push `main` and tags back to the repo

## Behavior changes

- **JFrog CLI install**: the original pipeline ran inside a custom runtime image (`releases-docker.jfrog.io/jfrog-ecosystem-integration-env`) and bootstrapped the CLI via `curl -fL https://install-cli.jfrog.io | sh`. Since `ubuntu-latest` doesn't have that image, this workflow uses `actions/setup-go@v5` (Go version read from `go.mod`) plus `jfrog/setup-jfrog-cli@v4`, which also configures the JFrog CLI server from env vars so the old `jf c add` step isn't needed.
- Dropped the `env -i ...` wrapper around the build step. The original pipeline reset the environment before re-exporting a few build-info vars; those vars are now just set once at the workflow level via `env:`, so the wrapper is unnecessary on a clean GitHub-hosted runner.

## Required secrets

| Secret | Used for |
|---|---|
| `IL_AUTOMATION_TOKEN` | Git push access (merge dev to main, push build-info.json commit + tag) - replaces the `il_automation` Pipelines integration |
| `ARTIFACTORY_URL` | JFrog CLI server URL - replaces `ecosys_entplus_deployer` |
| `ARTIFACTORY_USER` | JFrog CLI server user - replaces `ecosys_entplus_deployer` |
| `ARTIFACTORY_APIKEY` | JFrog CLI server API key - replaces `ecosys_entplus_deployer` |

**Not run yet - needs secrets added first.**

## Judgment calls

- Set `git config user.name`/`user.email` to `jfrog-ecosystem-integration-env` / `eco-system@jfrog.com` for the automation commit. The original pipeline relied on whatever identity was baked into the custom runtime image, which wasn't visible from the pipeline YAML itself. Happy to change to whatever identity is conventionally used for these bot commits.
- Used `go-version-file: go.mod` for `actions/setup-go` rather than hardcoding a version, so it always tracks whatever Go version the module declares.
