### PR TITLE
RTECO-1725: sync init-gradle-extractor-5.gradle with artifactory-grad…

### DIFF
--- a/build/init-gradle-extractor-5.gradle
+++ b/build/init-gradle-extractor-5.gradle
@@ -1,13 +1,18 @@
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginSettings
 import org.jfrog.gradle.plugin.artifactory.Constant
+import org.jfrog.gradle.plugin.artifactory.extractor.ExternalProjectModuleInfoFileProducer
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
+import org.jfrog.gradle.plugin.artifactory.task.DeployTask
+import org.jfrog.gradle.plugin.artifactory.utils.PluginUtils;
 
 initscript {
     dependencies {
         classpath fileTree('${pluginLibDir}')
     }
 }
+
+PluginUtils.assertGradleVersionSupported(getGradle())
 
 beforeSettings { Settings settings ->
     settings.apply plugin: ArtifactoryPluginSettings
@@ -19,10 +24,59 @@ projectsLoaded { Gradle gradle ->
     gradle.startParameter.setProjectProperties(projectProperties)
     Project root = gradle.getRootProject()
     root.logger.debug("Artifactory plugin: projectsEvaluated: ${root.name}")
-    if (!"buildSrc".equals(root.name)) {
+
+    if (gradle.parent == null) {
+        // The containing (top-level) build.
         root.allprojects {
             apply {
                 apply plugin: ArtifactoryPlugin
+            }
+        }
+    } else {
+        // RTECO-1725: buildSrc, or a composite/included build (settings.gradle includeBuild(...)).
+        // Both are separate Gradle build instances. Note that this init script is re-evaluated from
+        // scratch for each one - top-level script variables here do NOT persist across these separate
+        // firings of projectsLoaded, so we can't accumulate state in a plain script variable across them.
+        // gradle.parent, though, is a live reference to the actual containing Gradle build object, shared
+        // across all these separate evaluations within the same session.
+        //
+        // Apply the plugin here too (even though its own artifactoryPublish/extractModuleInfo tasks will
+        // never run): ExternalProjectModuleInfoFileProducer's dependency extraction needs
+        // project.getRootProject().getPlugins().getPlugin(ArtifactoryPlugin) to succeed, and it wouldn't
+        // without this - it would fail with UnknownPluginException and silently produce no dependencies.
+        // root.allprojects covers every subproject of this nested build too, not just its root - a
+        // multi-project included build needs the plugin applied to each of them individually.
+        root.allprojects {
+            apply {
+                apply plugin: ArtifactoryPlugin
+            }
+        }
+
+        // Register this build's (and each of its subprojects') dependencies directly on the containing
+        // build's DeployTask right now, instead of adding the usual ArtifactoryTask/ExtractModuleTask pair
+        // to each of these projects the normal way: those would never run anyway, because buildSrc's own
+        // task graph is already finished by the time the containing build is even configured, and an
+        // included build's tasks are only ever scheduled if something in the containing build substitutes
+        // a dependency for them, which our bookkeeping tasks never are.
+        //
+        // Deliberately NOT relying on Gradle firing the containing build's projectsLoaded before any
+        // nested build's (that ordering has only been empirically observed here, it is not a documented
+        // Gradle contract). `tasks.withType(DeployTask).configureEach { ... }` is a lazy, order-independent
+        // registration: it fires for the DeployTask whenever it gets added to containingRoot's task
+        // container, whether that already happened or happens later.
+        //
+        // gradle.parent is only the IMMEDIATE containing build, not necessarily the top-level one: a
+        // composite build can itself include another composite build (A includeBuild(B), B
+        // includeBuild(C)), in which case C's gradle.parent is B, not A. Only the true top-level build's
+        // DeployTask ever actually executes as part of a real `jf gradle` invocation. Walk all the way up.
+        Gradle topLevelGradle = gradle
+        while (topLevelGradle.parent != null) {
+            topLevelGradle = topLevelGradle.parent
+        }
+        Project containingRoot = topLevelGradle.getRootProject()
+        containingRoot.tasks.withType(DeployTask).configureEach { deployTask ->
+            root.allprojects.each { Project externalProject ->
+                deployTask.registerModuleInfoProducer(new ExternalProjectModuleInfoFileProducer(externalProject, containingRoot.getName()))
             }
         }
     }


### PR DESCRIPTION
…le-plugin

Re-syncs build-info-go's embedded copy of the Gradle 5+ init script with artifactory-gradle-plugin's src/main/resources/initscripttemplate.gradle, which now walks gradle.parent up to the true top-level build and registers buildSrc/composite (includeBuild) build dependencies on its DeployTask via a lazy tasks.withType(...).configureEach{} hook. jf gradle uses this embedded copy, not the plugin jar's own resource, so the two must stay byte-identical (enforced on the plugin side by the new syncCheckInitScript Gradle task).

- [ ] All [tests](https://github.com/jfrog/build-info-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/build-info-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Appropriate label is added to the PR for auto generate release notes.
-----
