### PR TITLE
RTECO-2003: add Chocolatey FlexPack collectors

### DIFF
--- a/flexpack/choco/choco_artifacts.go
+++ b/flexpack/choco/choco_artifacts.go
@@ -1,0 +1,306 @@
+package choco
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/gofrog/crypto"
+)
+
+const (
+	nupkgExtension = ".nupkg"
+	nupkgType      = "nupkg"
+)
+
+type snapshotEntry struct {
+	modTime time.Time
+	sha1    string
+}
+
+// PackageSnapshot records .nupkg files in a Chocolatey pack working directory.
+type PackageSnapshot map[string]snapshotEntry
+
+// SnapshotPackageFiles records the .nupkg files in root and in each of extraDirs. extraDirs carries
+// the directory named by `choco pack --output-directory` (and its aliases): that flag exists, and
+// without it a pack into a custom directory is invisible to the snapshot diff, so the build-info
+// comes back with no artifacts and no error at all.
+func SnapshotPackageFiles(root string, extraDirs ...string) (PackageSnapshot, error) {
+	if root == "" {
+		return nil, errors.New("the Chocolatey package snapshot root must not be empty")
+	}
+	snapshot := make(PackageSnapshot)
+	for _, directory := range append([]string{root}, extraDirs...) {
+		if err := addDirectoryToSnapshot(snapshot, directory, directory == root); err != nil {
+			return nil, err
+		}
+	}
+	return snapshot, nil
+}
+
+// addDirectoryToSnapshot indexes one directory. A missing extra directory is not an error: choco
+// creates the output directory itself, so it legitimately may not exist when the snapshot is taken.
+func addDirectoryToSnapshot(snapshot PackageSnapshot, directory string, required bool) error {
+	if directory == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		if !required && os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read Chocolatey package directory %s: %w", directory, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !isNupkg(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat Chocolatey package %s: %w", path, err)
+		}
+		details, err := crypto.GetFileDetails(path, true)
+		if err != nil {
+			return fmt.Errorf("compute snapshot checksum for %s: %w", path, err)
+		}
+		absolutePath, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("resolve Chocolatey package path %s: %w", path, err)
+		}
+		snapshot[absolutePath] = snapshotEntry{modTime: info.ModTime(), sha1: details.Checksum.Sha1}
+	}
+	return nil
+}
+
+// ExtractPackOutputDirectory returns the directory named by `choco pack`'s output-directory flag,
+// or "" when the command did not pass one. Chocolatey accepts four spellings, in both the
+// "--flag value" and "--flag=value" forms.
+func ExtractPackOutputDirectory(args []string) string {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+		name, value, hasValue := strings.Cut(arg, "=")
+		if !isPackOutputDirectoryFlag(name) {
+			continue
+		}
+		if hasValue {
+			return strings.Trim(value, `"'`)
+		}
+		if index+1 < len(args) {
+			return strings.Trim(args[index+1], `"'`)
+		}
+	}
+	return ""
+}
+
+func isPackOutputDirectoryFlag(name string) bool {
+	switch strings.ToLower(strings.TrimLeft(name, "-")) {
+	case "out", "outdir", "outputdirectory", "output-directory":
+		return true
+	default:
+		return false
+	}
+}
+
+// CollectPackedArtifacts diffs the post-pack state of root (and extraDirs) against before. Pass the
+// same extraDirs given to SnapshotPackageFiles, so a pack that wrote to --output-directory is seen.
+func CollectPackedArtifacts(root string, before PackageSnapshot, repoName string, extraDirs ...string) ([]entities.Artifact, error) {
+	after, err := SnapshotPackageFiles(root, extraDirs...)
+	if err != nil {
+		return nil, err
+	}
+	artifacts := make([]entities.Artifact, 0)
+	for path, entry := range after {
+		previous, existed := before[path]
+		if existed && !entry.modTime.After(previous.modTime) && entry.sha1 == previous.sha1 {
+			continue
+		}
+		artifact, err := newArtifactFromFile(path, repoName)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	sort.Slice(artifacts, func(left, right int) bool { return artifacts[left].Name < artifacts[right].Name })
+	return artifacts, nil
+}
+
+func CollectPushArtifacts(workingDirectory string, args []string, repoName string) ([]entities.Artifact, error) {
+	paths, err := resolvePushPackagePaths(workingDirectory, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no Chocolatey package (.nupkg) found in the push arguments")
+	}
+	artifacts := make([]entities.Artifact, 0, len(paths))
+	for _, path := range paths {
+		artifact, err := newArtifactFromFile(path, repoName)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts, nil
+}
+
+func BuildArtifactModules(artifacts []entities.Artifact, moduleOverride string) []entities.Module {
+	if moduleOverride != "" {
+		return []entities.Module{{Id: moduleOverride, Type: entities.Nuget, Artifacts: artifacts}}
+	}
+	if len(artifacts) == 0 {
+		return nil
+	}
+	groups := make(map[string][]entities.Artifact)
+	order := make([]string, 0)
+	for _, artifact := range artifacts {
+		moduleID := moduleIDFromFilename(artifact.Name)
+		if _, exists := groups[moduleID]; !exists {
+			order = append(order, moduleID)
+		}
+		groups[moduleID] = append(groups[moduleID], artifact)
+	}
+	modules := make([]entities.Module, 0, len(order))
+	for _, moduleID := range order {
+		modules = append(modules, entities.Module{Id: moduleID, Type: entities.Nuget, Artifacts: groups[moduleID]})
+	}
+	return modules
+}
+
+func newArtifactFromFile(path, repoName string) (entities.Artifact, error) {
+	name := filepath.Base(path)
+	if !isNupkg(name) {
+		return entities.Artifact{}, fmt.Errorf("%s is not a Chocolatey package", name)
+	}
+	details, err := crypto.GetFileDetails(path, true)
+	if err != nil {
+		return entities.Artifact{}, fmt.Errorf("compute checksum for %s: %w", name, err)
+	}
+	return entities.Artifact{
+		Name: name, Type: nupkgType, Path: name, OriginalDeploymentRepo: repoName,
+		Checksum: entities.Checksum{Sha1: details.Checksum.Sha1, Sha256: details.Checksum.Sha256, Md5: details.Checksum.Md5},
+	}, nil
+}
+
+func resolvePushPackagePaths(workingDirectory string, args []string) ([]string, error) {
+	seen := make(map[string]bool)
+	paths := make([]string, 0)
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") && chocoOptionTakesValue(arg) {
+				skipNext = true
+			}
+			continue
+		}
+		if !isNupkg(arg) {
+			continue
+		}
+		candidate := arg
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(workingDirectory, candidate)
+		}
+		matches, err := filepath.Glob(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("resolve Chocolatey push argument %q: %w", arg, err)
+		}
+		if len(matches) == 0 {
+			matches = []string{candidate}
+		}
+		for _, match := range matches {
+			absolutePath, err := filepath.Abs(match)
+			if err != nil {
+				return nil, err
+			}
+			if _, err = os.Stat(absolutePath); err == nil && !seen[absolutePath] {
+				seen[absolutePath] = true
+				paths = append(paths, absolutePath)
+			}
+		}
+	}
+	if len(paths) == 0 {
+		return packagePathFromWorkingDirectory(workingDirectory)
+	}
+	return paths, nil
+}
+
+// packagePathFromWorkingDirectory reproduces Chocolatey's own behaviour when `choco push` is given
+// no path: it pushes the single .nupkg in the current folder, and requires an explicit path only
+// when there is more than one. Without this, a bare `jf choco push` uploads the package but records
+// no artifact, leaving it unstamped and absent from the build-info.
+func packagePathFromWorkingDirectory(workingDirectory string) ([]string, error) {
+	if workingDirectory == "" {
+		return nil, nil
+	}
+	matches, err := filepath.Glob(filepath.Join(workingDirectory, "*"+nupkgExtension))
+	if err != nil {
+		return nil, fmt.Errorf("look for a Chocolatey package in %s: %w", workingDirectory, err)
+	}
+	if len(matches) != 1 {
+		// Zero means nothing was pushed from here; more than one means Chocolatey itself demanded
+		// an explicit path, so the push did not happen. Neither case is an error to report here.
+		return nil, nil
+	}
+	absolutePath, err := filepath.Abs(matches[0])
+	if err != nil {
+		return nil, err
+	}
+	return []string{absolutePath}, nil
+}
+
+// chocoOptionTakesValue reports whether a Chocolatey option consumes the following argument as its
+// value, so that value is not mistaken for a package ID or a .nupkg path.
+//
+// "-v" is deliberately absent: it is Chocolatey's global --verbose boolean switch, not a short form
+// of --version. ChocolateyInstallCommand registers the version option as "version=" with no "v|"
+// alias. Treating "-v" as value-taking made "choco install -v pkgname" swallow "pkgname", so the
+// build-info recorded no dependencies at all.
+func chocoOptionTakesValue(option string) bool {
+	switch strings.ToLower(option) {
+	case "-s", "--source", "--version", "--package-parameters", "--install-arguments",
+		"--execution-timeout", "--cache-location", "--proxy", "--proxy-user", "--proxy-password",
+		"--cert", "--certpassword",
+		// `choco pack` output-directory spellings: their value is a directory, never a package.
+		"--out", "--outdir", "--outputdirectory", "--output-directory",
+		// `choco push` credential spellings, so a key is never treated as a package path.
+		"-k", "--key", "--apikey", "--api-key":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNupkg(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), nupkgExtension)
+}
+
+func parseNupkgFilename(filename string) (string, string) {
+	base := strings.TrimSuffix(filename, filepath.Ext(filename))
+	parts := strings.Split(base, ".")
+	for index, part := range parts {
+		if index > 0 && len(part) > 0 && part[0] >= '0' && part[0] <= '9' {
+			return strings.Join(parts[:index], "."), strings.Join(parts[index:], ".")
+		}
+	}
+	return base, ""
+}
+
+func moduleIDFromFilename(filename string) string {
+	packageID, version := parseNupkgFilename(filename)
+	if version == "" {
+		return packageID
+	}
+	return packageID + ":" + version
+}

--- a/flexpack/choco/choco_flexpack.go
+++ b/flexpack/choco/choco_flexpack.go
@@ -1,0 +1,415 @@
+package choco
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jfrog/build-info-go/entities"
+	buildinfoflex "github.com/jfrog/build-info-go/flexpack"
+	"github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/gofrog/crypto"
+)
+
+// ChocoFlexPack collects the Chocolatey dependencies of an install or upgrade - the requested
+// packages and their transitives - from Chocolatey's lib directory.
+type ChocoFlexPack struct {
+	config buildinfoflex.ChocoConfig
+	log    utils.Log
+}
+
+func NewChocoFlexPack(config buildinfoflex.ChocoConfig, log utils.Log) (*ChocoFlexPack, error) {
+	if config.WorkingDirectory == "" {
+		return nil, fmt.Errorf("ChocoConfig.WorkingDirectory must not be empty")
+	}
+	if log == nil {
+		log = utils.NewDefaultLogger(utils.INFO)
+	}
+	return &ChocoFlexPack{config: config, log: log}, nil
+}
+
+func (collector *ChocoFlexPack) CollectBuildInfo(buildName, buildNumber string) (*entities.BuildInfo, error) {
+	rootModule := collector.config.Module
+	if rootModule == "" {
+		rootModule = filepath.Base(collector.config.WorkingDirectory)
+	}
+	dependencies, missing, _, err := collectDependencyTree(collector.config, rootModule, collector.log)
+	if err != nil {
+		return nil, err
+	}
+	for _, packageID := range missing {
+		collector.log.Warn("Chocolatey package was not found under the lib directory, so it is not" +
+			" recorded in the build-info: " + packageID)
+	}
+	return &entities.BuildInfo{
+		Name:   buildName,
+		Number: buildNumber,
+		Modules: []entities.Module{{
+			Id:           rootModule,
+			Type:         entities.Nuget,
+			Dependencies: dependencies,
+		}},
+	}, nil
+}
+
+func (collector *ChocoFlexPack) GetProjectDependencies() ([]buildinfoflex.DependencyInfo, error) {
+	rootModule := collector.config.Module
+	if rootModule == "" {
+		rootModule = filepath.Base(collector.config.WorkingDirectory)
+	}
+	dependencies, _, _, err := collectDependencyTree(collector.config, rootModule, collector.log)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]buildinfoflex.DependencyInfo, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		result = append(result, buildinfoflex.DependencyInfo{
+			ID: dependency.Id, Type: dependency.Type, SHA1: dependency.Sha1, SHA256: dependency.Sha256,
+			MD5: dependency.Md5, Scopes: dependency.Scopes, RequestedBy: dependency.RequestedBy,
+			Repository: dependency.Repository,
+		})
+	}
+	return result, nil
+}
+
+// GetDependencyGraph returns the dependency graph keyed by module ID: the root module maps to the
+// packages named on the command line, and every package maps to the dependencies its .nuspec
+// declares that Chocolatey actually installed.
+func (collector *ChocoFlexPack) GetDependencyGraph() (map[string][]string, error) {
+	rootModule := collector.config.Module
+	if rootModule == "" {
+		rootModule = filepath.Base(collector.config.WorkingDirectory)
+	}
+	_, _, graph, err := collectDependencyTree(collector.config, rootModule, collector.log)
+	if err != nil {
+		return nil, err
+	}
+	return graph, nil
+}
+
+// packageNode is one package located under Chocolatey's lib directory during the dependency walk.
+type packageNode struct {
+	id          string // package ID with the casing Chocolatey installed it under
+	version     string // version taken from the installed .nupkg, not from the declared range
+	packagePath string
+	requestedBy [][]string
+}
+
+// collectDependencyTree resolves the full dependency set of this invocation - the packages named on
+// the command line and everything they pull in - entirely from the local Chocolatey installation.
+//
+// Chocolatey has no lock file, but it does not need one: it installs the fully resolved dependency
+// set into $ChocolateyInstall\lib\<id>\, one directory per package, each holding the package's
+// .nupkg and .nuspec (NugetService.cs calls GetInstalledPath(packageDependencyInfo), so transitives
+// land in the same tree as the requested packages). So the graph is recovered by walking the
+// declared <dependencies> of each installed .nuspec and resolving every edge back to the lib
+// directory. The declared version is a range, so it is deliberately ignored: the concrete version
+// always comes from the installed .nupkg filename.
+//
+// The walk starts from the command-line packages rather than from a before/after diff of lib, which
+// would both over-report (unrelated concurrent installs) and under-report (a transitive already
+// satisfied on this machine is still a dependency of this build).
+//
+// Returns the dependencies in breadth-first order, the IDs that could not be located, and the
+// module dependency graph.
+func collectDependencyTree(config buildinfoflex.ChocoConfig, rootModule string, log utils.Log) ([]entities.Dependency, []string, map[string][]string, error) {
+	root := chocolateyInstallRoot(config.ChocolateyInstall)
+	graph := map[string][]string{rootModule: {}}
+	missing := make([]string, 0)
+	missingSeen := make(map[string]bool)
+	ordered := make([]*packageNode, 0, len(config.Packages))
+	visited := make(map[string]*packageNode)
+
+	type pendingPackage struct {
+		packageID string
+		// Path from the requester up to the root module, in build-info RequestedBy order.
+		requestedBy []string
+	}
+	queue := make([]pendingPackage, 0, len(config.Packages))
+	for _, packageID := range requestedPackages(config.Packages) {
+		queue = append(queue, pendingPackage{packageID: packageID, requestedBy: []string{rootModule}})
+	}
+
+	for len(queue) > 0 {
+		pending := queue[0]
+		queue = queue[1:]
+		packagePath, packageName, version, err := resolveInstalledPackage(root, pending.packageID)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Not under lib. Either the install failed, or the dependency is served by one of
+				// Chocolatey's special sources (ruby, cygwin, python, windowsfeatures), which do
+				// not produce a .nupkg there at all.
+				if key := strings.ToLower(pending.packageID); !missingSeen[key] {
+					missingSeen[key] = true
+					missing = append(missing, pending.packageID)
+				}
+				continue
+			}
+			return nil, nil, nil, err
+		}
+		dependencyID := packageName + ":" + version
+		requester := pending.requestedBy[0]
+		graph[requester] = appendUniqueEdge(graph[requester], dependencyID)
+
+		if existing, seen := visited[strings.ToLower(packageName)]; seen {
+			// Reached again through a different parent: a shared dependency has several requesters,
+			// so record the extra path but do not walk its own dependencies twice. This is also
+			// what terminates a dependency cycle.
+			existing.requestedBy = append(existing.requestedBy, pending.requestedBy)
+			continue
+		}
+		node := &packageNode{
+			id: packageName, version: version, packagePath: packagePath,
+			requestedBy: [][]string{pending.requestedBy},
+		}
+		visited[strings.ToLower(packageName)] = node
+		ordered = append(ordered, node)
+		if _, exists := graph[dependencyID]; !exists {
+			graph[dependencyID] = []string{}
+		}
+
+		declared, err := readNuspecDependencies(filepath.Dir(packagePath), packageName, log)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for _, declaredID := range declared {
+			// A fresh slice per child: the paths are retained in the build-info, so they must not
+			// share a backing array with a sibling's path.
+			childRequestedBy := append([]string{dependencyID}, pending.requestedBy...)
+			queue = append(queue, pendingPackage{packageID: declaredID, requestedBy: childRequestedBy})
+		}
+	}
+
+	dependencies := make([]entities.Dependency, 0, len(ordered))
+	for _, node := range ordered {
+		details, err := crypto.GetFileDetails(node.packagePath, true)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("compute dependency checksum for %s: %w", node.packagePath, err)
+		}
+		dependencies = append(dependencies, entities.Dependency{
+			Id:          node.id + ":" + node.version,
+			Type:        nupkgType,
+			Scopes:      []string{"compile"},
+			RequestedBy: node.requestedBy,
+			Repository:  config.RepoResolve,
+			Checksum: entities.Checksum{
+				Sha1: details.Checksum.Sha1, Sha256: details.Checksum.Sha256, Md5: details.Checksum.Md5,
+			},
+		})
+	}
+	return dependencies, missing, graph, nil
+}
+
+func appendUniqueEdge(edges []string, dependencyID string) []string {
+	for _, existing := range edges {
+		if existing == dependencyID {
+			return edges
+		}
+	}
+	return append(edges, dependencyID)
+}
+
+// nuspecDocument is the subset of the NuGet .nuspec schema needed to read declared dependencies.
+// The dependency element is either listed directly or grouped per target framework; Chocolatey
+// packages use the flat form, but the grouped form is valid and is read too. Field tags carry no
+// namespace, so they match the .nuspec regardless of which schema revision it declares.
+type nuspecDocument struct {
+	Metadata struct {
+		ID           string `xml:"id"`
+		Version      string `xml:"version"`
+		Dependencies struct {
+			Dependencies []nuspecDependency `xml:"dependency"`
+			Groups       []struct {
+				Dependencies []nuspecDependency `xml:"dependency"`
+			} `xml:"group"`
+		} `xml:"dependencies"`
+	} `xml:"metadata"`
+}
+
+type nuspecDependency struct {
+	ID string `xml:"id,attr"`
+}
+
+// readNuspecDependencies returns the package IDs declared by the .nuspec in an installed package
+// directory. A package with no .nuspec, or with an unreadable one, is treated as a leaf: a manifest
+// problem in an already-installed dependency must not fail the build-info collection.
+func readNuspecDependencies(packageDirectory, packageName string, log utils.Log) ([]string, error) {
+	nuspecPath, err := findNuspec(packageDirectory, packageName)
+	if err != nil {
+		return nil, err
+	}
+	if nuspecPath == "" {
+		log.Debug("No .nuspec found for Chocolatey package " + packageName + " in " + packageDirectory +
+			"; treating it as having no dependencies.")
+		return nil, nil
+	}
+	content, err := os.ReadFile(nuspecPath)
+	if err != nil {
+		return nil, fmt.Errorf("read Chocolatey manifest %s: %w", nuspecPath, err)
+	}
+	var document nuspecDocument
+	if err := xml.Unmarshal(content, &document); err != nil {
+		log.Warn("Could not parse the Chocolatey manifest " + nuspecPath + ", so the dependencies of " +
+			packageName + " are not recorded in the build-info: " + err.Error())
+		return nil, nil
+	}
+	declared := document.Metadata.Dependencies.Dependencies
+	for _, group := range document.Metadata.Dependencies.Groups {
+		declared = append(declared, group.Dependencies...)
+	}
+	result := make([]string, 0, len(declared))
+	seen := make(map[string]bool)
+	for _, dependency := range declared {
+		id := strings.TrimSpace(dependency.ID)
+		if id == "" || seen[strings.ToLower(id)] {
+			continue
+		}
+		seen[strings.ToLower(id)] = true
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+// findNuspec locates the manifest inside an installed package directory, returning "" when there is
+// none. Chocolatey repairs the manifest's casing after install (NugetService.NormalizeNuspecCasing),
+// but feeds have shipped it lower-cased, so the name is matched case-insensitively.
+func findNuspec(packageDirectory, packageName string) (string, error) {
+	entries, err := os.ReadDir(packageDirectory)
+	if err != nil {
+		return "", fmt.Errorf("read Chocolatey package directory %s: %w", packageDirectory, err)
+	}
+	candidate := ""
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".nuspec") {
+			continue
+		}
+		if strings.EqualFold(entry.Name(), packageName+".nuspec") {
+			return filepath.Join(packageDirectory, entry.Name()), nil
+		}
+		if candidate == "" {
+			candidate = filepath.Join(packageDirectory, entry.Name())
+		}
+	}
+	return candidate, nil
+}
+
+func resolveInstalledPackage(chocolateyRoot, requestedPackage string) (string, string, string, error) {
+	libraryRoot := filepath.Join(chocolateyRoot, "lib")
+	entries, err := os.ReadDir(libraryRoot)
+	if err != nil {
+		return "", "", "", err
+	}
+	packageDirectory := ""
+	for _, entry := range entries {
+		if entry.IsDir() && strings.EqualFold(entry.Name(), requestedPackage) {
+			packageDirectory = filepath.Join(libraryRoot, entry.Name())
+			break
+		}
+	}
+	if packageDirectory == "" {
+		return "", "", "", os.ErrNotExist
+	}
+	entries, err = os.ReadDir(packageDirectory)
+	if err != nil {
+		return "", "", "", err
+	}
+	var selectedPath string
+	var selectedTime time.Time
+	var selectedName, selectedVersion string
+	for _, entry := range entries {
+		if entry.IsDir() || !isNupkg(entry.Name()) {
+			continue
+		}
+		// Chocolatey stores the package as lib\<id>\<id>.nupkg, with NO version in the file name
+		// (verified against chocolatey/choco's own integration suite, e.g.
+		// Path.Combine(..., "lib", "isdependency", "isdependency.nupkg")). parseNupkgFilename
+		// therefore returns an empty version here in normal operation, and the real version comes
+		// from the sibling .nuspec below. Feeds and older clients have shipped the versioned form
+		// too, so a version parsed off the name is still accepted when present.
+		name, version := parseNupkgFilename(entry.Name())
+		if !strings.EqualFold(name, requestedPackage) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return "", "", "", err
+		}
+		if selectedPath == "" || info.ModTime().After(selectedTime) {
+			selectedPath = filepath.Join(packageDirectory, entry.Name())
+			selectedTime = info.ModTime()
+			selectedName, selectedVersion = name, version
+		}
+	}
+	if selectedPath == "" {
+		return "", "", "", os.ErrNotExist
+	}
+	if selectedVersion == "" {
+		selectedVersion = readNuspecVersion(packageDirectory, requestedPackage)
+		if selectedVersion == "" {
+			return "", "", "", fmt.Errorf(
+				"could not determine the installed version of Chocolatey package %s: %s holds no versioned .nupkg and no readable .nuspec",
+				requestedPackage, packageDirectory)
+		}
+	}
+	return selectedPath, selectedName, selectedVersion, nil
+}
+
+// readNuspecVersion reads <metadata><version> from an installed package's manifest, which is where
+// the version lives once Chocolatey has extracted the package: the .nupkg beside it is named
+// <id>.nupkg with no version. Returns "" when the manifest is absent or unparseable, leaving the
+// caller to report a resolution failure naming the package.
+func readNuspecVersion(packageDirectory, packageName string) string {
+	nuspecPath, err := findNuspec(packageDirectory, packageName)
+	if err != nil || nuspecPath == "" {
+		return ""
+	}
+	content, err := os.ReadFile(nuspecPath)
+	if err != nil {
+		return ""
+	}
+	var document nuspecDocument
+	if err := xml.Unmarshal(content, &document); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(document.Metadata.Version)
+}
+
+func chocolateyInstallRoot(configuredRoot string) string {
+	if configuredRoot != "" {
+		return configuredRoot
+	}
+	if root := os.Getenv("ChocolateyInstall"); root != "" {
+		return root
+	}
+	if programData := os.Getenv("ProgramData"); programData != "" {
+		return filepath.Join(programData, "chocolatey")
+	}
+	return `C:\ProgramData\chocolatey`
+}
+
+func requestedPackages(args []string) []string {
+	result := make([]string, 0)
+	seen := make(map[string]bool)
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			if strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && chocoOptionTakesValue(arg) {
+				skipNext = true
+			}
+			continue
+		}
+		key := strings.ToLower(arg)
+		if !seen[key] {
+			seen[key] = true
+			result = append(result, arg)
+		}
+	}
+	return result
+}

--- a/flexpack/choco/choco_flexpack.go
+++ b/flexpack/choco/choco_flexpack.go
@@ -254,6 +254,11 @@ func readNuspecDependencies(packageDirectory, packageName string, log utils.Log)
 	if err := xml.Unmarshal(content, &document); err != nil {
 		log.Warn("Could not parse the Chocolatey manifest " + nuspecPath + ", so the dependencies of " +
 			packageName + " are not recorded in the build-info: " + err.Error())
+		// Swallowing the error is deliberate: an unparseable manifest in an already-installed
+		// dependency means its own dependencies are unknown, not that the build failed. Returning
+		// the error here would fail build-info collection for the whole command over one bad
+		// package, so the package is treated as a leaf and the warning above is the record.
+		//nolint:nilerr // see above: a malformed manifest degrades to a leaf, it does not fail
 		return nil, nil
 	}
 	declared := document.Metadata.Dependencies.Dependencies

--- a/flexpack/choco/choco_test.go
+++ b/flexpack/choco/choco_test.go
@@ -1,0 +1,378 @@
+package choco
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jfrog/build-info-go/entities"
+	buildinfoflex "github.com/jfrog/build-info-go/flexpack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectPackedArtifacts(t *testing.T) {
+	workingDirectory := t.TempDir()
+	writePackage(t, workingDirectory, "stale.1.0.0.nupkg", "stale")
+	before, err := SnapshotPackageFiles(workingDirectory)
+	require.NoError(t, err)
+
+	writePackage(t, workingDirectory, "tool.2.0.0.nupkg", "tool")
+	artifacts, err := CollectPackedArtifacts(workingDirectory, before, "choco-local")
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "tool.2.0.0.nupkg", artifacts[0].Name)
+	assert.Equal(t, nupkgType, artifacts[0].Type)
+	assert.Equal(t, "tool.2.0.0.nupkg", artifacts[0].Path)
+	assert.Equal(t, "choco-local", artifacts[0].OriginalDeploymentRepo)
+	assert.NotEmpty(t, artifacts[0].Sha1)
+	assert.NotEmpty(t, artifacts[0].Sha256)
+	assert.NotEmpty(t, artifacts[0].Md5)
+}
+
+func TestCollectPushArtifactsIgnoresFlagValues(t *testing.T) {
+	workingDirectory := t.TempDir()
+	packagePath := writePackage(t, workingDirectory, "tool.1.2.3.nupkg", "tool")
+	writePackage(t, workingDirectory, "not-a-target.9.9.9.nupkg", "other")
+
+	artifacts, err := CollectPushArtifacts(workingDirectory, []string{
+		"--source", "https://example.test/api/nuget/choco-local",
+		"--api-key", "secret",
+		packagePath,
+	}, "choco-local")
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "tool.1.2.3.nupkg", artifacts[0].Name)
+}
+
+func TestCollectPushArtifactsAcceptsPackageAfterBooleanFlag(t *testing.T) {
+	workingDirectory := t.TempDir()
+	packagePath := writePackage(t, workingDirectory, "tool.1.2.3.nupkg", "tool")
+
+	artifacts, err := CollectPushArtifacts(workingDirectory, []string{"--yes", packagePath}, "choco-local")
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "tool.1.2.3.nupkg", artifacts[0].Name)
+}
+
+func TestCollectDirectDependencies(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	packageDirectory := filepath.Join(chocolateyRoot, "lib", "7zip.install")
+	writePackage(t, packageDirectory, "7zip.install.23.1.0.nupkg", "old")
+	time.Sleep(10 * time.Millisecond)
+	writePackage(t, packageDirectory, "7zip.install.24.0.0.nupkg", "new")
+
+	collector, err := NewChocoFlexPack(buildinfoflex.ChocoConfig{
+		WorkingDirectory:  filepath.Join(t.TempDir(), "project"),
+		ChocolateyInstall: chocolateyRoot,
+		Packages:          []string{"--yes", "7zip.install", "missing"},
+		RepoResolve:       "choco-virtual",
+		Module:            "image-build",
+	}, nil)
+	require.NoError(t, err)
+
+	buildInfo, err := collector.CollectBuildInfo("my-build", "42")
+	require.NoError(t, err)
+	require.Len(t, buildInfo.Modules, 1)
+	module := buildInfo.Modules[0]
+	assert.Equal(t, "image-build", module.Id)
+	require.Len(t, module.Dependencies, 1)
+	dependency := module.Dependencies[0]
+	assert.Equal(t, "7zip.install:24.0.0", dependency.Id)
+	assert.Equal(t, nupkgType, dependency.Type)
+	assert.Equal(t, []string{"compile"}, dependency.Scopes)
+	assert.Equal(t, [][]string{{"image-build"}}, dependency.RequestedBy)
+	assert.Equal(t, "choco-virtual", dependency.Repository)
+	assert.NotEmpty(t, dependency.Sha1)
+	assert.NotEmpty(t, dependency.Sha256)
+	assert.NotEmpty(t, dependency.Md5)
+}
+
+func TestBuildArtifactModules(t *testing.T) {
+	modules := BuildArtifactModules([]entities.Artifact{{Name: "git.install.2.43.0.2.nupkg", Type: nupkgType}}, "")
+	require.Len(t, modules, 1)
+	assert.Equal(t, "git.install:2.43.0.2", modules[0].Id)
+}
+
+// Chocolatey installs the fully resolved dependency set under lib, so the transitive graph is
+// recovered from the .nuspec of each installed package rather than from a lock file.
+func TestCollectTransitiveDependencies(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	library := filepath.Join(chocolateyRoot, "lib")
+
+	// tool -> liba, libshared, plus a dependency served by a Chocolatey special source, which never
+	// lands under lib. liba -> libshared (shared requester) and back to tool (a cycle).
+	writePackage(t, filepath.Join(library, "tool"), "tool.1.0.0.nupkg", "tool")
+	writeNuspec(t, filepath.Join(library, "tool"), "tool.nuspec", `
+		<dependency id="libA" version="[1.0,)" />
+		<dependency id="libShared" version="2.0.0" />
+		<dependency id="windowsfeatures-only" version="1.0.0" />`)
+	// The manifest name is lower-cased here on purpose: feeds have shipped it that way, and it must
+	// still be found.
+	writePackage(t, filepath.Join(library, "libA"), "libA.1.1.0.nupkg", "liba")
+	writeNuspec(t, filepath.Join(library, "libA"), "liba.nuspec", `
+		<dependency id="libshared" version="2.0.0" />
+		<dependency id="tool" version="1.0.0" />`)
+	writePackage(t, filepath.Join(library, "libShared"), "libShared.2.0.0.nupkg", "shared")
+	writeGroupedNuspec(t, filepath.Join(library, "libShared"), "libShared.nuspec")
+
+	collector, err := NewChocoFlexPack(buildinfoflex.ChocoConfig{
+		WorkingDirectory:  filepath.Join(t.TempDir(), "project"),
+		ChocolateyInstall: chocolateyRoot,
+		Packages:          []string{"--yes", "tool"},
+		RepoResolve:       "choco-virtual",
+		Module:            "image-build",
+	}, nil)
+	require.NoError(t, err)
+
+	buildInfo, err := collector.CollectBuildInfo("my-build", "42")
+	require.NoError(t, err)
+	require.Len(t, buildInfo.Modules, 1)
+	dependencies := buildInfo.Modules[0].Dependencies
+	require.Len(t, dependencies, 3, "the requested package and both of its transitives")
+
+	byID := make(map[string]entities.Dependency, len(dependencies))
+	for _, dependency := range dependencies {
+		byID[dependency.Id] = dependency
+		assert.Equal(t, nupkgType, dependency.Type)
+		assert.Equal(t, "choco-virtual", dependency.Repository)
+		assert.NotEmpty(t, dependency.Sha1, dependency.Id)
+		assert.NotEmpty(t, dependency.Sha256, dependency.Id)
+		assert.NotEmpty(t, dependency.Md5, dependency.Id)
+	}
+	require.Contains(t, byID, "libA:1.1.0")
+	require.Contains(t, byID, "libShared:2.0.0")
+
+	// The transitive records the path back to the root module, and a shared dependency records one
+	// path per requester.
+	assert.Equal(t, [][]string{{"tool:1.0.0", "image-build"}}, byID["libA:1.1.0"].RequestedBy)
+	assert.Equal(t, [][]string{
+		{"tool:1.0.0", "image-build"},
+		{"libA:1.1.0", "tool:1.0.0", "image-build"},
+	}, byID["libShared:2.0.0"].RequestedBy)
+
+	graph, err := collector.GetDependencyGraph()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tool:1.0.0"}, graph["image-build"])
+	assert.Equal(t, []string{"libA:1.1.0", "libShared:2.0.0"}, graph["tool:1.0.0"])
+	assert.Equal(t, []string{"libShared:2.0.0", "tool:1.0.0"}, graph["libA:1.1.0"],
+		"a dependency cycle is reported as an edge, and must not loop forever")
+	assert.Empty(t, graph["libShared:2.0.0"])
+}
+
+// "-v" is Chocolatey's global --verbose switch, not a short form of --version, so it must not
+// swallow the package that follows it.
+func TestVerboseFlagDoesNotSwallowThePackage(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	writePackage(t, filepath.Join(chocolateyRoot, "lib", "tool"), "tool.1.0.0.nupkg", "tool")
+
+	collector, err := NewChocoFlexPack(buildinfoflex.ChocoConfig{
+		WorkingDirectory:  filepath.Join(t.TempDir(), "project"),
+		ChocolateyInstall: chocolateyRoot,
+		Packages:          []string{"-v", "tool"},
+		Module:            "image-build",
+	}, nil)
+	require.NoError(t, err)
+
+	buildInfo, err := collector.CollectBuildInfo("my-build", "42")
+	require.NoError(t, err)
+	require.Len(t, buildInfo.Modules, 1)
+	require.Len(t, buildInfo.Modules[0].Dependencies, 1)
+	assert.Equal(t, "tool:1.0.0", buildInfo.Modules[0].Dependencies[0].Id)
+}
+
+// A manifest that is not valid XML belongs to a package that is already installed, so it degrades to
+// "no declared dependencies" rather than failing the whole collection.
+func TestUnparsableNuspecIsTreatedAsALeaf(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	packageDirectory := filepath.Join(chocolateyRoot, "lib", "tool")
+	writePackage(t, packageDirectory, "tool.1.0.0.nupkg", "tool")
+	writePackage(t, packageDirectory, "tool.nuspec", "<package><metadata>truncated")
+
+	collector, err := NewChocoFlexPack(buildinfoflex.ChocoConfig{
+		WorkingDirectory:  filepath.Join(t.TempDir(), "project"),
+		ChocolateyInstall: chocolateyRoot,
+		Packages:          []string{"tool"},
+		Module:            "image-build",
+	}, nil)
+	require.NoError(t, err)
+
+	buildInfo, err := collector.CollectBuildInfo("my-build", "42")
+	require.NoError(t, err)
+	require.Len(t, buildInfo.Modules[0].Dependencies, 1)
+	assert.Equal(t, "tool:1.0.0", buildInfo.Modules[0].Dependencies[0].Id)
+}
+
+func writeNuspec(t *testing.T, directory, name, dependencies string) {
+	t.Helper()
+	writePackage(t, directory, name, `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>`+strings.TrimSuffix(name, ".nuspec")+`</id>
+    <dependencies>`+dependencies+`
+    </dependencies>
+  </metadata>
+</package>`)
+}
+
+// A .nuspec may group its dependencies per target framework instead of listing them directly.
+func writeGroupedNuspec(t *testing.T, directory, name string) {
+	t.Helper()
+	writePackage(t, directory, name, `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>`+strings.TrimSuffix(name, ".nuspec")+`</id>
+    <dependencies>
+      <group targetFramework="net48" />
+    </dependencies>
+  </metadata>
+</package>`)
+}
+
+func writePackage(t *testing.T, directory, name, contents string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(directory, 0o750))
+	path := filepath.Join(directory, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+// writeVersionedNuspec writes the manifest Chocolatey extracts beside the .nupkg in an installed
+// package directory. The version lives here, not in the .nupkg file name. Distinct from
+// writeNuspec above, which builds a dependency-focused manifest with no <version> element.
+func writeVersionedNuspec(t *testing.T, directory, packageID, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(directory, 0o750))
+	manifest := `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>` + packageID + `</id>
+    <version>` + version + `</version>
+    <authors>test</authors>
+    <description>test</description>
+  </metadata>
+</package>`
+	require.NoError(t, os.WriteFile(filepath.Join(directory, packageID+".nuspec"), []byte(manifest), 0o600))
+}
+
+// TestResolveInstalledPackageReadsVersionFromNuspec pins the real on-disk layout: Chocolatey stores
+// lib\<id>\<id>.nupkg with NO version in the file name, and keeps the version in the sibling
+// .nuspec. Verified against chocolatey/choco's own integration suite, which asserts paths of the
+// form Path.Combine(..., "lib", "isdependency", "isdependency.nupkg").
+//
+// The other dependency tests in this file use the versioned "<id>.<version>.nupkg" spelling, which
+// a feed serves but an installed package directory never contains, so they passed while the real
+// resolution path returned os.ErrNotExist and dropped every dependency.
+func TestResolveInstalledPackageReadsVersionFromNuspec(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	packageDirectory := filepath.Join(chocolateyRoot, "lib", "7zip.install")
+	writePackage(t, packageDirectory, "7zip.install.nupkg", "package")
+	writeVersionedNuspec(t, packageDirectory, "7zip.install", "24.0.0")
+
+	path, name, version, err := resolveInstalledPackage(chocolateyRoot, "7zip.install")
+	require.NoError(t, err, "an installed package with no version in its file name must still resolve")
+	assert.Equal(t, filepath.Join(packageDirectory, "7zip.install.nupkg"), path)
+	assert.Equal(t, "7zip.install", name)
+	assert.Equal(t, "24.0.0", version, "the version must come from the .nuspec")
+}
+
+// TestResolveInstalledPackageWithoutVersionSourceFails covers the honest failure: no version in the
+// file name and no readable manifest means the version is genuinely unknown, and recording a
+// dependency with an empty version would be worse than saying so.
+func TestResolveInstalledPackageWithoutVersionSourceFails(t *testing.T) {
+	chocolateyRoot := t.TempDir()
+	packageDirectory := filepath.Join(chocolateyRoot, "lib", "orphan")
+	writePackage(t, packageDirectory, "orphan.nupkg", "package")
+
+	_, _, _, err := resolveInstalledPackage(chocolateyRoot, "orphan")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orphan", "the error must name the package that could not be resolved")
+}
+
+// TestExtractPackOutputDirectory covers every spelling Chocolatey accepts for `choco pack`'s output
+// directory, in both the "--flag value" and "--flag=value" forms.
+func TestExtractPackOutputDirectory(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{"absent", []string{"pack", "tool.nuspec"}, ""},
+		{"out-space", []string{"pack", "--out", "build"}, "build"},
+		{"out-equals", []string{"pack", "--out=build"}, "build"},
+		{"outdir", []string{"pack", "--outdir=build"}, "build"},
+		{"outputdirectory", []string{"pack", "--outputdirectory=build"}, "build"},
+		{"output-directory", []string{"pack", "--output-directory=build"}, "build"},
+		{"quoted", []string{"pack", `--output-directory="build dir"`}, "build dir"},
+		{"trailing-flag-no-value", []string{"pack", "--out"}, ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, ExtractPackOutputDirectory(testCase.args))
+		})
+	}
+}
+
+// TestCollectPackedArtifactsFromOutputDirectory covers the flag's consequence. `choco pack` does
+// have an output-directory flag, so a CWD-only snapshot silently yields zero artifacts and an empty
+// build-info with no error at all.
+func TestCollectPackedArtifactsFromOutputDirectory(t *testing.T) {
+	workingDirectory := t.TempDir()
+	outputDirectory := filepath.Join(workingDirectory, "build")
+
+	before, err := SnapshotPackageFiles(workingDirectory, outputDirectory)
+	require.NoError(t, err, "a not-yet-created output directory must not fail the snapshot")
+
+	writePackage(t, outputDirectory, "tool.2.0.0.nupkg", "tool")
+
+	artifacts, err := CollectPackedArtifacts(workingDirectory, before, "choco-local", outputDirectory)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1, "a package written to --output-directory must be collected")
+	assert.Equal(t, "tool.2.0.0.nupkg", artifacts[0].Name)
+	assert.Equal(t, "choco-local", artifacts[0].OriginalDeploymentRepo)
+}
+
+// TestCollectPushArtifactsFallsBackToWorkingDirectory covers `choco push` with no positional path.
+// Chocolatey pushes the single .nupkg in the folder in that case, so the artifact must still be
+// recorded; otherwise the package uploads but is left unstamped and absent from the build-info.
+func TestCollectPushArtifactsFallsBackToWorkingDirectory(t *testing.T) {
+	workingDirectory := t.TempDir()
+	writePackage(t, workingDirectory, "tool.1.2.3.nupkg", "tool")
+
+	artifacts, err := CollectPushArtifacts(workingDirectory, []string{"--source", "https://example.test"}, "choco-local")
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1, "a bare `choco push` must record the package Chocolatey found in the CWD")
+	assert.Equal(t, "tool.1.2.3.nupkg", artifacts[0].Name)
+}
+
+// TestCollectPushArtifactsAmbiguousWorkingDirectory: with several packages present, the fallback
+// deliberately does not guess. Chocolatey itself refuses this push and demands an explicit path, so
+// in practice the native command fails and collection is never reached; the error here is the
+// defensive case, and it must not silently attribute an arbitrary package to the build.
+func TestCollectPushArtifactsAmbiguousWorkingDirectory(t *testing.T) {
+	workingDirectory := t.TempDir()
+	writePackage(t, workingDirectory, "tool.1.2.3.nupkg", "tool")
+	writePackage(t, workingDirectory, "other.4.5.6.nupkg", "other")
+
+	_, err := CollectPushArtifacts(workingDirectory, []string{"--source", "https://example.test"}, "choco-local")
+	require.Error(t, err, "an ambiguous folder must not resolve to an arbitrarily chosen package")
+}
+
+// TestCollectPushArtifactsIgnoresApiKeyValue guards the credential spellings now in the
+// value-taking table: an API key must never be mistaken for a package path.
+func TestCollectPushArtifactsIgnoresApiKeyValue(t *testing.T) {
+	workingDirectory := t.TempDir()
+	packagePath := writePackage(t, workingDirectory, "tool.1.2.3.nupkg", "tool")
+
+	for _, keyFlag := range []string{"-k", "--key", "--apikey", "--api-key"} {
+		t.Run(keyFlag, func(t *testing.T) {
+			artifacts, err := CollectPushArtifacts(workingDirectory,
+				[]string{keyFlag, "user:token", packagePath}, "choco-local")
+			require.NoError(t, err)
+			require.Len(t, artifacts, 1)
+			assert.Equal(t, "tool.1.2.3.nupkg", artifacts[0].Name)
+		})
+	}
+}

--- a/flexpack/flexpack.go
+++ b/flexpack/flexpack.go
@@ -182,6 +182,15 @@ type NuGetConfig struct {
 	Module string
 }
 
+// ChocoConfig holds configuration for Chocolatey build-info collection.
+type ChocoConfig struct {
+	WorkingDirectory  string
+	ChocolateyInstall string
+	Packages          []string
+	RepoResolve       string
+	Module            string
+}
+
 // IsFlexPackEnabled checks if the FlexPack (native) implementation should be used
 // Returns true if JFROG_RUN_NATIVE environment variable is set to "true"
 func IsFlexPackEnabled() bool {

--- a/utils/error.go
+++ b/utils/error.go
@@ -17,6 +17,7 @@ const (
 	Pnpm   PackageManager = "pnpm"
 	Uv     PackageManager = "uv"
 	Pipenv PackageManager = "pipenv"
+	Choco  PackageManager = "choco"
 )
 
 // ForbiddenError represents a 403 Forbidden error.
@@ -71,6 +72,10 @@ func IsForbiddenOutput(tech PackageManager, cmdOutput string) bool {
 		return strings.Contains(strings.ToLower(cmdOutput), "403 forbidden")
 	case "pipenv":
 		return strings.Contains(strings.ToLower(cmdOutput), "http error 403")
+	case "nuget", "choco":
+		output := strings.ToLower(cmdOutput)
+		return (strings.Contains(output, "403") && strings.Contains(output, "forbidden")) ||
+			strings.Contains(output, "response status code does not indicate success: 403")
 	}
 	return false
 }

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsForbiddenOutputForChocolatey(t *testing.T) {
+	assert.True(t, IsForbiddenOutput(Choco, "The remote server returned an error: (403) Forbidden."))
+	assert.True(t, IsForbiddenOutput("nuget", "Response status code does not indicate success: 403 (Forbidden)."))
+	assert.False(t, IsForbiddenOutput(Choco, "package was not found"))
+}


### PR DESCRIPTION
## Summary

Adds `flexpack/choco`: artifact collection for `choco pack` / `choco push`, and dependency collection for `choco install` / `upgrade`. Chocolatey writes no lock file, so the transitive graph is recovered from each installed package's `.nuspec`.

Part of RTECO-2003 (`jf choco` + `jf setup choco`). Ships first; the other three PRs pin this commit.

## Three native behaviours worth calling out

Each was verified against Chocolatey's documentation or its own source rather than assumed, and each fails **silently** if modelled wrongly:

| Behaviour | Consequence if missed |
|---|---|
| `choco pack` accepts `--out` / `--outdir` / `--outputdirectory` / `--output-directory` | Snapshotting only the working directory finds nothing the pack produced → empty build-info, no error |
| An installed package is `lib/<id>/<id>.nupkg` — **no version in the file name** | Reading the version off the name always yields `""` → every dependency dropped |
| `choco push` takes an **optional** path, pushing the single `.nupkg` in the folder | A bare push uploads the package but records no artifact → unstamped, absent from build-info |

The layout claim is verifiable in Chocolatey's own integration suite, which asserts paths of the form `lib/isdependency/isdependency.nupkg`.

Also treats a Chocolatey 403 as forbidden output (reusing the NuGet wording) so curation-on-failure classifies a blocked package correctly.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./flexpack/choco/... ./utils/...`
- [x] New unit tests cover all three behaviours above, plus the ambiguous-folder case (records nothing rather than guessing) and the API-key spellings that must never be mistaken for a package path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
